### PR TITLE
chore: Changes for COPPA compliance removing YOB from profile

### DIFF
--- a/profile/src/main/java/org/openedx/profile/data/model/Account.kt
+++ b/profile/src/main/java/org/openedx/profile/data/model/Account.kt
@@ -3,7 +3,7 @@ package org.openedx.profile.data.model
 import com.google.gson.annotations.SerializedName
 import org.openedx.core.data.model.ProfileImage
 import org.openedx.profile.domain.model.Account
-import java.util.*
+import java.util.Date
 import org.openedx.profile.domain.model.Account as DomainAccount
 
 data class Account(
@@ -42,16 +42,17 @@ data class Account(
 ) {
 
     enum class Privacy {
-        @SerializedName("private")
+        @SerializedName(value = "PRIVATE", alternate = ["private"])
         PRIVATE,
-        @SerializedName("all_users")
+
+        @SerializedName("ALL_USERS", alternate = ["all_users"])
         ALL_USERS
     }
 
     fun mapToDomain(): Account {
         return Account(
             username = username ?: "",
-            bio = bio?:"",
+            bio = bio ?: "",
             requiresParentalConsent = requiresParentalConsent ?: false,
             name = name ?: "",
             country = country ?: "",

--- a/profile/src/main/java/org/openedx/profile/domain/model/Account.kt
+++ b/profile/src/main/java/org/openedx/profile/domain/model/Account.kt
@@ -35,9 +35,9 @@ data class Account(
 
     fun isLimited() = accountPrivacy == Privacy.PRIVATE
 
-    fun isOlderThanMinAge() : Boolean {
+    fun isOlderThanMinAge(): Boolean {
         val currentYear = Calendar.getInstance().get(Calendar.YEAR)
-        return yearOfBirth != null && currentYear - yearOfBirth > USER_MIN_YEAR
+        return !requiresParentalConsent && yearOfBirth != null && currentYear - yearOfBirth > USER_MIN_YEAR
     }
 
 }

--- a/profile/src/main/java/org/openedx/profile/presentation/edit/EditProfileFragment.kt
+++ b/profile/src/main/java/org/openedx/profile/presentation/edit/EditProfileFragment.kt
@@ -1,4 +1,5 @@
-@file:OptIn(ExperimentalComposeUiApi::class, ExperimentalComposeUiApi::class,
+@file:OptIn(
+    ExperimentalComposeUiApi::class, ExperimentalComposeUiApi::class,
     ExperimentalComposeUiApi::class
 )
 
@@ -42,6 +43,7 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Card
+import androidx.compose.material.ContentAlpha
 import androidx.compose.material.Divider
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.Icon
@@ -74,6 +76,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
@@ -180,6 +183,7 @@ class EditProfileFragment : Fragment() {
                 val selectedImageUri by viewModel.selectedImageUri.observeAsState()
                 val isImageDeleted by viewModel.deleteImage.observeAsState(false)
                 val leaveDialog by viewModel.showLeaveDialog.observeAsState(false)
+                val focusManager = LocalFocusManager.current
 
                 EditProfileScreen(
                     windowSize = windowSize,
@@ -215,6 +219,7 @@ class EditProfileFragment : Fragment() {
                                     }
                             }
                         }
+                        focusManager.clearFocus()
                     },
                     onDataChanged = {
                         viewModel.profileDataChanged = it
@@ -1084,7 +1089,9 @@ private fun InputEditField(
             shape = MaterialTheme.appShapes.textFieldShape,
             placeholder = {
                 Text(
-                    modifier = Modifier.testTag("txt_placeholder_${name.tagId()}"),
+                    modifier = Modifier
+                        .alpha(if (disabled) ContentAlpha.disabled else ContentAlpha.high)
+                        .testTag("txt_placeholder_${name.tagId()}"),
                     text = name,
                     color = MaterialTheme.appColors.textFieldHint,
                     style = MaterialTheme.appTypography.bodyMedium

--- a/profile/src/main/java/org/openedx/profile/presentation/edit/EditProfileFragment.kt
+++ b/profile/src/main/java/org/openedx/profile/presentation/edit/EditProfileFragment.kt
@@ -407,6 +407,8 @@ private fun EditProfileScreen(
 
     val isImeVisible by isImeVisibleState()
 
+    val requiresParentalConsent = uiState.account.requiresParentalConsent
+
     LaunchedEffect(bottomSheetScaffoldState.isVisible) {
         if (!bottomSheetScaffoldState.isVisible) {
             focusManager.clearFocus()
@@ -635,7 +637,7 @@ private fun EditProfileScreen(
                                         .clip(CircleShape)
 
                                         .noRippleClickable {
-                                            if (!uiState.account.requiresParentalConsent) {
+                                            if (!requiresParentalConsent) {
                                                 isOpenChangeImageDialogState = true
                                                 if (!uiState.account.isOlderThanMinAge()) {
                                                     openWarningMessageDialog = true
@@ -643,7 +645,7 @@ private fun EditProfileScreen(
                                             }
                                         }
                                 )
-                                if (!uiState.account.requiresParentalConsent) {
+                                if (!requiresParentalConsent) {
                                     Icon(
                                         modifier = Modifier
                                             .size(32.dp)
@@ -670,7 +672,7 @@ private fun EditProfileScreen(
                                 color = MaterialTheme.appColors.textPrimary
                             )
                             Spacer(modifier = Modifier.height(16.dp))
-                            if (!uiState.account.requiresParentalConsent) {
+                            if (!requiresParentalConsent) {
                                 Text(
                                     modifier = Modifier
                                         .testTag("txt_edit_profile_limited_profile_label")
@@ -698,7 +700,7 @@ private fun EditProfileScreen(
                                 verticalAlignment = Alignment.CenterVertically,
                                 horizontalArrangement = Arrangement.Center
                             ) {
-                                if (uiState.account.requiresParentalConsent) {
+                                if (requiresParentalConsent) {
                                     Icon(
                                         imageVector = Icons.Filled.VisibilityOff,
                                         tint = MaterialTheme.appColors.textSecondary,
@@ -711,7 +713,7 @@ private fun EditProfileScreen(
                                         .align(Alignment.CenterVertically)
                                         .testTag("txt_edit_profile_limited_profile_message"),
                                     text = stringResource(
-                                        if (uiState.account.requiresParentalConsent) {
+                                        if (requiresParentalConsent) {
                                             R.string.profile_restricted_profile_message
                                         } else {
                                             R.string.profile_unrestricted_profile_message

--- a/profile/src/main/res/values/strings.xml
+++ b/profile/src/main/res/values/strings.xml
@@ -16,6 +16,8 @@
     <string name="profile_spoken_language">Spoken Language</string>
     <string name="profile_switch_to_full">Switch to full profile</string>
     <string name="profile_switch_to_limited">Switch to limited profile</string>
+    <string name="profile_unrestricted_profile_message">A limited profile only shares your username and profile photo.</string>
+    <string name="profile_restricted_profile_message">Your profile information is only visible to you. Only your username is visible to others.</string>
     <string name="profile_delete_account">Delete account</string>
     <string name="profile_you_want_to">Are you sure you want to</string>
     <string name="profile_delete_your_account">delete your account?</string>


### PR DESCRIPTION
### Description

To ensure the app complies with COPPA regulations - [Issue](https://docs.google.com/spreadsheets/d/1YuN7Wg2sqMwQf8R02Z0iLtKhPsq1C4LWklMmR1QU5Cs/edit?gid=36631478#gid=36631478&range=17:17)

### Requirements:

- Remove the Year of Birth (YOB) field from the profile section
- If learner's age is more than 13:
    - Display toggle for Limited and Full profile
    - Allow image upload in both Limited and Full profile
    - Display all fields in both Limited and Full profile, except YOB
    - Disable the fields in Limited profile
- If learner's age is less than 13 or not provided (`requiresParentalConsent = true`):
    - Do not display toggle for Limited profile
    - Do not allow image upload, hide the icon
    - Display all fields but disable them
    
    
### Note: 
Instead of removing the code, I've commented the code, because post-MVP we might be moving these changes behind a feature flag.

We currently don't have specific design guidelines for this request. So the changes are approved by Moiz.

<hr>


https://github.com/user-attachments/assets/1da2c36d-f544-433d-b765-a82cd83cfe7a

