### PR TITLE
fix: Auto Playing Videos and Discovery's External Browser Pop-Up

### DIFF
--- a/course/src/main/java/org/openedx/course/presentation/unit/video/VideoUnitFragment.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/video/VideoUnitFragment.kt
@@ -192,7 +192,7 @@ class VideoUnitFragment : Fragment(R.layout.fragment_video_unit) {
             if (!viewModel.isPlayerSetUp) {
                 setPlayerMedia(mediaItem)
                 viewModel.getActivePlayer()?.prepare()
-                viewModel.getActivePlayer()?.playWhenReady = viewModel.isPlaying
+                viewModel.getActivePlayer()?.playWhenReady = viewModel.isPlaying && isResumed
                 viewModel.isPlayerSetUp = true
             }
 

--- a/course/src/main/java/org/openedx/course/presentation/unit/video/VideoUnitFragment.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/video/VideoUnitFragment.kt
@@ -195,6 +195,7 @@ class VideoUnitFragment : Fragment(R.layout.fragment_video_unit) {
                 viewModel.getActivePlayer()?.playWhenReady = viewModel.isPlaying && isResumed
                 viewModel.isPlayerSetUp = true
             }
+            viewModel.getActivePlayer()?.seekTo(viewModel.getCurrentVideoTime())
 
             viewModel.castPlayer?.setSessionAvailabilityListener(
                 object : SessionAvailabilityListener {

--- a/course/src/main/java/org/openedx/course/presentation/unit/video/YoutubeVideoUnitFragment.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/video/YoutubeVideoUnitFragment.kt
@@ -79,6 +79,13 @@ class YoutubeVideoUnitFragment : Fragment(R.layout.fragment_youtube_video_unit) 
         return binding.root
     }
 
+    override fun onResume() {
+        super.onResume()
+        if (viewModel.isPlaying) {
+            _youTubePlayer?.play()
+        }
+    }
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
@@ -193,7 +200,7 @@ class YoutubeVideoUnitFragment : Fragment(R.layout.fragment_youtube_video_unit) 
                 }
 
                 viewModel.videoUrl.split("watch?v=").getOrNull(1)?.let { videoId ->
-                    if (viewModel.isPlaying) {
+                    if (viewModel.isPlaying && isResumed) {
                         youTubePlayer.loadVideo(
                             videoId, viewModel.getCurrentVideoTime().toFloat() / 1000
                         )

--- a/discovery/src/main/java/org/openedx/discovery/presentation/info/CourseInfoFragment.kt
+++ b/discovery/src/main/java/org/openedx/discovery/presentation/info/CourseInfoFragment.kt
@@ -395,9 +395,6 @@ private fun CourseInfoWebView(
         factory = {
             webView
         },
-        update = {
-            webView.loadUrl(contentUrl)
-        }
     )
 }
 


### PR DESCRIPTION
### Description:

The PR fixes the following bugs:

- Retain Video Seek Time when Exiting Fullscreen in Native Videos
- Multiple videos were playing simultaneously when appeared in a single unit
- Open in External Browser Pop-Up for Bachelor's Degrees - [Issue](https://docs.google.com/spreadsheets/d/1YuN7Wg2sqMwQf8R02Z0iLtKhPsq1C4LWklMmR1QU5Cs/edit?gid=36631478#gid=36631478&range=77:77)

### To Test:

Multiple Videos Issue - Open these units in the videos tab:
- Unit for Youtube Videos: [The Big Picture](https://learning.edx.org/course/course-v1:RWTHx+MTI003x+1T2024/block-v1:RWTHx+MTI003x+1T2024+type@sequential+block@c784b927d69340de87d6c0d9be8cc678/block-v1:RWTHx+MTI003x+1T2024+type@vertical+block@ba158699b87b4397ae499d36cd25a358)
- Unit for Native Videos: [Feature Scaling - Normalization and Standardization](https://learning.edx.org/course/course-v1:HarvardX+CS109x+3T2023a/block-v1:HarvardX+CS109x+3T2023a+type@sequential+block@73c5510ba0764db6ba97e1737b4fbe1a/block-v1:HarvardX+CS109x+3T2023a+type@vertical+block@a1d3d1938e7d47d68accde72c6535e03)
