### PR TITLE
fix: crash when internet disconnected right after opening a course

### DIFF
--- a/course/src/main/java/org/openedx/course/presentation/outline/CourseOutlineScreen.kt
+++ b/course/src/main/java/org/openedx/course/presentation/outline/CourseOutlineScreen.kt
@@ -342,6 +342,10 @@ private fun CourseOutlineUI(
                             }
                         }
 
+                        CourseOutlineUIState.Error -> {
+                            NoContentScreen(noContentScreenType = NoContentScreenType.COURSE_OUTLINE)
+                        }
+                        
                         CourseOutlineUIState.Loading -> {
                             CircularProgress()
                         }

--- a/course/src/main/java/org/openedx/course/presentation/outline/CourseOutlineUIState.kt
+++ b/course/src/main/java/org/openedx/course/presentation/outline/CourseOutlineUIState.kt
@@ -17,5 +17,6 @@ sealed class CourseOutlineUIState {
         val datesBannerInfo: CourseDatesBannerInfo,
     ) : CourseOutlineUIState()
 
+    data object Error : CourseOutlineUIState()
     data object Loading : CourseOutlineUIState()
 }

--- a/course/src/main/java/org/openedx/course/presentation/outline/CourseOutlineViewModel.kt
+++ b/course/src/main/java/org/openedx/course/presentation/outline/CourseOutlineViewModel.kt
@@ -218,6 +218,7 @@ class CourseOutlineViewModel(
                     datesBannerInfo = datesBannerInfo
                 )
             } catch (e: Exception) {
+                _uiState.value = CourseOutlineUIState.Error
                 if (e.isInternetError()) {
                     _uiMessage.emit(UIMessage.SnackBarMessage(resourceManager.getString(R.string.core_error_no_connection)))
                 } else {

--- a/course/src/main/java/org/openedx/course/presentation/videos/CourseVideoViewModel.kt
+++ b/course/src/main/java/org/openedx/course/presentation/videos/CourseVideoViewModel.kt
@@ -145,27 +145,31 @@ class CourseVideoViewModel(
 
     fun getVideos() {
         viewModelScope.launch {
-            var courseStructure = interactor.getCourseStructureForVideos(courseId)
-            val blocks = courseStructure.blockData
-            if (blocks.isEmpty()) {
+            try {
+                var courseStructure = interactor.getCourseStructureForVideos(courseId)
+                val blocks = courseStructure.blockData
+                if (blocks.isEmpty()) {
+                    _uiState.value = CourseVideosUIState.Empty
+                } else {
+                    setBlocks(courseStructure.blockData)
+                    courseSubSections.clear()
+                    courseSubSectionUnit.clear()
+                    courseStructure = courseStructure.copy(blockData = sortBlocks(blocks))
+                    initDownloadModelsStatus()
+
+                    val courseSectionsState =
+                        (_uiState.value as? CourseVideosUIState.CourseData)?.courseSectionsState.orEmpty()
+
+                    _uiState.value =
+                        CourseVideosUIState.CourseData(
+                            courseStructure, getDownloadModelsStatus(), courseSubSections,
+                            courseSectionsState, subSectionsDownloadsCount, getDownloadModelsSize()
+                        )
+                }
+                courseNotifier.send(CourseLoading(false))
+            } catch (e: Exception) {
                 _uiState.value = CourseVideosUIState.Empty
-            } else {
-                setBlocks(courseStructure.blockData)
-                courseSubSections.clear()
-                courseSubSectionUnit.clear()
-                courseStructure = courseStructure.copy(blockData = sortBlocks(blocks))
-                initDownloadModelsStatus()
-
-                val courseSectionsState =
-                    (_uiState.value as? CourseVideosUIState.CourseData)?.courseSectionsState.orEmpty()
-
-                _uiState.value =
-                    CourseVideosUIState.CourseData(
-                        courseStructure, getDownloadModelsStatus(), courseSubSections,
-                        courseSectionsState, subSectionsDownloadsCount, getDownloadModelsSize()
-                    )
             }
-            courseNotifier.send(CourseLoading(false))
         }
     }
 

--- a/course/src/test/java/org/openedx/course/presentation/outline/CourseOutlineViewModelTest.kt
+++ b/course/src/test/java/org/openedx/course/presentation/outline/CourseOutlineViewModelTest.kt
@@ -275,7 +275,7 @@ class CourseOutlineViewModelTest {
         coVerify(exactly = 2) { interactor.getCourseStatus(any()) }
 
         assertEquals(noInternet, message.await()?.message)
-        assert(viewModel.uiState.value is CourseOutlineUIState.Loading)
+        assert(viewModel.uiState.value is CourseOutlineUIState.Error)
     }
 
     @Test
@@ -310,7 +310,7 @@ class CourseOutlineViewModelTest {
         coVerify(exactly = 2) { interactor.getCourseStatus(any()) }
 
         assertEquals(somethingWrong, message.await()?.message)
-        assert(viewModel.uiState.value is CourseOutlineUIState.Loading)
+        assert(viewModel.uiState.value is CourseOutlineUIState.Error)
     }
 
     @Test


### PR DESCRIPTION
The crash was fixed + added UI handlers for the Home and Videos tabs to stop infinite loading

<img src="https://github.com/user-attachments/assets/a827a9d7-7c53-43de-b2af-71897bca3a1d" width=320/>
<img src="https://github.com/user-attachments/assets/146556a5-df35-4eac-8ab2-fe0b45cd0b13" width=320/>


