### PR TITLE
feat: Crashlytics Integration with FullStory

### DIFF
--- a/app/src/main/java/org/openedx/app/AnalyticsManager.kt
+++ b/app/src/main/java/org/openedx/app/AnalyticsManager.kt
@@ -42,7 +42,7 @@ class AnalyticsManager(
         }
 
         if (config.getFullstoryConfig().isEnabled) {
-            addAnalyticsTracker(FullstoryAnalytics())
+            addAnalyticsTracker(FullstoryAnalytics(config.getFirebaseConfig().enabled))
         }
     }
 
@@ -196,7 +196,11 @@ class AnalyticsManager(
         })
     }
 
-    override fun logIAPEvent(event: IAPAnalyticsEvent, params: MutableMap<String, Any?>, screenName: String) {
+    override fun logIAPEvent(
+        event: IAPAnalyticsEvent,
+        params: MutableMap<String, Any?>,
+        screenName: String
+    ) {
         logEvent(
             event = event.eventName,
             params = params.apply {

--- a/app/src/main/java/org/openedx/app/analytics/FullstoryAnalytics.kt
+++ b/app/src/main/java/org/openedx/app/analytics/FullstoryAnalytics.kt
@@ -2,9 +2,11 @@ package org.openedx.app.analytics
 
 import com.fullstory.FS
 import com.fullstory.FSSessionData
+import com.google.firebase.crashlytics.FirebaseCrashlytics
 import org.openedx.core.utils.Logger
 
-class FullstoryAnalytics : Analytics {
+
+class FullstoryAnalytics(isFirebaseEnabled: Boolean = false) : Analytics {
 
     private val logger = Logger(TAG)
 
@@ -12,6 +14,10 @@ class FullstoryAnalytics : Analytics {
         FS.setReadyListener { sessionData: FSSessionData ->
             val sessionUrl = sessionData.currentSessionURL
             logger.d { "FullStory Session URL is: $sessionUrl" }
+            if (isFirebaseEnabled) {
+                val instance = FirebaseCrashlytics.getInstance()
+                instance.setCustomKey("FSsessionURL", sessionUrl)
+            }
         }
     }
 

--- a/app/src/main/java/org/openedx/app/analytics/FullstoryAnalytics.kt
+++ b/app/src/main/java/org/openedx/app/analytics/FullstoryAnalytics.kt
@@ -5,7 +5,6 @@ import com.fullstory.FSSessionData
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 import org.openedx.core.utils.Logger
 
-
 class FullstoryAnalytics(isFirebaseEnabled: Boolean = false) : Analytics {
 
     private val logger = Logger(TAG)
@@ -16,7 +15,7 @@ class FullstoryAnalytics(isFirebaseEnabled: Boolean = false) : Analytics {
             logger.d { "FullStory Session URL is: $sessionUrl" }
             if (isFirebaseEnabled) {
                 val instance = FirebaseCrashlytics.getInstance()
-                instance.setCustomKey("FSsessionURL", sessionUrl)
+                instance.setCustomKey("fullstory_session_url", sessionUrl)
             }
         }
     }


### PR DESCRIPTION
### Description

Crashlytics Integration with FullStory
- Add a Fullstory session replay link to a crash report.

fixes: [LEARNER-10158](https://2u-internal.atlassian.net/browse/LEARNER-10158)