### PR TITLE
fix: Remove setting button from toolbar

### DIFF
--- a/dashboard/src/main/java/org/openedx/dashboard/presentation/DashboardRouter.kt
+++ b/dashboard/src/main/java/org/openedx/dashboard/presentation/DashboardRouter.kt
@@ -13,8 +13,6 @@ interface DashboardRouter {
         resumeBlockId: String = ""
     )
 
-    fun navigateToSettings(fm: FragmentManager)
-
     fun navigateToAllEnrolledCourses(fm: FragmentManager)
 
     fun getProgramFragment(): Fragment

--- a/dashboard/src/main/java/org/openedx/learn/presentation/LearnFragment.kt
+++ b/dashboard/src/main/java/org/openedx/learn/presentation/LearnFragment.kt
@@ -36,7 +36,6 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.FragmentManager
 import androidx.viewpager2.widget.ViewPager2
 import org.koin.androidx.compose.koinViewModel
 import org.koin.androidx.viewmodel.ext.android.viewModel
@@ -72,7 +71,6 @@ class LearnFragment : Fragment(R.layout.fragment_learn) {
         binding.header.setContent {
             OpenEdXTheme {
                 Header(
-                    fragmentManager = requireParentFragment().parentFragmentManager,
                     defaultLearnType = defaultLearnType,
                     viewPager = binding.viewPager
                 )
@@ -106,7 +104,7 @@ class LearnFragment : Fragment(R.layout.fragment_learn) {
     companion object {
         private const val ARG_OPEN_TAB = "open_tab"
         fun newInstance(
-            openTab: String = LearnTab.COURSES.name
+            openTab: String = LearnTab.COURSES.name,
         ): LearnFragment {
             val fragment = LearnFragment()
             fragment.arguments = bundleOf(
@@ -119,7 +117,6 @@ class LearnFragment : Fragment(R.layout.fragment_learn) {
 
 @Composable
 private fun Header(
-    fragmentManager: FragmentManager,
     defaultLearnType: LearnType,
     viewPager: ViewPager2,
 ) {

--- a/dashboard/src/main/java/org/openedx/learn/presentation/LearnFragment.kt
+++ b/dashboard/src/main/java/org/openedx/learn/presentation/LearnFragment.kt
@@ -15,12 +15,10 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.DropdownMenu
 import androidx.compose.material.DropdownMenuItem
 import androidx.compose.material.Icon
-import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ExpandMore
-import androidx.compose.material.icons.filled.ManageAccounts
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -55,7 +53,6 @@ import org.openedx.core.ui.windowSizeValue
 import org.openedx.dashboard.R
 import org.openedx.dashboard.databinding.FragmentLearnBinding
 import org.openedx.learn.LearnType
-import org.openedx.core.R as CoreR
 
 class LearnFragment : Fragment(R.layout.fragment_learn) {
 
@@ -147,9 +144,6 @@ private fun Header(
     ) {
         Title(
             label = stringResource(id = R.string.dashboard_learn),
-            onSettingsClick = {
-                viewModel.onSettingsClick(fragmentManager)
-            }
         )
         if (viewModel.isProgramTypeWebView) {
             LearnDropdownMenu(
@@ -167,7 +161,6 @@ private fun Header(
 private fun Title(
     modifier: Modifier = Modifier,
     label: String,
-    onSettingsClick: () -> Unit,
 ) {
     Box(
         modifier = modifier.fillMaxWidth()
@@ -180,20 +173,6 @@ private fun Title(
             color = MaterialTheme.appColors.textDark,
             style = MaterialTheme.appTypography.headlineBold
         )
-        IconButton(
-            modifier = Modifier
-                .align(Alignment.CenterEnd)
-                .padding(end = 12.dp),
-            onClick = {
-                onSettingsClick()
-            }
-        ) {
-            Icon(
-                imageVector = Icons.Default.ManageAccounts,
-                tint = MaterialTheme.appColors.primary,
-                contentDescription = stringResource(id = CoreR.string.core_accessibility_settings)
-            )
-        }
     }
 }
 
@@ -290,10 +269,7 @@ private fun LearnDropdownMenu(
 @Composable
 private fun HeaderPreview() {
     OpenEdXTheme {
-        Title(
-            label = stringResource(id = R.string.dashboard_learn),
-            onSettingsClick = {}
-        )
+        Title(label = stringResource(id = R.string.dashboard_learn))
     }
 }
 

--- a/dashboard/src/main/java/org/openedx/learn/presentation/LearnViewModel.kt
+++ b/dashboard/src/main/java/org/openedx/learn/presentation/LearnViewModel.kt
@@ -1,6 +1,5 @@
 package org.openedx.learn.presentation
 
-import androidx.fragment.app.FragmentManager
 import org.openedx.DashboardNavigator
 import org.openedx.core.BaseViewModel
 import org.openedx.core.config.Config
@@ -17,10 +16,6 @@ class LearnViewModel(
 
     private val dashboardType get() = config.getDashboardConfig().getType()
     val isProgramTypeWebView get() = config.getProgramConfig().isViewTypeWebView()
-
-    fun onSettingsClick(fragmentManager: FragmentManager) {
-        dashboardRouter.navigateToSettings(fragmentManager)
-    }
 
     val getDashboardFragment get() = DashboardNavigator(dashboardType).getDashboardFragment()
 

--- a/discovery/src/main/java/org/openedx/discovery/presentation/DiscoveryRouter.kt
+++ b/discovery/src/main/java/org/openedx/discovery/presentation/DiscoveryRouter.kt
@@ -24,7 +24,5 @@ interface DiscoveryRouter {
 
     fun navigateToSignIn(fm: FragmentManager, courseId: String?, infoType: String?)
 
-    fun navigateToSettings(fm: FragmentManager)
-
     fun navigateToEnrolledProgramInfo(fm: FragmentManager, pathId: String)
 }

--- a/discovery/src/main/java/org/openedx/discovery/presentation/NativeDiscoveryFragment.kt
+++ b/discovery/src/main/java/org/openedx/discovery/presentation/NativeDiscoveryFragment.kt
@@ -168,9 +168,6 @@ class NativeDiscoveryFragment : Fragment() {
                     onBackClick = {
                         requireActivity().supportFragmentManager.popBackStackImmediate()
                     },
-                    onSettingsClick = {
-                        router.navigateToSettings(requireActivity().supportFragmentManager)
-                    }
                 )
                 LaunchedEffect(uiState) {
                     if (querySearch.isNotEmpty()) {
@@ -218,7 +215,6 @@ internal fun DiscoveryScreen(
     onRegisterClick: () -> Unit,
     onSignInClick: () -> Unit,
     onBackClick: () -> Unit,
-    onSettingsClick: () -> Unit,
 ) {
     val scaffoldState = rememberScaffoldState()
     val scrollState = rememberLazyListState()
@@ -323,9 +319,7 @@ internal fun DiscoveryScreen(
                 Toolbar(
                     label = stringResource(id = R.string.discovery_Discovery),
                     canShowBackBtn = canShowBackButton,
-                    canShowSettingsIcon = !canShowBackButton,
                     onBackClick = onBackClick,
-                    onSettingsClick = onSettingsClick
                 )
 
                 Spacer(modifier = Modifier.height(16.dp))
@@ -521,7 +515,6 @@ private fun DiscoveryScreenPreview() {
             onSignInClick = {},
             onRegisterClick = {},
             onBackClick = {},
-            onSettingsClick = {},
             canShowBackButton = false
         )
     }
@@ -562,7 +555,6 @@ private fun DiscoveryScreenTabletPreview() {
             onSignInClick = {},
             onRegisterClick = {},
             onBackClick = {},
-            onSettingsClick = {},
             canShowBackButton = false
         )
     }

--- a/discovery/src/main/java/org/openedx/discovery/presentation/WebViewDiscoveryFragment.kt
+++ b/discovery/src/main/java/org/openedx/discovery/presentation/WebViewDiscoveryFragment.kt
@@ -168,9 +168,6 @@ class WebViewDiscoveryFragment : Fragment() {
                     onSignInClick = {
                         viewModel.navigateToSignIn(parentFragmentManager)
                     },
-                    onSettingsClick = {
-                        viewModel.navigateToSettings(requireActivity().supportFragmentManager)
-                    },
                     onBackClick = {
                         requireActivity().supportFragmentManager.popBackStackImmediate()
                     }
@@ -207,8 +204,7 @@ private fun WebViewDiscoveryScreen(
     onUriClick: (String, WebViewLink.Authority) -> Unit,
     onRegisterClick: () -> Unit,
     onSignInClick: () -> Unit,
-    onSettingsClick: () -> Unit,
-    onBackClick: () -> Unit
+    onBackClick: () -> Unit,
 ) {
     val scaffoldState = rememberScaffoldState()
     val configuration = LocalConfiguration.current
@@ -263,9 +259,7 @@ private fun WebViewDiscoveryScreen(
             Toolbar(
                 label = stringResource(id = R.string.discovery_explore_the_catalog),
                 canShowBackBtn = isPreLogin,
-                canShowSettingsIcon = !isPreLogin,
                 onBackClick = onBackClick,
-                onSettingsClick = onSettingsClick
             )
 
             Surface {
@@ -424,7 +418,6 @@ private fun WebViewDiscoveryScreenPreview() {
             onUriClick = { _, _ -> },
             onRegisterClick = {},
             onSignInClick = {},
-            onSettingsClick = {},
             onBackClick = {},
         )
     }

--- a/discovery/src/main/java/org/openedx/discovery/presentation/WebViewDiscoveryViewModel.kt
+++ b/discovery/src/main/java/org/openedx/discovery/presentation/WebViewDiscoveryViewModel.kt
@@ -85,10 +85,6 @@ class WebViewDiscoveryViewModel(
         router.navigateToSignIn(fragmentManager, null, null)
     }
 
-    fun navigateToSettings(fragmentManager: FragmentManager) {
-        router.navigateToSettings(fragmentManager)
-    }
-
     fun courseInfoClickedEvent(courseId: String) {
         logEvent(DiscoveryAnalyticsEvent.COURSE_INFO, courseId)
     }

--- a/discovery/src/main/java/org/openedx/discovery/presentation/program/ProgramFragment.kt
+++ b/discovery/src/main/java/org/openedx/discovery/presentation/program/ProgramFragment.kt
@@ -203,9 +203,6 @@ class ProgramFragment : Fragment() {
                             }
                         }
                     },
-                    onSettingsClick = {
-                        viewModel.navigateToSettings(requireActivity().supportFragmentManager)
-                    }
                 )
             }
         }
@@ -249,7 +246,6 @@ private fun ProgramInfoScreen(
     isNestedFragment: Boolean,
     hasInternetConnection: Boolean,
     onWebViewUIAction: (WebViewUIAction) -> Unit,
-    onSettingsClick: () -> Unit,
     onBackClick: () -> Unit,
     onUriClick: (String, WebViewLink.Authority) -> Unit,
 ) {
@@ -304,9 +300,7 @@ private fun ProgramInfoScreen(
                 Toolbar(
                     label = stringResource(id = R.string.discovery_programs),
                     canShowBackBtn = canShowBackBtn,
-                    canShowSettingsIcon = !canShowBackBtn,
                     onBackClick = onBackClick,
-                    onSettingsClick = onSettingsClick
                 )
             }
 
@@ -388,7 +382,6 @@ fun MyProgramsPreview() {
             hasInternetConnection = false,
             onWebViewUIAction = {},
             onBackClick = {},
-            onSettingsClick = {},
             onUriClick = { _, _ -> },
         )
     }

--- a/discovery/src/main/java/org/openedx/discovery/presentation/program/ProgramViewModel.kt
+++ b/discovery/src/main/java/org/openedx/discovery/presentation/program/ProgramViewModel.kt
@@ -105,10 +105,6 @@ class ProgramViewModel(
         viewModelScope.launch { notifier.send(NavigationToDiscovery()) }
     }
 
-    fun navigateToSettings(fragmentManager: FragmentManager) {
-        router.navigateToSettings(fragmentManager)
-    }
-
     fun onPageLoadError() {
         viewModelScope.launch {
             _uiState.emit(ProgramUIState.Error(if (networkConnection.isOnline()) ErrorType.UNKNOWN_ERROR else ErrorType.CONNECTION_ERROR))


### PR DESCRIPTION
### Description

- Remove IconBtn and its implementation from Discovery and Learn toolbar


![Screenshot 2024-08-15 at 5 30 29 PM](https://github.com/user-attachments/assets/5c71f501-3773-48b7-81ae-7407258aa439)
![Screenshot 2024-08-15 at 5 30 16 PM](https://github.com/user-attachments/assets/ea74ff30-4c7c-4d97-830b-1b7bf687fa16)

fix: LEARNER-10138