### PR TITLE
chore: Theme Improvements for Primary Course Card

### DIFF
--- a/core/src/edx/org/openedx/core/ui/theme/Colors.kt
+++ b/core/src/edx/org/openedx/core/ui/theme/Colors.kt
@@ -84,7 +84,10 @@ val light_course_home_header_shade = Color(0xFFBABABA)
 val light_course_home_back_btn_background = light_surface
 val light_settings_title_content = light_surface
 val light_progress_bar_color = light_primary_button_background
-val light_progress_bar_background_color = Color(0xFFCCD4E0)
+val light_progress_bar_background_color = Color(0xFFE7E4DB)
+
+val light_primary_card_caution_background = Color(0xFFF3F1ED)
+val light_primary_card_info_background = Color(0xFFE7E4DB)
 
 
 // Dark theme colors scheme
@@ -166,4 +169,7 @@ val dark_course_home_header_shade = Color(0xFF999999)
 val dark_course_home_back_btn_background = Color.Black
 val dark_settings_title_content = Color.White
 val dark_progress_bar_color = dark_primary_button_background
-val dark_progress_bar_background_color = Color(0xFF8E9BAE)
+val dark_progress_bar_background_color = Color(0xFFE7E4DB)
+
+val dark_primary_card_caution_background = Color(0xFF2D494E)
+val dark_primary_card_info_background = Color(0xFF0E3639)

--- a/core/src/main/java/org/openedx/core/ui/UpgradeToAccessView.kt
+++ b/core/src/main/java/org/openedx/core/ui/UpgradeToAccessView.kt
@@ -75,7 +75,7 @@ fun UpgradeToAccessView(
             primaryIcon = Icons.Filled.EmojiEvents
             textColor = MaterialTheme.appColors.textDark
             shape = RectangleShape
-            backgroundColor = textColor.copy(0.05f)
+            backgroundColor = MaterialTheme.appColors.primaryCardInfoBackground
             secondaryIcon = {
                 Icon(
                     modifier = Modifier

--- a/core/src/main/java/org/openedx/core/ui/theme/AppColors.kt
+++ b/core/src/main/java/org/openedx/core/ui/theme/AppColors.kt
@@ -78,7 +78,10 @@ data class AppColors(
     val settingsTitleContent: Color,
 
     val progressBarColor: Color,
-    val progressBarBackgroundColor: Color
+    val progressBarBackgroundColor: Color,
+
+    val primaryCardCautionBackground: Color,
+    val primaryCardInfoBackground: Color,
 ) {
     val primary: Color get() = material.primary
     val primaryVariant: Color get() = material.primaryVariant

--- a/core/src/main/java/org/openedx/core/ui/theme/Theme.kt
+++ b/core/src/main/java/org/openedx/core/ui/theme/Theme.kt
@@ -96,7 +96,10 @@ private val DarkColorPalette = AppColors(
     settingsTitleContent = dark_settings_title_content,
 
     progressBarColor = dark_progress_bar_color,
-    progressBarBackgroundColor = dark_progress_bar_background_color
+    progressBarBackgroundColor = dark_progress_bar_background_color,
+
+    primaryCardCautionBackground = dark_primary_card_caution_background,
+    primaryCardInfoBackground = dark_primary_card_info_background,
 )
 
 private val LightColorPalette = AppColors(
@@ -185,7 +188,10 @@ private val LightColorPalette = AppColors(
     settingsTitleContent = light_settings_title_content,
 
     progressBarColor = light_progress_bar_color,
-    progressBarBackgroundColor = light_progress_bar_background_color
+    progressBarBackgroundColor = light_progress_bar_background_color,
+
+    primaryCardCautionBackground = light_primary_card_caution_background,
+    primaryCardInfoBackground = light_primary_card_info_background,
 )
 
 val MaterialTheme.appColors: AppColors

--- a/core/src/openedx/org/openedx/core/ui/theme/Colors.kt
+++ b/core/src/openedx/org/openedx/core/ui/theme/Colors.kt
@@ -74,6 +74,8 @@ val light_course_home_back_btn_background = Color.White
 val light_settings_title_content = Color.White
 val light_progress_bar_color = light_primary
 val light_progress_bar_background_color = Color(0xFF97A5BB)
+val light_primary_card_caution_background = Color(0xFFF3F1ED)
+val light_primary_card_info_background = Color(0xFFE7E4DB)
 
 
 val dark_primary = Color(0xFF3F68F8)
@@ -148,3 +150,5 @@ val dark_course_home_back_btn_background = Color.Black
 val dark_settings_title_content = Color.White
 val dark_progress_bar_color = light_primary
 val dark_progress_bar_background_color = Color(0xFF8E9BAE)
+val dark_primary_card_caution_background = Color(0xFF2D494E)
+val dark_primary_card_info_background = Color(0xFF0E3639)

--- a/dashboard/src/main/java/org/openedx/courses/presentation/DashboardGalleryView.kt
+++ b/dashboard/src/main/java/org/openedx/courses/presentation/DashboardGalleryView.kt
@@ -671,15 +671,21 @@ private fun PrimaryCourseButtons(
     if (!pastAssignments.isNullOrEmpty()) {
         viewsList.add {
             val nearestAssignment = pastAssignments.maxBy { it.date }
-            val title = if (pastAssignments.size == 1) nearestAssignment.title else null
+            val title = if (pastAssignments.size == 1) {
+                nearestAssignment.title
+            } else {
+                stringResource(R.string.dashboard_assignment_due_default)
+            }
             AssignmentItem(
-                modifier = Modifier.clickable {
-                    if (pastAssignments.size == 1) {
-                        resumeBlockId(primaryCourse, nearestAssignment.blockId)
-                    } else {
-                        navigateToDates(primaryCourse)
-                    }
-                },
+                modifier = Modifier
+                    .background(MaterialTheme.appColors.primaryCardCautionBackground)
+                    .clickable {
+                        if (pastAssignments.size == 1) {
+                            resumeBlockId(primaryCourse, nearestAssignment.blockId)
+                        } else {
+                            navigateToDates(primaryCourse)
+                        }
+                    },
                 painter = rememberVectorPainter(Icons.Default.Warning),
                 title = title,
                 info = pluralStringResource(
@@ -697,13 +703,20 @@ private fun PrimaryCourseButtons(
             val nearestAssignment = futureAssignments.minBy { it.date }
             val title = if (futureAssignments.size == 1) nearestAssignment.title else null
             AssignmentItem(
-                modifier = Modifier.clickable {
-                    if (futureAssignments.size == 1) {
-                        resumeBlockId(primaryCourse, nearestAssignment.blockId)
-                    } else {
-                        navigateToDates(primaryCourse)
-                    }
-                },
+                modifier = Modifier
+                    .background(
+                        if (!pastAssignments.isNullOrEmpty())
+                            MaterialTheme.appColors.primaryCardInfoBackground
+                        else
+                            MaterialTheme.appColors.primaryCardCautionBackground
+                    )
+                    .clickable {
+                        if (futureAssignments.size == 1) {
+                            resumeBlockId(primaryCourse, nearestAssignment.blockId)
+                        } else {
+                            navigateToDates(primaryCourse)
+                        }
+                    },
                 painter = painterResource(id = CoreR.drawable.ic_core_chapter_icon),
                 title = title,
                 info = stringResource(
@@ -988,7 +1001,7 @@ private val mockCourse = EnrolledCourse(
     certificate = Certificate(""),
     mode = "mode",
     isActive = true,
-    progress = Progress.DEFAULT_PROGRESS,
+    progress = Progress(4, 10),
     courseStatus = CourseStatus("", emptyList(), "", "Unit name"),
     courseAssignments = mockCourseAssignments,
     course = EnrolledCourseData(

--- a/dashboard/src/main/java/org/openedx/courses/presentation/DashboardGalleryView.kt
+++ b/dashboard/src/main/java/org/openedx/courses/presentation/DashboardGalleryView.kt
@@ -653,6 +653,19 @@ private fun PrimaryCourseCard(
     }
 }
 
+/**
+ * Manages and displays a dynamic list of primary course card buttons for up to four views: Due,
+ * Future, Upgrade, and Resume. The views are prioritized in the following order: Due, Future,
+ * Upgrade, and Resume.
+ *
+ * If all four views are active, the Future view is omitted to ensure only three buttons
+ * are shown. Unavailable views are automatically excluded from the list, preserving the
+ * established priority.
+ *
+ * Additionally, the visible buttons adhere to a specific color scheme, respecting the
+ * priority order of the colors: caution, info, and brand. The brand color is fixed for the
+ * Resume view.
+ */
 @Composable
 private fun PrimaryCourseButtons(
     modifier: Modifier = Modifier,

--- a/dashboard/src/main/res/values/strings.xml
+++ b/dashboard/src/main/res/values/strings.xml
@@ -10,6 +10,7 @@
     <string name="dashboard_view_all_with_count">View All My Courses (%1$d)</string>
     <string name="dashboard_view_all">View All</string>
     <string name="dashboard_assignment_due" translatable="false">%1$s %2$s</string>
+    <string name="dashboard_assignment_due_default">View Assignments</string>
     <string name="dashboard_course_filter_all">All</string>
     <string name="dashboard_course_filter_in_progress">In Progress</string>
     <string name="dashboard_course_filter_completed">Completed</string>


### PR DESCRIPTION
### Description

Improve Primary Course Card CTAs Background Color (left is for light & right is for dark):

<img width="1098" alt="Screenshot 2024-08-19 at 4 24 07 PM" src="https://github.com/user-attachments/assets/5086ed00-4685-4d96-a250-86eee39a1149">

### Attachments

| Before | After | Before | After |
|--------|--------|--------|--------|
| <img height=400 src="https://github.com/user-attachments/assets/9d9cb81e-54a4-42d2-964c-768226132e4f"/> | <img height=400 src="https://github.com/user-attachments/assets/e7c95a70-f29e-4330-863c-f10a7f402c7c"/> | <img height=400 src="https://github.com/user-attachments/assets/121e1fe2-7493-4b1e-be04-d5361573a3b1"/> | <img height=400 src="https://github.com/user-attachments/assets/bc54324d-bc65-44e3-b5a4-f1128c457a73"/> | 



Fixes: [LEARNER-10078](https://2u-internal.atlassian.net/browse/LEARNER-10078)