### PR TITLE
fix: Handle missing email in Facebook login

### DIFF
--- a/auth/src/main/java/org/openedx/auth/presentation/sso/FacebookAuthHelper.kt
+++ b/auth/src/main/java/org/openedx/auth/presentation/sso/FacebookAuthHelper.kt
@@ -46,8 +46,8 @@ class FacebookAuthHelper {
                                 continuation.safeResume(
                                     SocialAuthResponse(
                                         accessToken = result.accessToken.token,
-                                        name = obj?.getString(ApiConstants.NAME) ?: "",
-                                        email = obj?.getString(ApiConstants.EMAIL) ?: "",
+                                        name = obj?.optString(ApiConstants.NAME).orEmpty(),
+                                        email = obj?.optString(ApiConstants.EMAIL).orEmpty(),
                                         authType = AuthType.FACEBOOK,
                                     )
                                 ) {


### PR DESCRIPTION
### Description

Replaced `JSONObject.getString()` with `JSONObject.optString()` to prevent exceptions when the email is not provided. Since the email is not required in the login flow, the change ensures a smooth process by returning an empty string if the email key is absent.

Fixes: [Bug Sheet](https://docs.google.com/spreadsheets/d/1YuN7Wg2sqMwQf8R02Z0iLtKhPsq1C4LWklMmR1QU5Cs/edit?gid=87739949#gid=87739949&range=17:17)