### PR TITLE
fix: added default value to the AppConfig to prevent crashes in some cases 

### DIFF
--- a/app/src/main/java/org/openedx/app/data/storage/PreferencesManager.kt
+++ b/app/src/main/java/org/openedx/app/data/storage/PreferencesManager.kt
@@ -129,9 +129,11 @@ class PreferencesManager(context: Context) : CorePreferences, ProfilePreferences
             saveString(APP_CONFIG, appConfigJson)
         }
         get() {
-            val appConfigString = getString(APP_CONFIG)
+            val appConfigString = getString(APP_CONFIG, getDefaultAppConfig())
             return Gson().fromJson(appConfigString, AppConfig::class.java)
         }
+
+    private fun getDefaultAppConfig() = Gson().toJson(AppConfig())
 
     override var lastWhatsNewVersion: String
         set(value) {

--- a/core/src/main/java/org/openedx/core/domain/model/AppConfig.kt
+++ b/core/src/main/java/org/openedx/core/domain/model/AppConfig.kt
@@ -3,16 +3,16 @@ package org.openedx.core.domain.model
 import java.io.Serializable
 
 data class AppConfig(
-    val courseDatesCalendarSync: CourseDatesCalendarSync,
+    val courseDatesCalendarSync: CourseDatesCalendarSync = CourseDatesCalendarSync(),
     val iapConfig: IAPConfig = IAPConfig(),
     val feedbackFormUrl: String = "",
 ) : Serializable
 
 data class CourseDatesCalendarSync(
-    val isEnabled: Boolean,
-    val isSelfPacedEnabled: Boolean,
-    val isInstructorPacedEnabled: Boolean,
-    val isDeepLinkEnabled: Boolean,
+    val isEnabled: Boolean = false,
+    val isSelfPacedEnabled: Boolean = false,
+    val isInstructorPacedEnabled: Boolean = false,
+    val isDeepLinkEnabled: Boolean = false,
 ) : Serializable
 
 data class IAPConfig(


### PR DESCRIPTION
Fix several crashes when app config is not saved in the preferences.

line 22 [doc](https://docs.google.com/spreadsheets/d/1YuN7Wg2sqMwQf8R02Z0iLtKhPsq1C4LWklMmR1QU5Cs/)