### PR TITLE
fix: crash when trying to get first topic in list

### DIFF
--- a/discussion/src/main/java/org/openedx/discussion/presentation/threads/DiscussionAddThreadViewModel.kt
+++ b/discussion/src/main/java/org/openedx/discussion/presentation/threads/DiscussionAddThreadViewModel.kt
@@ -65,9 +65,8 @@ class DiscussionAddThreadViewModel(
     }
 
     fun getHandledTopicById(topicId: String): Pair<String, String> {
-        return getHandledTopics().find{
-            it.second == topicId
-        } ?: getHandledTopics()[0]
+        val topics = getHandledTopics()
+        return topics.find { it.second == topicId } ?: topics.firstOrNull() ?: Pair("", "")
     }
 
     fun sendThreadAdded() {


### PR DESCRIPTION
Fixed a crash when trying to retrieve the first element in an empty list