### PR TITLE
fix: Fullstory Custom Events

### DIFF
--- a/app/src/main/java/org/openedx/app/analytics/FullstoryAnalytics.kt
+++ b/app/src/main/java/org/openedx/app/analytics/FullstoryAnalytics.kt
@@ -27,7 +27,7 @@ class FullstoryAnalytics(isFirebaseEnabled: Boolean = false) : Analytics {
 
     override fun logEvent(eventName: String, params: Map<String, Any?>) {
         logger.d { "Event: $eventName $params" }
-        FS.page(eventName, params).start()
+        FS.event(eventName, params)
     }
 
     override fun logUserId(userId: Long) {


### PR DESCRIPTION
We were mistakenly sending custom or track events as page events. This update fixes them to the correct event types.

_Note: I’ve created a dummy session with App Version 5.9.5 that you can use for verification._