### PR TITLE
fix: `IllegalStateException` on `supportFragmentManager.popBackStack()`

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -114,6 +114,7 @@ dependencies {
     api "androidx.lifecycle:lifecycle-runtime-ktx:$lifecycle_version"
     api "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycle_version"
     api "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycle_version"
+    api "androidx.lifecycle:lifecycle-runtime-compose:$lifecycle_version"
 
     // Fullstory
     api 'com.fullstory:instrumentation-full:1.47.0@aar'

--- a/course/src/main/java/org/openedx/course/settings/download/DownloadQueueFragment.kt
+++ b/course/src/main/java/org/openedx/course/settings/download/DownloadQueueFragment.kt
@@ -23,7 +23,6 @@ import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.material.rememberScaffoldState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -41,6 +40,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.koin.core.parameter.parametersOf
 import org.openedx.core.module.db.DownloadModel
@@ -80,7 +80,7 @@ class DownloadQueueFragment : Fragment() {
         setContent {
             OpenEdXTheme {
                 val windowSize = rememberWindowSize()
-                val uiState by viewModel.uiState.collectAsState(DownloadQueueUIState.Loading)
+                val uiState by viewModel.uiState.collectAsStateWithLifecycle(DownloadQueueUIState.Loading)
 
                 DownloadQueueScreen(
                     windowSize = windowSize,


### PR DESCRIPTION
### Description

Fix `IllegalStateException` on `supportFragmentManager.popBackStack()`
- Ensure `MutableStateFlow` is lifecycle-aware by utilizing `collectAsStateWithLifecycle`.

**Steps to reproduce:**
- Login in the app.
- Open any course.
- Start downloading any video.
- Open the video downloading Queue screen.
- Move the app in the background before completing the video download.
- App leads to crash after completing video download when the app is in the background.

**Note:** Make sure the following options are enabled from the Developer options.
- Always show crash dialog.
- Show background ANRs.