### PR TITLE
fix: Enabled cast button for HLS videos

### DIFF
--- a/course/src/main/java/org/openedx/course/presentation/unit/container/CourseUnitContainerFragment.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/container/CourseUnitContainerFragment.kt
@@ -78,7 +78,6 @@ class CourseUnitContainerFragment : Fragment(R.layout.fragment_course_unit_conta
                 val encodedVideo = currentBlock.studentViewData?.encodedVideos
                 binding.mediaRouteButton.isVisible = currentBlock.type == BlockType.VIDEO
                         && encodedVideo?.hasNonYoutubeVideo == true
-                        && !encodedVideo.videoUrl.endsWith(".m3u8")
             }
         }
     }


### PR DESCRIPTION
### Description
 
Enable the cast button for HLS videos.

- After the [PR#43](https://github.com/edx/edx-mobile-marketplace-android/pull/43) HLS video can be cast via chrome cast from the app.