### PR TITLE
fix: Crash on CastContext instance when play services aren't available

### DIFF
--- a/course/src/main/java/org/openedx/course/presentation/unit/video/EncodedVideoUnitViewModel.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/video/EncodedVideoUnitViewModel.kt
@@ -24,6 +24,7 @@ import org.openedx.core.domain.model.VideoQuality
 import org.openedx.core.module.TranscriptManager
 import org.openedx.core.system.connection.NetworkConnection
 import org.openedx.core.system.notifier.CourseNotifier
+import org.openedx.core.utils.Logger
 import org.openedx.course.data.repository.CourseRepository
 import org.openedx.course.presentation.CourseAnalytics
 import org.openedx.course.presentation.CourseAnalyticsKey
@@ -48,7 +49,7 @@ class EncodedVideoUnitViewModel(
     transcriptManager,
     courseAnalytics
 ) {
-
+    private val logger = Logger(TAG)
     private val _isVideoEnded = MutableLiveData(false)
     val isVideoEnded: LiveData<Boolean>
         get() = _isVideoEnded
@@ -104,8 +105,10 @@ class EncodedVideoUnitViewModel(
         initPlayer()
 
         val executor = Executors.newSingleThreadExecutor()
-        CastContext.getSharedInstance(context, executor).result?.let { castContext ->
+        CastContext.getSharedInstance(context, executor).addOnSuccessListener { castContext ->
             castPlayer = CastPlayer(castContext)
+        }.addOnFailureListener {
+            logger.e(it, true)
         }
     }
 
@@ -184,5 +187,9 @@ class EncodedVideoUnitViewModel(
         } else {
             CourseAnalyticsKey.NATIVE.key
         }
+    }
+
+    private companion object {
+        private const val TAG = "EncodedVideoUnitViewModel"
     }
 }


### PR DESCRIPTION
### Description

Jira: [LEARNER-10231](https://2u-internal.atlassian.net/browse/LEARNER-10231)
Firebase Crash: [EncodedVideoUnitViewModel.onCreate](https://console.firebase.google.com/u/1/project/openedx-mobile/crashlytics/app/android:org.edx.mobile/issues?versions=6.0.3%20(6000003)&state=open&time=last-seven-days&tag=all&sort=eventCount)


Crash on CastContext instance when play services aren't available

- Unable to get CastContext when Google Play services aren’t available, leads to the app crash.

**Steps to reproduce:**
- Log in to the app on the emulator OR real device with no OR disabled Google Play service.
- Open any course, and click on the Videos tab.
- Open any video from the list, and the user is redirected to the video component screen, and 🔥 app crashes.