### PR TITLE
fix: Remove `student_view_mutli_device` dependency for HTML XBlocks

### DIFF
--- a/course/src/main/java/org/openedx/course/presentation/unit/container/CourseUnitContainerAdapter.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/container/CourseUnitContainerAdapter.kt
@@ -66,13 +66,6 @@ class CourseUnitContainerAdapter(
                 )
             }
 
-            block.studentViewMultiDevice.not() -> {
-                NotSupportedUnitFragment.newInstance(
-                    block.id,
-                    block.lmsWebUrl
-                )
-            }
-
             block.isHTMLBlock ||
                     block.isProblemBlock ||
                     block.isOpenAssessmentBlock ||


### PR DESCRIPTION
### Description:

- Going forward, all HTML Xblocks will be visible on the mobile side, regardless of `student_view_multi_device`.

fix: LEARNER-10232