### PR TITLE
chore: Elm theme improvement on Course Home

### DIFF
--- a/core/src/edx/org/openedx/core/ui/theme/Colors.kt
+++ b/core/src/edx/org/openedx/core/ui/theme/Colors.kt
@@ -169,7 +169,7 @@ val dark_course_home_header_shade = Color(0xFF999999)
 val dark_course_home_back_btn_background = Color.Black
 val dark_settings_title_content = Color.White
 val dark_progress_bar_color = dark_primary_button_background
-val dark_progress_bar_background_color = Color(0xFFE7E4DB)
+val dark_progress_bar_background_color = Color(0xFF707070)
 
 val dark_primary_card_caution_background = Color(0xFF2D494E)
 val dark_primary_card_info_background = Color(0xFF0E3639)

--- a/course/src/main/java/org/openedx/course/presentation/ui/CourseUI.kt
+++ b/course/src/main/java/org/openedx/course/presentation/ui/CourseUI.kt
@@ -704,7 +704,7 @@ fun CourseExpandableChapterCard(
                     if (downloadedState == DownloadedState.DOWNLOADED) {
                         MaterialTheme.appColors.successGreen
                     } else {
-                        MaterialTheme.appColors.textAccent
+                        MaterialTheme.appColors.textPrimary
                     }
                 IconButton(modifier = iconModifier,
                     onClick = { onDownloadClick() }) {


### PR DESCRIPTION
### Description

- The checkmark icon will retain its current design but will now use the color **Success-500 (#0D7D4D)**.
- The download icon will adopt the **Section Title Text** color, which for Android is defined as follows:
  - **Dark Mode:** Paragon Light 200 — #FBFAF9
  - **Light Mode:** Paragon/Paragon Elm Primary 500 — #00262B
- The background color of the progress bar will be updated to Grey-500 (#707070) in dark mode.

### Screenshots

| Dark Mode                               | Light Mode                               |
|-----------------------------------------|------------------------------------------|
| <img src="https://github.com/user-attachments/assets/d68de847-6e4a-4eec-8629-366b4ed01f5e" height="400"> | <img src="https://github.com/user-attachments/assets/274d0c67-8af1-414d-832f-0c8c4733894d" height="400"> |
