### PR TITLE
fix: Inconsistency of `keepScreenOn` to restrict display timeout

### DIFF
--- a/course/src/main/java/org/openedx/course/presentation/unit/video/VideoFullScreenFragment.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/video/VideoFullScreenFragment.kt
@@ -3,6 +3,7 @@ package org.openedx.course.presentation.unit.video
 import android.annotation.SuppressLint
 import android.os.Bundle
 import android.view.View
+import android.view.WindowManager
 import android.widget.FrameLayout
 import androidx.core.os.bundleOf
 import androidx.core.view.WindowInsetsCompat
@@ -184,7 +185,7 @@ class VideoFullScreenFragment : Fragment(R.layout.fragment_video_full_screen) {
     }
 
     override fun onPause() {
-        binding.playerView.keepScreenOn = false
+        requireActivity().window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
         exoPlayer?.removeListener(exoPlayerListener)
         exoPlayer?.pause()
         super.onPause()
@@ -205,7 +206,7 @@ class VideoFullScreenFragment : Fragment(R.layout.fragment_video_full_screen) {
 
     override fun onResume() {
         super.onResume()
-        binding.playerView.keepScreenOn = true
+        requireActivity().window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
         exoPlayer?.addListener(exoPlayerListener)
     }
 

--- a/course/src/main/java/org/openedx/course/presentation/unit/video/VideoUnitFragment.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/video/VideoUnitFragment.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
 import android.view.View
+import android.view.WindowManager
 import android.widget.FrameLayout
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.collectAsState
@@ -241,11 +242,11 @@ class VideoUnitFragment : Fragment(R.layout.fragment_video_unit) {
 
     override fun onResume() {
         super.onResume()
-        binding.playerView.keepScreenOn = true
+        requireActivity().window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
     }
 
     override fun onPause() {
-        binding.playerView.keepScreenOn = false
+        requireActivity().window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
         super.onPause()
     }
 


### PR DESCRIPTION
### Description

[LEARNER-10283](https://2u-internal.atlassian.net/browse/LEARNER-10283)

Fix the Inconsistency of `keepScreenOn` to restrict display timeout.
- Replace the `keepScreenOn` property with the activity level flag `FLAG_KEEP_SCREEN_ON`.