### PR TITLE
chore: Remove visibility of scored grades from assignment section

### DIFF
--- a/course/src/main/java/org/openedx/course/presentation/ui/CourseUI.kt
+++ b/course/src/main/java/org/openedx/course/presentation/ui/CourseUI.kt
@@ -792,8 +792,6 @@ fun CourseSubSectionItem(
                     R.string.course_subsection_assignment_info,
                     block.assignmentProgress?.assignmentType ?: "",
                     due ?: "",
-                    block.assignmentProgress?.numPointsEarned?.toInt() ?: 0,
-                    block.assignmentProgress?.numPointsPossible?.toInt() ?: 0
                 )
             Spacer(modifier = Modifier.height(8.dp))
             Text(

--- a/course/src/main/res/values/strings.xml
+++ b/course/src/main/res/values/strings.xml
@@ -61,7 +61,7 @@
     <string name="course_delete_while_downloading_confirmation_text" formatted="false">Turning off the switch will stop downloading and delete all downloaded videos for \"%s\"?</string>
     <string name="course_delete_downloads_confirmation_text" formatted="false">Are you sure you want to delete all video(s) for \"%s\"?</string>
     <string name="course_delete_download_confirmation_text" formatted="false">Are you sure you want to delete video(s) for \"%s\"?</string>
-    <string name="course_subsection_assignment_info" translatable="false">%1$s - %2$s - %3$d / %4$d</string>
+    <string name="course_subsection_assignment_info" translatable="false">%1$s - %2$s</string>
 
     <plurals name="course_assignments_complete" tools:ignore="MissingTranslation">
         <item quantity="one">%1$s of %2$s  assignment complete</item>


### PR DESCRIPTION
### Description

[LEARNER-10302](https://2u-internal.atlassian.net/browse/LEARNER-10302)

This PR removes grades-related UI to align with course settings that specify "Never Show Assessment Results." This ensures compliance and avoids user confusion until the backend provides the necessary visibility flags in the Blocks API. We will revisit the implementation once the backend fix is available.

| Before  | After |
| ------------- | ------------- |
| <img src="https://github.com/user-attachments/assets/f079dc5e-5082-4fd6-9854-a19477c71dce"  /> | <img src="https://github.com/user-attachments/assets/acf5601c-a696-4ce9-88c6-4ffd06add577" /> |