### PR TITLE
chore: log custom event for notification permission status

### DIFF
--- a/app/src/main/java/org/openedx/app/AppAnalytics.kt
+++ b/app/src/main/java/org/openedx/app/AppAnalytics.kt
@@ -38,5 +38,4 @@ enum class AppAnalyticsKey(val key: String) {
 enum class PermissionStatus(val status: String) {
     DENIED("denied"),
     AUTHORIZED("authorized"),
-    NOT_DETERMINED("not_determined"),
 }

--- a/app/src/main/java/org/openedx/app/AppAnalytics.kt
+++ b/app/src/main/java/org/openedx/app/AppAnalytics.kt
@@ -24,8 +24,19 @@ enum class AppAnalyticsEvent(val eventName: String, val biValue: String) {
         "MainDashboard:Profile",
         "edx.bi.app.main_dashboard.profile"
     ),
+    NOTIFICATION_PERMISSION(
+        "Notification:Setting Permission Status",
+        "edx.bi.app.notification.permission_settings.status"
+    )
 }
 
 enum class AppAnalyticsKey(val key: String) {
     NAME("name"),
+    STATUS("status"),
+}
+
+enum class PermissionStatus(val status: String) {
+    DENIED("denied"),
+    AUTHORIZED("authorized"),
+    NOT_DETERMINED("not_determined"),
 }

--- a/app/src/main/java/org/openedx/app/MainViewModel.kt
+++ b/app/src/main/java/org/openedx/app/MainViewModel.kt
@@ -1,5 +1,8 @@
 package org.openedx.app
 
+import android.annotation.SuppressLint
+import android.content.Context
+import androidx.core.app.NotificationManagerCompat
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
@@ -16,7 +19,9 @@ import org.openedx.core.system.notifier.DiscoveryNotifier
 import org.openedx.core.system.notifier.NavigationToDiscovery
 import org.openedx.discovery.presentation.DiscoveryNavigator
 
+@SuppressLint("StaticFieldLeak")
 class MainViewModel(
+    private val context: Context,
     private val config: Config,
     private val notifier: DiscoveryNotifier,
     private val analytics: AppAnalytics,
@@ -43,6 +48,7 @@ class MainViewModel(
             }
             .distinctUntilChanged()
             .launchIn(viewModelScope)
+        logSettingPermissionStatusEvent()
     }
 
     fun enableBottomBar(enable: Boolean) {
@@ -52,7 +58,7 @@ class MainViewModel(
     fun logLearnTabClickedEvent() {
         logScreenEvent(AppAnalyticsEvent.LEARN)
     }
-    
+
     fun logDiscoveryTabClickedEvent() {
         logScreenEvent(AppAnalyticsEvent.DISCOVER)
     }
@@ -68,5 +74,19 @@ class MainViewModel(
                 put(AppAnalyticsKey.NAME.key, event.biValue)
             }
         )
+    }
+
+    private fun logSettingPermissionStatusEvent() {
+        val event = AppAnalyticsEvent.NOTIFICATION_PERMISSION
+        val permissionStatus =
+            if (NotificationManagerCompat.from(context).areNotificationsEnabled()) {
+                PermissionStatus.AUTHORIZED
+            } else {
+                PermissionStatus.DENIED
+            }
+        analytics.logEvent(event.eventName, buildMap {
+            put(AppAnalyticsKey.NAME.key, event.biValue)
+            put(AppAnalyticsKey.STATUS.key, permissionStatus.status)
+        })
     }
 }

--- a/app/src/main/java/org/openedx/app/MainViewModel.kt
+++ b/app/src/main/java/org/openedx/app/MainViewModel.kt
@@ -48,7 +48,7 @@ class MainViewModel(
             }
             .distinctUntilChanged()
             .launchIn(viewModelScope)
-        logSettingPermissionStatusEvent()
+        logNotificationPermissionStatusEvent()
     }
 
     fun enableBottomBar(enable: Boolean) {
@@ -76,7 +76,7 @@ class MainViewModel(
         )
     }
 
-    private fun logSettingPermissionStatusEvent() {
+    private fun logNotificationPermissionStatusEvent() {
         val event = AppAnalyticsEvent.NOTIFICATION_PERMISSION
         val permissionStatus =
             if (NotificationManagerCompat.from(context).areNotificationsEnabled()) {

--- a/app/src/main/java/org/openedx/app/di/ScreenModule.kt
+++ b/app/src/main/java/org/openedx/app/di/ScreenModule.kt
@@ -86,7 +86,7 @@ val screenModule = module {
             get()
         )
     }
-    viewModel { MainViewModel(get(), get(), get()) }
+    viewModel { MainViewModel(get(), get(), get(), get()) }
 
     factory { AuthRepository(get(), get(), get()) }
     factory { AuthInteractor(get()) }


### PR DESCRIPTION
### Description 

Jira: [LEARNER-10338](https://2u-internal.atlassian.net/browse/LEARNER-10338)

We need to implement a new custom event to capture the notification permission status set by the user on the Learn tab. This event will send the current permission status once per app session.