### PR TITLE
Hide google auth option, if GoogleApi doesn't available on device

### DIFF
--- a/app/src/main/java/org/openedx/app/di/AppModule.kt
+++ b/app/src/main/java/org/openedx/app/di/AppModule.kt
@@ -206,7 +206,7 @@ val appModule = module {
 
     factory { AgreementProvider(get(), get()) }
     factory { FacebookAuthHelper() }
-    factory { GoogleAuthHelper(get()) }
+    factory { GoogleAuthHelper(get(), get()) }
     factory { MicrosoftAuthHelper() }
     factory { OAuthHelper(get(), get(), get()) }
 

--- a/auth/src/main/java/org/openedx/auth/presentation/signin/SignInViewModel.kt
+++ b/auth/src/main/java/org/openedx/auth/presentation/signin/SignInViewModel.kt
@@ -59,7 +59,7 @@ class SignInViewModel(
     private val _uiState = MutableStateFlow(
         SignInUIState(
             isFacebookAuthEnabled = config.getFacebookConfig().isEnabled(),
-            isGoogleAuthEnabled = config.getGoogleConfig().isEnabled(),
+            isGoogleAuthEnabled = config.getGoogleConfig().isEnabled() && oAuthHelper.isGoogleAuthEnabled(),
             isMicrosoftAuthEnabled = config.getMicrosoftConfig().isEnabled(),
             isSocialAuthEnabled = config.isSocialAuthEnabled(),
             isLogistrationEnabled = config.isPreLoginExperienceEnabled(),

--- a/auth/src/main/java/org/openedx/auth/presentation/signup/SignUpViewModel.kt
+++ b/auth/src/main/java/org/openedx/auth/presentation/signup/SignUpViewModel.kt
@@ -56,7 +56,7 @@ class SignUpViewModel(
     private val _uiState = MutableStateFlow(
         SignUpUIState(
             isFacebookAuthEnabled = config.getFacebookConfig().isEnabled(),
-            isGoogleAuthEnabled = config.getGoogleConfig().isEnabled(),
+            isGoogleAuthEnabled = config.getGoogleConfig().isEnabled() && oAuthHelper.isGoogleAuthEnabled(),
             isMicrosoftAuthEnabled = config.getMicrosoftConfig().isEnabled(),
             isSocialAuthEnabled = config.isSocialAuthEnabled(),
             isLoading = true,

--- a/auth/src/main/java/org/openedx/auth/presentation/sso/GoogleAuthHelper.kt
+++ b/auth/src/main/java/org/openedx/auth/presentation/sso/GoogleAuthHelper.kt
@@ -2,6 +2,7 @@ package org.openedx.auth.presentation.sso
 
 import android.accounts.Account
 import android.app.Activity
+import android.content.Context
 import android.credentials.GetCredentialException
 import android.os.Bundle
 import androidx.annotation.WorkerThread
@@ -11,6 +12,8 @@ import androidx.credentials.CustomCredential
 import androidx.credentials.GetCredentialRequest
 import androidx.credentials.exceptions.GetCredentialCancellationException
 import com.google.android.gms.auth.GoogleAuthUtil
+import com.google.android.gms.common.ConnectionResult
+import com.google.android.gms.common.GoogleApiAvailability
 import com.google.android.libraries.identity.googleid.GetSignInWithGoogleOption
 import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
 import com.google.android.libraries.identity.googleid.GoogleIdTokenParsingException
@@ -19,7 +22,7 @@ import org.openedx.auth.domain.model.SocialAuthResponse
 import org.openedx.core.config.Config
 import org.openedx.core.utils.Logger
 
-class GoogleAuthHelper(private val config: Config) {
+class GoogleAuthHelper(private val context: Context, private val config: Config) {
 
     private val logger = Logger(TAG)
 
@@ -102,6 +105,9 @@ class GoogleAuthHelper(private val config: Config) {
             }
         }
     }
+
+    fun isGoogleAuthEnabled() =
+        GoogleApiAvailability.getInstance().isGooglePlayServicesAvailable(context) == ConnectionResult.SUCCESS
 
     private companion object {
         const val TAG = "GoogleAuthHelper"

--- a/auth/src/main/java/org/openedx/auth/presentation/sso/OAuthHelper.kt
+++ b/auth/src/main/java/org/openedx/auth/presentation/sso/OAuthHelper.kt
@@ -24,6 +24,8 @@ class OAuthHelper(
         }
     }
 
+    internal fun isGoogleAuthEnabled() = googleAuthHelper.isGoogleAuthEnabled()
+
     fun clear() {
         facebookAuthHelper.clear()
     }


### PR DESCRIPTION
Some devices are coming with no GooglePlayServices installed on it, so If you will try to sign in or sign up using google auth option you will get an error.

It this PR I added option to hide Google auth button if GooglePlayServices doesn't available on device.