### PR TITLE
feat: Notifications Preferences Screen

### DIFF
--- a/app/src/main/java/org/openedx/app/AnalyticsManager.kt
+++ b/app/src/main/java/org/openedx/app/AnalyticsManager.kt
@@ -14,6 +14,7 @@ import org.openedx.course.presentation.CourseAnalytics
 import org.openedx.dashboard.presentation.DashboardAnalytics
 import org.openedx.discovery.presentation.DiscoveryAnalytics
 import org.openedx.discussion.presentation.DiscussionAnalytics
+import org.openedx.notifications.presentation.NotificationsAnalytics
 import org.openedx.profile.presentation.ProfileAnalytics
 import org.openedx.whatsnew.presentation.WhatsNewAnalytics
 
@@ -22,7 +23,7 @@ class AnalyticsManager(
     config: Config,
 ) : AppAnalytics, AppReviewAnalytics, AuthAnalytics, CoreAnalytics, CourseAnalytics,
     DashboardAnalytics, DiscoveryAnalytics, DiscussionAnalytics, ProfileAnalytics,
-    WhatsNewAnalytics, IAPAnalytics {
+    WhatsNewAnalytics, IAPAnalytics, NotificationsAnalytics {
 
     private val services: ArrayList<Analytics> = arrayListOf()
 

--- a/app/src/main/java/org/openedx/app/AppRouter.kt
+++ b/app/src/main/java/org/openedx/app/AppRouter.kt
@@ -43,6 +43,7 @@ import org.openedx.discussion.presentation.search.DiscussionSearchThreadFragment
 import org.openedx.discussion.presentation.threads.DiscussionAddThreadFragment
 import org.openedx.discussion.presentation.threads.DiscussionThreadsFragment
 import org.openedx.notifications.presentation.inbox.NotificationsInboxFragment
+import org.openedx.notifications.presentation.settings.NotificationsSettingsFragment
 import org.openedx.profile.domain.model.Account
 import org.openedx.profile.presentation.ProfileRouter
 import org.openedx.profile.presentation.anothersaccount.AnothersProfileFragment
@@ -423,6 +424,10 @@ class AppRouter : AuthRouter, DiscoveryRouter, DashboardRouter, CourseRouter, Di
 
     override fun navigateToVideoSettings(fm: FragmentManager) {
         replaceFragmentWithBackStack(fm, VideoSettingsFragment())
+    }
+
+    override fun navigateToPushNotificationsSettings(fm: FragmentManager) {
+        replaceFragmentWithBackStack(fm, NotificationsSettingsFragment())
     }
 
     override fun navigateToVideoQuality(fm: FragmentManager, videoQualityType: VideoQualityType) {

--- a/app/src/main/java/org/openedx/app/data/storage/PreferencesManager.kt
+++ b/app/src/main/java/org/openedx/app/data/storage/PreferencesManager.kt
@@ -13,12 +13,14 @@ import org.openedx.core.domain.model.VideoQuality
 import org.openedx.core.domain.model.VideoSettings
 import org.openedx.core.extension.replaceSpace
 import org.openedx.course.data.storage.CoursePreferences
+import org.openedx.notifications.data.storage.NotificationsPreferences
+import org.openedx.notifications.domain.model.NotificationsConfiguration
 import org.openedx.profile.data.model.Account
 import org.openedx.profile.data.storage.ProfilePreferences
 import org.openedx.whatsnew.data.storage.WhatsNewPreferences
 
 class PreferencesManager(context: Context) : CorePreferences, ProfilePreferences,
-    WhatsNewPreferences, InAppReviewPreferences, CoursePreferences {
+    WhatsNewPreferences, InAppReviewPreferences, CoursePreferences, NotificationsPreferences {
 
     private val sharedPreferences =
         context.getSharedPreferences(BuildConfig.APPLICATION_ID, Context.MODE_PRIVATE)
@@ -186,6 +188,17 @@ class PreferencesManager(context: Context) : CorePreferences, ProfilePreferences
     override fun isCalendarSyncEventsDialogShown(courseName: String): Boolean =
         getBoolean(courseName.replaceSpace("_"))
 
+    override var notifications: NotificationsConfiguration
+        set(value) {
+            val notificationsJson = Gson().toJson(value)
+            saveString(NOTIFICATIONS_CONFIGURATION, notificationsJson)
+        }
+        get() {
+            val notificationsString = getString(NOTIFICATIONS_CONFIGURATION)
+            return Gson().fromJson(notificationsString, NotificationsConfiguration::class.java)
+                ?: NotificationsConfiguration.default
+        }
+
     companion object {
         private const val ACCESS_TOKEN = "access_token"
         private const val REFRESH_TOKEN = "refresh_token"
@@ -203,5 +216,6 @@ class PreferencesManager(context: Context) : CorePreferences, ProfilePreferences
         private const val APP_CONFIG = "app_config"
         private const val RESET_APP_DIRECTORY = "reset_app_directory"
         private const val LAST_SIGN_IN_TYPE = "last_sign_in_type"
+        private const val NOTIFICATIONS_CONFIGURATION = "notifications_configuration"
     }
 }

--- a/app/src/main/java/org/openedx/app/di/AppModule.kt
+++ b/app/src/main/java/org/openedx/app/di/AppModule.kt
@@ -47,13 +47,13 @@ import org.openedx.core.presentation.global.app_upgrade.AppUpgradeRouter
 import org.openedx.core.system.AppCookieManager
 import org.openedx.core.system.CalendarManager
 import org.openedx.core.system.PushGlobalManager
-import org.openedx.core.system.notifier.PushNotifier
 import org.openedx.core.system.ResourceManager
 import org.openedx.core.system.connection.NetworkConnection
 import org.openedx.core.system.notifier.CourseNotifier
 import org.openedx.core.system.notifier.DiscoveryNotifier
 import org.openedx.core.system.notifier.DownloadNotifier
 import org.openedx.core.system.notifier.IAPNotifier
+import org.openedx.core.system.notifier.PushNotifier
 import org.openedx.core.system.notifier.VideoNotifier
 import org.openedx.core.system.notifier.app.AppNotifier
 import org.openedx.core.utils.FileUtil
@@ -68,6 +68,8 @@ import org.openedx.discussion.presentation.DiscussionAnalytics
 import org.openedx.discussion.presentation.DiscussionRouter
 import org.openedx.discussion.system.notifier.DiscussionNotifier
 import org.openedx.notifications.PushManager
+import org.openedx.notifications.data.storage.NotificationsPreferences
+import org.openedx.notifications.presentation.NotificationsAnalytics
 import org.openedx.profile.data.storage.ProfilePreferences
 import org.openedx.profile.presentation.ProfileAnalytics
 import org.openedx.profile.presentation.ProfileRouter
@@ -87,6 +89,7 @@ val appModule = module {
     single<WhatsNewPreferences> { get<PreferencesManager>() }
     single<InAppReviewPreferences> { get<PreferencesManager>() }
     single<CoursePreferences> { get<PreferencesManager>() }
+    single<NotificationsPreferences> { get<PreferencesManager>() }
 
     single { ResourceManager(get()) }
     single { AppCookieManager(get(), get()) }
@@ -207,6 +210,7 @@ val appModule = module {
     single<ProfileAnalytics> { get<AnalyticsManager>() }
     single<WhatsNewAnalytics> { get<AnalyticsManager>() }
     single<IAPAnalytics> { get<AnalyticsManager>() }
+    single<NotificationsAnalytics> { get<AnalyticsManager>() }
 
     single { PushManager(get()) }
     single<PushGlobalManager> { get<PushManager>() }

--- a/app/src/main/java/org/openedx/app/di/ScreenModule.kt
+++ b/app/src/main/java/org/openedx/app/di/ScreenModule.kt
@@ -61,6 +61,7 @@ import org.openedx.learn.presentation.LearnViewModel
 import org.openedx.notifications.data.repository.NotificationsRepository
 import org.openedx.notifications.domain.interactor.NotificationsInteractor
 import org.openedx.notifications.presentation.inbox.NotificationsInboxViewModel
+import org.openedx.notifications.presentation.settings.NotificationsSettingsViewModel
 import org.openedx.profile.data.repository.ProfileRepository
 import org.openedx.profile.domain.interactor.ProfileInteractor
 import org.openedx.profile.domain.model.Account
@@ -487,6 +488,7 @@ val screenModule = module {
     factory { NotificationsInteractor(get()) }
 
     viewModel { NotificationsInboxViewModel(get(), get()) }
+    viewModel { NotificationsSettingsViewModel(get(), get(), get()) }
 
     single { IAPRepository(get()) }
     factory { IAPInteractor(get(), get(), get(), get(), get()) }

--- a/notifications/src/main/java/org/openedx/notifications/data/api/APIConstants.kt
+++ b/notifications/src/main/java/org/openedx/notifications/data/api/APIConstants.kt
@@ -1,10 +1,15 @@
 package org.openedx.notifications.data.api
 
 object APIConstants {
-    const val NOTIFICATION_COUNT = "/api/notifications/count/"
+    const val NOTIFICATIONS_COUNT = "/api/notifications/count/"
     const val NOTIFICATIONS_INBOX = "/api/notifications/"
     const val NOTIFICATIONS_SEEN = "/api/notifications/mark-seen/{app_name}/"
     const val NOTIFICATION_READ = "/api/notifications/read/"
 
+    const val NOTIFICATIONS_CONFIGURATION = "/api/notifications/configurations/"
+    const val NOTIFICATION_UPDATE_CONFIGURATION = "/api/notifications/preferences/update-all/"
+
     const val APP_NAME_DISCUSSION = "discussion"
+    const val NOTIFICATION_TYPE = "core"
+    const val NOTIFICATION_CHANNEL = "push"
 }

--- a/notifications/src/main/java/org/openedx/notifications/data/api/NotificationsApi.kt
+++ b/notifications/src/main/java/org/openedx/notifications/data/api/NotificationsApi.kt
@@ -2,17 +2,21 @@ package org.openedx.notifications.data.api
 
 import org.openedx.notifications.data.model.InboxNotificationsResponse
 import org.openedx.notifications.data.model.MarkNotificationReadBody
+import org.openedx.notifications.data.model.NotificationsConfiguration
 import org.openedx.notifications.data.model.NotificationsCountResponse
 import org.openedx.notifications.data.model.NotificationsMarkResponse
+import org.openedx.notifications.data.model.NotificationsUpdateBody
+import org.openedx.notifications.data.model.NotificationsUpdateResponse
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.PATCH
+import retrofit2.http.POST
 import retrofit2.http.PUT
 import retrofit2.http.Path
 import retrofit2.http.Query
 
 interface NotificationsApi {
-    @GET(APIConstants.NOTIFICATION_COUNT)
+    @GET(APIConstants.NOTIFICATIONS_COUNT)
     suspend fun getUnreadNotificationsCount(): NotificationsCountResponse
 
     @GET(APIConstants.NOTIFICATIONS_INBOX)
@@ -30,4 +34,12 @@ interface NotificationsApi {
     suspend fun markNotificationAsRead(
         @Body markNotification: MarkNotificationReadBody,
     ): NotificationsMarkResponse
+
+    @GET(APIConstants.NOTIFICATIONS_CONFIGURATION)
+    suspend fun fetchNotificationsConfiguration(): NotificationsConfiguration
+
+    @POST(APIConstants.NOTIFICATION_UPDATE_CONFIGURATION)
+    suspend fun updateNotificationsConfiguration(
+        @Body notificationsUpdateBody: NotificationsUpdateBody,
+    ): NotificationsUpdateResponse
 }

--- a/notifications/src/main/java/org/openedx/notifications/data/model/NotificationsConfiguration.kt
+++ b/notifications/src/main/java/org/openedx/notifications/data/model/NotificationsConfiguration.kt
@@ -1,0 +1,35 @@
+package org.openedx.notifications.data.model
+
+import com.google.gson.annotations.SerializedName
+import org.openedx.notifications.domain.model.NotificationsConfiguration
+
+data class NotificationsConfiguration(
+    @SerializedName("status") val status: String,
+    @SerializedName("message") val message: String,
+    @SerializedName("data") val data: NotificationData,
+) {
+    fun mapToDomain(): NotificationsConfiguration {
+        return NotificationsConfiguration(
+            discussionsPushEnabled = data.discussion
+                .notificationTypes[CORE_NOTIFICATION_TYPE]?.push ?: false
+        )
+    }
+
+    companion object {
+        const val CORE_NOTIFICATION_TYPE = "core"
+    }
+}
+
+data class NotificationData(
+    @SerializedName("discussion") val discussion: NotificationCategory,
+)
+
+data class NotificationCategory(
+    @SerializedName("enabled") val enabled: Boolean,
+    @SerializedName("notification_types") val notificationTypes: Map<String, NotificationType>,
+    @SerializedName("core_notification_types") val coreNotificationTypes: List<String>,
+)
+
+data class NotificationType(
+    @SerializedName("push") val push: Boolean,
+)

--- a/notifications/src/main/java/org/openedx/notifications/data/model/NotificationsUpdateBody.kt
+++ b/notifications/src/main/java/org/openedx/notifications/data/model/NotificationsUpdateBody.kt
@@ -1,0 +1,33 @@
+package org.openedx.notifications.data.model
+
+import com.google.gson.annotations.SerializedName
+import org.openedx.notifications.domain.model.NotificationsUpdateResponse
+
+data class NotificationsUpdateBody(
+    @SerializedName("notification_app") val notificationApp: String,
+    @SerializedName("notification_type") val notificationType: String,
+    @SerializedName("notification_channel") val notificationChannel: String,
+    @SerializedName("value") val value: Boolean,
+)
+
+data class NotificationsUpdateResponse(
+    @SerializedName("status") val status: String,
+    @SerializedName("data") val data: NotificationUpdateData,
+) {
+    fun mapToDomain(): NotificationsUpdateResponse {
+        return NotificationsUpdateResponse(
+            status = status,
+            updatedValue = data.updatedValue,
+            notificationType = data.notificationType,
+            channel = data.channel,
+            app = data.app
+        )
+    }
+}
+
+data class NotificationUpdateData(
+    @SerializedName("updated_value") val updatedValue: Boolean,
+    @SerializedName("notification_type") val notificationType: String,
+    @SerializedName("channel") val channel: String,
+    @SerializedName("app") val app: String,
+)

--- a/notifications/src/main/java/org/openedx/notifications/data/repository/NotificationsRepository.kt
+++ b/notifications/src/main/java/org/openedx/notifications/data/repository/NotificationsRepository.kt
@@ -4,10 +4,15 @@ import org.openedx.core.extension.isNotNull
 import org.openedx.notifications.data.api.APIConstants
 import org.openedx.notifications.data.api.NotificationsApi
 import org.openedx.notifications.data.model.MarkNotificationReadBody
+import org.openedx.notifications.data.model.NotificationsUpdateBody
 import org.openedx.notifications.domain.model.InboxNotifications
+import org.openedx.notifications.domain.model.NotificationsConfiguration
 import org.openedx.notifications.domain.model.NotificationsCount
+import org.openedx.notifications.domain.model.NotificationsUpdateResponse
 
-class NotificationsRepository(private val api: NotificationsApi) {
+class NotificationsRepository(
+    private val api: NotificationsApi,
+) {
     suspend fun getUnreadNotificationsCount(): NotificationsCount {
         return api.getUnreadNotificationsCount().mapToDomain()
     }
@@ -31,5 +36,22 @@ class NotificationsRepository(private val api: NotificationsApi) {
                 notificationId = notificationId,
             )
         ).message.isNotNull()
+    }
+
+    suspend fun fetchNotificationsConfiguration(): NotificationsConfiguration {
+        return api.fetchNotificationsConfiguration().mapToDomain()
+    }
+
+    suspend fun updateNotificationsConfiguration(
+        isDiscussionPushEnabled: Boolean,
+    ): NotificationsUpdateResponse {
+        return api.updateNotificationsConfiguration(
+            NotificationsUpdateBody(
+                notificationApp = APIConstants.APP_NAME_DISCUSSION,
+                notificationType = APIConstants.NOTIFICATION_TYPE,
+                notificationChannel = APIConstants.NOTIFICATION_CHANNEL,
+                value = isDiscussionPushEnabled,
+            )
+        ).mapToDomain()
     }
 }

--- a/notifications/src/main/java/org/openedx/notifications/data/storage/NotificationsPreferences.kt
+++ b/notifications/src/main/java/org/openedx/notifications/data/storage/NotificationsPreferences.kt
@@ -1,2 +1,7 @@
 package org.openedx.notifications.data.storage
 
+import org.openedx.notifications.domain.model.NotificationsConfiguration
+
+interface NotificationsPreferences {
+    var notifications: NotificationsConfiguration
+}

--- a/notifications/src/main/java/org/openedx/notifications/domain/interactor/NotificationsInteractor.kt
+++ b/notifications/src/main/java/org/openedx/notifications/domain/interactor/NotificationsInteractor.kt
@@ -2,10 +2,13 @@ package org.openedx.notifications.domain.interactor
 
 import org.openedx.notifications.data.repository.NotificationsRepository
 import org.openedx.notifications.domain.model.InboxNotifications
+import org.openedx.notifications.domain.model.NotificationsConfiguration
 import org.openedx.notifications.domain.model.NotificationsCount
+import org.openedx.notifications.domain.model.NotificationsUpdateResponse
 
-class NotificationsInteractor(private val repository: NotificationsRepository) {
-
+class NotificationsInteractor(
+    private val repository: NotificationsRepository,
+) {
     suspend fun getUnreadNotificationsCount(): NotificationsCount {
         return repository.getUnreadNotificationsCount()
     }
@@ -20,5 +23,17 @@ class NotificationsInteractor(private val repository: NotificationsRepository) {
 
     suspend fun markNotificationAsRead(notificationId: Int): Boolean {
         return repository.markNotificationAsRead(notificationId = notificationId)
+    }
+
+    suspend fun fetchNotificationsConfiguration(): NotificationsConfiguration {
+        return repository.fetchNotificationsConfiguration()
+    }
+
+    suspend fun updateNotificationsConfiguration(
+        isDiscussionPushEnabled: Boolean,
+    ): NotificationsUpdateResponse {
+        return repository.updateNotificationsConfiguration(
+            isDiscussionPushEnabled = isDiscussionPushEnabled,
+        )
     }
 }

--- a/notifications/src/main/java/org/openedx/notifications/domain/model/NotificationsConfiguration.kt
+++ b/notifications/src/main/java/org/openedx/notifications/domain/model/NotificationsConfiguration.kt
@@ -1,0 +1,11 @@
+package org.openedx.notifications.domain.model
+
+data class NotificationsConfiguration(
+    val discussionsPushEnabled: Boolean,
+) {
+    companion object {
+        val default = NotificationsConfiguration(
+            discussionsPushEnabled = false,
+        )
+    }
+}

--- a/notifications/src/main/java/org/openedx/notifications/domain/model/NotificationsSettings.kt
+++ b/notifications/src/main/java/org/openedx/notifications/domain/model/NotificationsSettings.kt
@@ -1,2 +1,0 @@
-package org.openedx.notifications.domain.model
-

--- a/notifications/src/main/java/org/openedx/notifications/domain/model/NotificationsUpdateResponse.kt
+++ b/notifications/src/main/java/org/openedx/notifications/domain/model/NotificationsUpdateResponse.kt
@@ -1,0 +1,9 @@
+package org.openedx.notifications.domain.model
+
+data class NotificationsUpdateResponse(
+    val status: String,
+    val updatedValue: Boolean,
+    val notificationType: String,
+    val channel: String,
+    val app: String,
+)

--- a/notifications/src/main/java/org/openedx/notifications/presentation/NotificationsAnalytics.kt
+++ b/notifications/src/main/java/org/openedx/notifications/presentation/NotificationsAnalytics.kt
@@ -1,2 +1,20 @@
 package org.openedx.notifications.presentation
 
+interface NotificationsAnalytics {
+    fun logEvent(event: String, params: Map<String, Any?>)
+    fun logScreenEvent(screenName: String, params: Map<String, Any?>)
+}
+
+enum class NotificationsAnalyticsEvent(val eventName: String, val biValue: String) {
+    DISCUSSION_PERMISSION_TOGGLE(
+        eventName = "Notification:Discussion Permission Toggle",
+        biValue = "edx.bi.app.notification.discussion.permission.toggle"
+    )
+}
+
+enum class NotificationsAnalyticsKey(val key: String) {
+    NAME("name"),
+    ACTION("action"),
+    CATEGORY("category"),
+    NOTIFICATIONS("notifications"),
+}

--- a/notifications/src/main/java/org/openedx/notifications/presentation/NotificationsSettingsFragment.kt
+++ b/notifications/src/main/java/org/openedx/notifications/presentation/NotificationsSettingsFragment.kt
@@ -1,2 +1,0 @@
-package org.openedx.notifications.presentation
-

--- a/notifications/src/main/java/org/openedx/notifications/presentation/NotificationsSettingsViewModel.kt
+++ b/notifications/src/main/java/org/openedx/notifications/presentation/NotificationsSettingsViewModel.kt
@@ -1,2 +1,0 @@
-package org.openedx.notifications.presentation
-

--- a/notifications/src/main/java/org/openedx/notifications/presentation/settings/NotificationsSettingsFragment.kt
+++ b/notifications/src/main/java/org/openedx/notifications/presentation/settings/NotificationsSettingsFragment.kt
@@ -1,0 +1,232 @@
+package org.openedx.notifications.presentation.settings
+
+import android.content.res.Configuration.UI_MODE_NIGHT_NO
+import android.content.res.Configuration.UI_MODE_NIGHT_YES
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.material.Divider
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Switch
+import androidx.compose.material.SwitchDefaults
+import androidx.compose.material.Text
+import androidx.compose.material.rememberScaffoldState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTagsAsResourceId
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.fragment.app.Fragment
+import org.koin.androidx.viewmodel.ext.android.viewModel
+import org.openedx.core.ui.Toolbar
+import org.openedx.core.ui.WindowSize
+import org.openedx.core.ui.WindowType
+import org.openedx.core.ui.displayCutoutForLandscape
+import org.openedx.core.ui.noRippleClickable
+import org.openedx.core.ui.rememberWindowSize
+import org.openedx.core.ui.settingsHeaderBackground
+import org.openedx.core.ui.statusBarsInset
+import org.openedx.core.ui.theme.OpenEdXTheme
+import org.openedx.core.ui.theme.appColors
+import org.openedx.core.ui.theme.appShapes
+import org.openedx.core.ui.theme.appTypography
+import org.openedx.core.ui.windowSizeValue
+import org.openedx.notifications.R
+import org.openedx.notifications.domain.model.NotificationsConfiguration
+
+class NotificationsSettingsFragment : Fragment() {
+
+    private val viewModel by viewModel<NotificationsSettingsViewModel>()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ) = ComposeView(requireContext()).apply {
+        setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+        setContent {
+            OpenEdXTheme {
+                val windowSize = rememberWindowSize()
+
+                val notificationsConfiguration by viewModel.notificationsConfiguration.collectAsState()
+
+                NotificationsSettingsScreen(
+                    windowSize = windowSize,
+                    notificationsConfiguration = notificationsConfiguration,
+                    onBackClick = {
+                        requireActivity().supportFragmentManager.popBackStack()
+                    },
+                    discussionPreferenceChanged = {
+                        viewModel.setDiscussionNotificationPreference(it)
+                    },
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalComposeUiApi::class)
+@Composable
+private fun NotificationsSettingsScreen(
+    windowSize: WindowSize,
+    notificationsConfiguration: NotificationsConfiguration,
+    discussionPreferenceChanged: (Boolean) -> Unit,
+    onBackClick: () -> Unit,
+) {
+    val scaffoldState = rememberScaffoldState()
+
+    Scaffold(
+        modifier = Modifier
+            .fillMaxSize()
+            .semantics {
+                testTagsAsResourceId = true
+            },
+        scaffoldState = scaffoldState
+    ) { paddingValues ->
+
+        val contentWidth by remember(key1 = windowSize) {
+            mutableStateOf(
+                windowSize.windowSizeValue(
+                    expanded = Modifier.widthIn(Dp.Unspecified, 420.dp),
+                    compact = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 24.dp, vertical = 16.dp)
+                )
+            )
+        }
+
+        val topBarWidth by remember(key1 = windowSize) {
+            mutableStateOf(
+                windowSize.windowSizeValue(
+                    expanded = Modifier.widthIn(Dp.Unspecified, 560.dp),
+                    compact = Modifier
+                        .fillMaxWidth()
+                )
+            )
+        }
+
+        Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.TopCenter
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues)
+                    .settingsHeaderBackground()
+                    .statusBarsInset(),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Toolbar(
+                    modifier = topBarWidth
+                        .displayCutoutForLandscape(),
+                    label = stringResource(id = R.string.notification_push_notifications),
+                    canShowBackBtn = true,
+                    labelTint = MaterialTheme.appColors.settingsTitleContent,
+                    iconTint = MaterialTheme.appColors.settingsTitleContent,
+                    onBackClick = onBackClick
+                )
+
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .clip(MaterialTheme.appShapes.screenBackgroundShape)
+                        .background(MaterialTheme.appColors.background)
+                        .displayCutoutForLandscape(),
+                    contentAlignment = Alignment.TopCenter
+                ) {
+                    Column(
+                        modifier = contentWidth
+                    ) {
+                        Row(
+                            Modifier
+                                .testTag("btn_discussions_activity")
+                                .fillMaxWidth()
+                                .padding(vertical = 16.dp)
+                                .noRippleClickable {
+                                    discussionPreferenceChanged(
+                                        notificationsConfiguration.discussionsPushEnabled.not()
+                                    )
+                                },
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Column(Modifier.weight(1f)) {
+                                Text(
+                                    modifier = Modifier.testTag("txt_discussions_activity_label"),
+                                    text = stringResource(id = R.string.notification_discussions_activity),
+                                    color = MaterialTheme.appColors.textPrimary,
+                                    style = MaterialTheme.appTypography.titleMedium
+                                )
+                                Spacer(Modifier.height(4.dp))
+                                Text(
+                                    modifier = Modifier.testTag("txt_discussions_activity_description"),
+                                    text = stringResource(id = R.string.notification_discussions_activity_description),
+                                    color = MaterialTheme.appColors.textSecondary,
+                                    style = MaterialTheme.appTypography.labelMedium
+                                )
+                            }
+                            Switch(
+                                modifier = Modifier.testTag("sw_discussions_activity"),
+                                checked = notificationsConfiguration.discussionsPushEnabled,
+                                onCheckedChange = {
+                                    discussionPreferenceChanged(
+                                        notificationsConfiguration.discussionsPushEnabled.not()
+                                    )
+                                },
+                                colors = SwitchDefaults.colors(
+                                    checkedThumbColor = MaterialTheme.appColors.primary,
+                                    checkedTrackColor = MaterialTheme.appColors.primary,
+                                    uncheckedThumbColor = MaterialTheme.appColors.cardViewBorder,
+                                    uncheckedTrackColor = MaterialTheme.appColors.cardViewBorder,
+                                )
+                            )
+                        }
+                        Divider()
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Preview(uiMode = UI_MODE_NIGHT_NO)
+@Preview(uiMode = UI_MODE_NIGHT_YES)
+@Composable
+private fun NotificationsSettingsScreenPreview() {
+    OpenEdXTheme {
+        NotificationsSettingsScreen(
+            windowSize = WindowSize(WindowType.Compact, WindowType.Compact),
+            discussionPreferenceChanged = {},
+            onBackClick = {},
+            notificationsConfiguration = NotificationsConfiguration(
+                discussionsPushEnabled = false,
+            )
+        )
+    }
+}

--- a/notifications/src/main/java/org/openedx/notifications/presentation/settings/NotificationsSettingsViewModel.kt
+++ b/notifications/src/main/java/org/openedx/notifications/presentation/settings/NotificationsSettingsViewModel.kt
@@ -1,0 +1,75 @@
+package org.openedx.notifications.presentation.settings
+
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import org.openedx.core.BaseViewModel
+import org.openedx.notifications.data.storage.NotificationsPreferences
+import org.openedx.notifications.domain.interactor.NotificationsInteractor
+import org.openedx.notifications.domain.model.NotificationsConfiguration
+import org.openedx.notifications.presentation.NotificationsAnalytics
+import org.openedx.notifications.presentation.NotificationsAnalyticsEvent
+import org.openedx.notifications.presentation.NotificationsAnalyticsKey
+
+class NotificationsSettingsViewModel(
+    private val interactor: NotificationsInteractor,
+    private val analytics: NotificationsAnalytics,
+    private val preference: NotificationsPreferences,
+) : BaseViewModel() {
+
+    private val _notificationsConfiguration = MutableStateFlow(preference.notifications)
+    val notificationsConfiguration: StateFlow<NotificationsConfiguration>
+        get() = _notificationsConfiguration
+
+    init {
+        viewModelScope.launch {
+            fetchAndUpdateNotificationsSettings()
+        }
+    }
+
+    fun setDiscussionNotificationPreference(value: Boolean) {
+        viewModelScope.launch {
+            try {
+                val response = interactor.updateNotificationsConfiguration(value)
+                updateDiscussionPreference(updatedValue = response.updatedValue)
+
+                logDiscussionPermissionToggleEvent(isDiscussionPushEnabled = value)
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
+        }
+    }
+
+    private suspend fun fetchAndUpdateNotificationsSettings() {
+        try {
+            val response = interactor.fetchNotificationsConfiguration()
+            updateDiscussionPreference(updatedValue = response.discussionsPushEnabled)
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+    }
+
+    private fun updateDiscussionPreference(updatedValue: Boolean) {
+        _notificationsConfiguration.update { it.copy(discussionsPushEnabled = updatedValue) }
+        preference.notifications = _notificationsConfiguration.value
+    }
+
+    private fun logDiscussionPermissionToggleEvent(
+        isDiscussionPushEnabled: Boolean,
+    ) {
+        val event = NotificationsAnalyticsEvent.DISCUSSION_PERMISSION_TOGGLE
+        analytics.logEvent(
+            event = event.eventName,
+            params = buildMap {
+                put(NotificationsAnalyticsKey.NAME.key, event.biValue)
+                put(NotificationsAnalyticsKey.ACTION.key, isDiscussionPushEnabled)
+                put(
+                    NotificationsAnalyticsKey.CATEGORY.key,
+                    NotificationsAnalyticsKey.NOTIFICATIONS.key
+                )
+            }
+        )
+    }
+}

--- a/notifications/src/main/res/values/strings.xml
+++ b/notifications/src/main/res/values/strings.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="notifications_notifications">Notifications</string>
     <string name="notifications_accessibility_settings">Settings</string>
@@ -31,4 +32,7 @@
         <item quantity="one">%1$s month</item>
         <item quantity="other">%1$s months</item>
     </plurals>
+    <string name="notification_push_notifications">Push Notifications</string>
+    <string name="notification_discussions_activity">Discussions Activity</string>
+    <string name="notification_discussions_activity_description">Notifications for course discussions you post, comment, or follow.</string>
 </resources>

--- a/profile/src/main/java/org/openedx/profile/domain/model/Configuration.kt
+++ b/profile/src/main/java/org/openedx/profile/domain/model/Configuration.kt
@@ -9,6 +9,7 @@ import org.openedx.core.domain.model.AgreementUrls
  * @param feedbackFormUrl URL of the learner feedback form
  * @param supportEmail Email address of support
  * @param versionName Version of the application (1.0.0)
+ * @param isPushNotificationsEnabled Push Notifications is enabled or not
  */
 data class Configuration(
     val isIAPEnabled: Boolean,
@@ -17,4 +18,5 @@ data class Configuration(
     val feedbackFormUrl: String,
     val supportEmail: String,
     val versionName: String,
+    val isPushNotificationsEnabled: Boolean,
 )

--- a/profile/src/main/java/org/openedx/profile/presentation/ProfileAnalytics.kt
+++ b/profile/src/main/java/org/openedx/profile/presentation/ProfileAnalytics.kt
@@ -26,6 +26,10 @@ enum class ProfileAnalyticsEvent(val eventName: String, val biValue: String) {
         "Profile:Video Setting Clicked",
         "edx.bi.app.profile.video_setting.clicked"
     ),
+    PUSH_NOTIFICATIONS_CLICKED(
+        "Profile:Push Notifications Setting Clicked",
+        "edx.bi.app.profile.push_notifications_setting.clicked"
+    ),
     CONTACT_SUPPORT_CLICKED(
         "Profile:Contact Support Clicked",
         "edx.bi.app.profile.email_support.clicked"

--- a/profile/src/main/java/org/openedx/profile/presentation/ProfileRouter.kt
+++ b/profile/src/main/java/org/openedx/profile/presentation/ProfileRouter.kt
@@ -16,6 +16,8 @@ interface ProfileRouter {
 
     fun navigateToVideoSettings(fm: FragmentManager)
 
+    fun navigateToPushNotificationsSettings(fm: FragmentManager)
+
     fun navigateToVideoQuality(fm: FragmentManager, videoQualityType: VideoQualityType)
 
     fun navigateToWebContent(fm: FragmentManager, title: String, url: String)

--- a/profile/src/main/java/org/openedx/profile/presentation/settings/SettingsFragment.kt
+++ b/profile/src/main/java/org/openedx/profile/presentation/settings/SettingsFragment.kt
@@ -89,6 +89,12 @@ class SettingsFragment : Fragment() {
                                 )
                             }
 
+                            SettingsScreenAction.PushNotificationsSettingsClick -> {
+                                viewModel.pushNotificationsSettingsClicked(
+                                    requireActivity().supportFragmentManager
+                                )
+                            }
+
                             SettingsScreenAction.ManageAccountClick -> {
                                 viewModel.manageAccountClicked(
                                     requireActivity().supportFragmentManager
@@ -165,6 +171,7 @@ internal interface SettingsScreenAction {
     object VideoSettingsClick : SettingsScreenAction
     object ManageAccountClick : SettingsScreenAction
     object CalendarSettingsClick : SettingsScreenAction
+    object PushNotificationsSettingsClick : SettingsScreenAction
     object RestorePurchaseClick : SettingsScreenAction
     object FeedbackFormClick : SettingsScreenAction
 }

--- a/profile/src/main/java/org/openedx/profile/presentation/settings/SettingsScreenUI.kt
+++ b/profile/src/main/java/org/openedx/profile/presentation/settings/SettingsScreenUI.kt
@@ -186,11 +186,15 @@ internal fun SettingsScreen(
                                     Spacer(modifier = Modifier.height(24.dp))
 
                                     SettingsSection(
+                                        uiState = uiState,
                                         onVideoSettingsClick = {
                                             onAction(SettingsScreenAction.VideoSettingsClick)
                                         },
                                         onCalendarSettingsClick = {
                                             onAction(SettingsScreenAction.CalendarSettingsClick)
+                                        },
+                                        onPushNotificationsSettingsClick = {
+                                            onAction(SettingsScreenAction.PushNotificationsSettingsClick)
                                         }
                                     )
 
@@ -267,8 +271,10 @@ internal fun SettingsScreen(
 
 @Composable
 private fun SettingsSection(
+    uiState: SettingsUIState.Data,
     onVideoSettingsClick: () -> Unit,
-    onCalendarSettingsClick: () -> Unit
+    onCalendarSettingsClick: () -> Unit,
+    onPushNotificationsSettingsClick: () -> Unit,
 ) {
     Column {
         Text(
@@ -289,11 +295,20 @@ private fun SettingsSection(
                     text = stringResource(id = profileR.string.profile_video),
                     onClick = onVideoSettingsClick
                 )
+
 //                SettingsDivider()
 //                SettingsItem(
 //                    text = stringResource(id = profileR.string.profile_dates_and_calendar),
 //                    onClick = onCalendarSettingsClick
 //                )
+
+                if (uiState.configuration.isPushNotificationsEnabled) {
+                    SettingsDivider()
+                    SettingsItem(
+                        text = stringResource(id = profileR.string.profile_push_notifications),
+                        onClick = onPushNotificationsSettingsClick
+                    )
+                }
             }
         }
     }
@@ -729,6 +744,7 @@ private val mockConfiguration = Configuration(
     feedbackFormUrl = "www.feedback.com",
     versionName = mockAppData.versionName,
     isIAPEnabled = true,
+    isPushNotificationsEnabled = true,
 )
 
 private val mockUiState = SettingsUIState.Data(

--- a/profile/src/main/java/org/openedx/profile/presentation/settings/SettingsViewModel.kt
+++ b/profile/src/main/java/org/openedx/profile/presentation/settings/SettingsViewModel.kt
@@ -93,6 +93,7 @@ class SettingsViewModel(
             feedbackFormUrl = corePreferences.appConfig.feedbackFormUrl,
             supportEmail = config.getFeedbackEmailAddress(),
             versionName = appData.versionName,
+            isPushNotificationsEnabled = config.isPushNotificationsEnabled()
         )
 
     init {
@@ -151,6 +152,11 @@ class SettingsViewModel(
     fun videoSettingsClicked(fragmentManager: FragmentManager) {
         router.navigateToVideoSettings(fragmentManager)
         logProfileEvent(ProfileAnalyticsEvent.VIDEO_SETTING_CLICKED)
+    }
+
+    fun pushNotificationsSettingsClicked(fragmentManager: FragmentManager) {
+        router.navigateToPushNotificationsSettings(fragmentManager)
+        logProfileEvent((ProfileAnalyticsEvent.PUSH_NOTIFICATIONS_CLICKED))
     }
 
     fun privacyPolicyClicked(fragmentManager: FragmentManager) {

--- a/profile/src/main/res/values/strings.xml
+++ b/profile/src/main/res/values/strings.xml
@@ -63,5 +63,5 @@
     <string name="profile_color">Color</string>
     <string name="profile_purchases">Purchases</string>
     <string name="profile_restore_purchaes">Restore Purchases</string>
-
+    <string name="profile_push_notifications">Push Notifications</string>
 </resources>


### PR DESCRIPTION
### Description

[LEARNER-10345](https://2u-internal.atlassian.net/browse/LEARNER-10345)

Add Push Notification settings to the profile, allowing users to manage permissions for discussion notifications.

### Screenshots

| Settings Screen | Push Notifications Screen |
|--------|--------|
|<img height=800 src="https://github.com/user-attachments/assets/2de03cd0-20ff-4718-a248-b535ac8381f1"/>|<img height=800 src="https://github.com/user-attachments/assets/ad5e6d4c-f9f7-4e9a-8aff-526d9f01f8b5"/>| 

### Config

PR: https://github.com/edx/edx-mobile-config/pull/188