### PR TITLE
feat: Notifications Inbox Screen

### DIFF
--- a/app/src/main/java/org/openedx/app/AppRouter.kt
+++ b/app/src/main/java/org/openedx/app/AppRouter.kt
@@ -42,6 +42,7 @@ import org.openedx.discussion.presentation.responses.DiscussionResponsesFragment
 import org.openedx.discussion.presentation.search.DiscussionSearchThreadFragment
 import org.openedx.discussion.presentation.threads.DiscussionAddThreadFragment
 import org.openedx.discussion.presentation.threads.DiscussionThreadsFragment
+import org.openedx.notifications.presentation.inbox.NotificationsInboxFragment
 import org.openedx.profile.domain.model.Account
 import org.openedx.profile.presentation.ProfileRouter
 import org.openedx.profile.presentation.anothersaccount.AnothersProfileFragment
@@ -147,6 +148,10 @@ class AppRouter : AuthRouter, DiscoveryRouter, DashboardRouter, CourseRouter, Di
 
     override fun getProgramFragment(): Fragment {
         return ProgramFragment.newInstance(isNestedFragment = true)
+    }
+
+    override fun navigateToNotificationsInbox(fm: FragmentManager) {
+        replaceFragmentWithBackStack(fm, NotificationsInboxFragment())
     }
 
     override fun navigateToCourseInfo(

--- a/app/src/main/java/org/openedx/app/di/ScreenModule.kt
+++ b/app/src/main/java/org/openedx/app/di/ScreenModule.kt
@@ -60,6 +60,7 @@ import org.openedx.discussion.presentation.topics.DiscussionTopicsViewModel
 import org.openedx.learn.presentation.LearnViewModel
 import org.openedx.notifications.data.repository.NotificationsRepository
 import org.openedx.notifications.domain.interactor.NotificationsInteractor
+import org.openedx.notifications.presentation.inbox.NotificationsInboxViewModel
 import org.openedx.profile.data.repository.ProfileRepository
 import org.openedx.profile.domain.interactor.ProfileInteractor
 import org.openedx.profile.domain.model.Account
@@ -484,6 +485,8 @@ val screenModule = module {
 
     single { NotificationsRepository(get()) }
     factory { NotificationsInteractor(get()) }
+
+    viewModel { NotificationsInboxViewModel(get()) }
 
     single { IAPRepository(get()) }
     factory { IAPInteractor(get(), get(), get(), get(), get()) }

--- a/core/src/edx/org/openedx/core/ui/theme/Colors.kt
+++ b/core/src/edx/org/openedx/core/ui/theme/Colors.kt
@@ -90,7 +90,7 @@ val light_progress_bar_background_color = Color(0xFFE7E4DB)
 val light_primary_card_caution_background = Color(0xFFF3F1ED)
 val light_primary_card_info_background = Color(0xFFE7E4DB)
 
-val light_notification_timestamp = Color(0xFF707070)
+val light_inbox_time_marker_color = Color(0xFF707070)
 
 // Dark theme colors scheme
 val dark_primary = Color(0xFFFBFAF9) // Light 200
@@ -177,4 +177,4 @@ val dark_progress_bar_background_color = Color(0xFF707070)
 val dark_primary_card_caution_background = Color(0xFF2D494E)
 val dark_primary_card_info_background = Color(0xFF0E3639)
 
-val dark_notification_timestamp = Color(0xFFADADAD)
+val dark_inbox_time_marker_color = Color(0xFFADADAD)

--- a/core/src/edx/org/openedx/core/ui/theme/Colors.kt
+++ b/core/src/edx/org/openedx/core/ui/theme/Colors.kt
@@ -90,6 +90,7 @@ val light_progress_bar_background_color = Color(0xFFE7E4DB)
 val light_primary_card_caution_background = Color(0xFFF3F1ED)
 val light_primary_card_info_background = Color(0xFFE7E4DB)
 
+val light_notification_timestamp = Color(0xFF707070)
 
 // Dark theme colors scheme
 val dark_primary = Color(0xFFFBFAF9) // Light 200
@@ -175,3 +176,5 @@ val dark_progress_bar_background_color = Color(0xFF707070)
 
 val dark_primary_card_caution_background = Color(0xFF2D494E)
 val dark_primary_card_info_background = Color(0xFF0E3639)
+
+val dark_notification_timestamp = Color(0xFFADADAD)

--- a/core/src/main/java/org/openedx/core/ui/theme/AppColors.kt
+++ b/core/src/main/java/org/openedx/core/ui/theme/AppColors.kt
@@ -84,7 +84,7 @@ data class AppColors(
     val primaryCardCautionBackground: Color,
     val primaryCardInfoBackground: Color,
 
-    val notificationTimestamp: Color,
+    val inboxTimeMarkerColor: Color,
 ) {
     val primary: Color get() = material.primary
     val primaryVariant: Color get() = material.primaryVariant

--- a/core/src/main/java/org/openedx/core/ui/theme/AppColors.kt
+++ b/core/src/main/java/org/openedx/core/ui/theme/AppColors.kt
@@ -83,6 +83,8 @@ data class AppColors(
 
     val primaryCardCautionBackground: Color,
     val primaryCardInfoBackground: Color,
+
+    val notificationTimestamp: Color,
 ) {
     val primary: Color get() = material.primary
     val primaryVariant: Color get() = material.primaryVariant

--- a/core/src/main/java/org/openedx/core/ui/theme/Theme.kt
+++ b/core/src/main/java/org/openedx/core/ui/theme/Theme.kt
@@ -101,6 +101,8 @@ private val DarkColorPalette = AppColors(
 
     primaryCardCautionBackground = dark_primary_card_caution_background,
     primaryCardInfoBackground = dark_primary_card_info_background,
+
+    notificationTimestamp = dark_notification_timestamp,
 )
 
 private val LightColorPalette = AppColors(
@@ -194,6 +196,8 @@ private val LightColorPalette = AppColors(
 
     primaryCardCautionBackground = light_primary_card_caution_background,
     primaryCardInfoBackground = light_primary_card_info_background,
+
+    notificationTimestamp = light_notification_timestamp,
 )
 
 val MaterialTheme.appColors: AppColors

--- a/core/src/main/java/org/openedx/core/ui/theme/Theme.kt
+++ b/core/src/main/java/org/openedx/core/ui/theme/Theme.kt
@@ -102,7 +102,7 @@ private val DarkColorPalette = AppColors(
     primaryCardCautionBackground = dark_primary_card_caution_background,
     primaryCardInfoBackground = dark_primary_card_info_background,
 
-    notificationTimestamp = dark_notification_timestamp,
+    inboxTimeMarkerColor = dark_inbox_time_marker_color,
 )
 
 private val LightColorPalette = AppColors(
@@ -197,7 +197,7 @@ private val LightColorPalette = AppColors(
     primaryCardCautionBackground = light_primary_card_caution_background,
     primaryCardInfoBackground = light_primary_card_info_background,
 
-    notificationTimestamp = light_notification_timestamp,
+    inboxTimeMarkerColor = light_inbox_time_marker_color,
 )
 
 val MaterialTheme.appColors: AppColors

--- a/core/src/openedx/org/openedx/core/ui/theme/Colors.kt
+++ b/core/src/openedx/org/openedx/core/ui/theme/Colors.kt
@@ -77,7 +77,7 @@ val light_progress_bar_background_color = Color(0xFF97A5BB)
 val light_primary_card_caution_background = Color(0xFFF3F1ED)
 val light_primary_card_info_background = Color(0xFFE7E4DB)
 val light_social_auth_divider = light_divider
-val light_notification_timestamp = Color(0xFF707070)
+val light_inbox_time_marker_color = Color(0xFF707070)
 
 
 val dark_primary = Color(0xFF3F68F8)
@@ -155,4 +155,4 @@ val dark_progress_bar_background_color = Color(0xFF8E9BAE)
 val dark_primary_card_caution_background = Color(0xFF2D494E)
 val dark_primary_card_info_background = Color(0xFF0E3639)
 val dark_social_auth_divider = dark_divider
-val dark_notification_timestamp = Color(0xFFADADAD)
+val dark_inbox_time_marker_color = Color(0xFFADADAD)

--- a/core/src/openedx/org/openedx/core/ui/theme/Colors.kt
+++ b/core/src/openedx/org/openedx/core/ui/theme/Colors.kt
@@ -77,6 +77,7 @@ val light_progress_bar_background_color = Color(0xFF97A5BB)
 val light_primary_card_caution_background = Color(0xFFF3F1ED)
 val light_primary_card_info_background = Color(0xFFE7E4DB)
 val light_social_auth_divider = light_divider
+val light_notification_timestamp = Color(0xFF707070)
 
 
 val dark_primary = Color(0xFF3F68F8)
@@ -154,3 +155,4 @@ val dark_progress_bar_background_color = Color(0xFF8E9BAE)
 val dark_primary_card_caution_background = Color(0xFF2D494E)
 val dark_primary_card_info_background = Color(0xFF0E3639)
 val dark_social_auth_divider = dark_divider
+val dark_notification_timestamp = Color(0xFFADADAD)

--- a/dashboard/src/main/java/org/openedx/dashboard/presentation/DashboardRouter.kt
+++ b/dashboard/src/main/java/org/openedx/dashboard/presentation/DashboardRouter.kt
@@ -16,4 +16,6 @@ interface DashboardRouter {
     fun navigateToAllEnrolledCourses(fm: FragmentManager)
 
     fun getProgramFragment(): Fragment
+
+    fun navigateToNotificationsInbox(fm: FragmentManager)
 }

--- a/dashboard/src/main/java/org/openedx/learn/presentation/LearnFragment.kt
+++ b/dashboard/src/main/java/org/openedx/learn/presentation/LearnFragment.kt
@@ -81,7 +81,7 @@ class LearnFragment : Fragment(R.layout.fragment_learn) {
                         viewModel.updateLearnType(learnType)
                     },
                     onNotificationBadgeClick = {
-                        viewModel.onNotificationBadgeClick()
+                        viewModel.onNotificationBadgeClick(requireActivity().supportFragmentManager)
                     }
                 )
             }

--- a/dashboard/src/main/java/org/openedx/learn/presentation/LearnViewModel.kt
+++ b/dashboard/src/main/java/org/openedx/learn/presentation/LearnViewModel.kt
@@ -1,5 +1,6 @@
 package org.openedx.learn.presentation
 
+import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -50,20 +51,18 @@ class LearnViewModel(
 
     init {
         viewModelScope.launch {
-            launch {
-                _uiState.collect { uiState ->
-                    if (uiState.learnType == LearnType.COURSES) {
-                        logMyCoursesTabClickedEvent()
-                    } else {
-                        logMyProgramsTabClickedEvent()
-                    }
+            _uiState.collect { uiState ->
+                if (uiState.learnType == LearnType.COURSES) {
+                    logMyCoursesTabClickedEvent()
+                } else {
+                    logMyProgramsTabClickedEvent()
                 }
             }
-            launch {
-                pushNotifier.notifier.collect { event ->
-                    if (event is PushEvent.RefreshBadgeCount) {
-                        checkNotificationCount()
-                    }
+        }
+        viewModelScope.launch {
+            pushNotifier.notifier.collect { event ->
+                if (event is PushEvent.RefreshBadgeCount) {
+                    checkNotificationCount()
                 }
             }
         }
@@ -85,7 +84,8 @@ class LearnViewModel(
         }
     }
 
-    fun onNotificationBadgeClick() {
+    fun onNotificationBadgeClick(fm: FragmentManager) {
+        dashboardRouter.navigateToNotificationsInbox(fm)
         _uiState.update { it.copy(hasUnreadNotifications = false) }
     }
 

--- a/notifications/src/main/java/org/openedx/notifications/data/api/APIConstants.kt
+++ b/notifications/src/main/java/org/openedx/notifications/data/api/APIConstants.kt
@@ -2,4 +2,5 @@ package org.openedx.notifications.data.api
 
 object APIConstants {
     const val NOTIFICATION_COUNT = "/api/notifications/count/"
+    const val NOTIFICATIONS_INBOX = "api/notifications/"
 }

--- a/notifications/src/main/java/org/openedx/notifications/data/api/APIConstants.kt
+++ b/notifications/src/main/java/org/openedx/notifications/data/api/APIConstants.kt
@@ -2,5 +2,7 @@ package org.openedx.notifications.data.api
 
 object APIConstants {
     const val NOTIFICATION_COUNT = "/api/notifications/count/"
-    const val NOTIFICATIONS_INBOX = "api/notifications/"
+    const val NOTIFICATIONS_INBOX = "/api/notifications/"
+
+    const val APP_NAME_DISCUSSION = "discussion"
 }

--- a/notifications/src/main/java/org/openedx/notifications/data/api/NotificationsApi.kt
+++ b/notifications/src/main/java/org/openedx/notifications/data/api/NotificationsApi.kt
@@ -1,9 +1,17 @@
 package org.openedx.notifications.data.api
 
 import org.openedx.notifications.data.model.NotificationsCountResponse
+import org.openedx.notifications.data.model.InboxNotificationsResponse
 import retrofit2.http.GET
+import retrofit2.http.Query
 
 interface NotificationsApi {
     @GET(APIConstants.NOTIFICATION_COUNT)
     suspend fun getUnreadNotificationsCount(): NotificationsCountResponse
+
+    @GET(APIConstants.NOTIFICATIONS_INBOX)
+    suspend fun getInboxNotifications(
+        @Query("app_name") appName: String,
+        @Query("page") page: Int,
+    ): InboxNotificationsResponse
 }

--- a/notifications/src/main/java/org/openedx/notifications/data/api/NotificationsApi.kt
+++ b/notifications/src/main/java/org/openedx/notifications/data/api/NotificationsApi.kt
@@ -1,7 +1,7 @@
 package org.openedx.notifications.data.api
 
-import org.openedx.notifications.data.model.NotificationsCountResponse
 import org.openedx.notifications.data.model.InboxNotificationsResponse
+import org.openedx.notifications.data.model.NotificationsCountResponse
 import retrofit2.http.GET
 import retrofit2.http.Query
 

--- a/notifications/src/main/java/org/openedx/notifications/data/model/InboxNotificationsResponse.kt
+++ b/notifications/src/main/java/org/openedx/notifications/data/model/InboxNotificationsResponse.kt
@@ -5,7 +5,6 @@ import org.openedx.core.utils.TimeUtils
 import org.openedx.notifications.domain.model.InboxNotifications
 import org.openedx.notifications.domain.model.InboxSection
 import org.openedx.notifications.domain.model.Pagination
-import org.openedx.notifications.utils.TextUtils
 import java.util.Date
 import org.openedx.notifications.domain.model.NotificationContent as DomainNotificationContent
 import org.openedx.notifications.domain.model.NotificationItem as DomainNotificationItem
@@ -45,7 +44,7 @@ data class InboxNotificationsResponse(
             },
             InboxSection.THIS_WEEK to notifications.filter {
                 val createdTime = it.created?.time ?: 0L
-                createdTime in (weekThresholdMillis + 1) until recentThresholdMillis
+                createdTime in weekThresholdMillis until recentThresholdMillis
             },
             InboxSection.OLDER to notifications.filter {
                 (it.created?.time ?: 0L) < weekThresholdMillis
@@ -75,7 +74,7 @@ data class NotificationItem(
         appName = appName,
         notificationType = notificationType,
         contentContext = contentContext.mapToDomain(),
-        content = TextUtils.htmlContentToAnnotatedString(content),
+        content = content,
         contentUrl = contentUrl,
         lastRead = TimeUtils.iso8601ToDate(lastRead ?: ""),
         lastSeen = TimeUtils.iso8601ToDate(lastSeen ?: ""),

--- a/notifications/src/main/java/org/openedx/notifications/data/model/InboxNotificationsResponse.kt
+++ b/notifications/src/main/java/org/openedx/notifications/data/model/InboxNotificationsResponse.kt
@@ -1,0 +1,80 @@
+package org.openedx.notifications.data.model
+
+import com.google.gson.annotations.SerializedName
+import org.openedx.notifications.domain.model.InboxNotifications
+import org.openedx.notifications.domain.model.Pagination
+import org.openedx.notifications.domain.model.NotificationContent as DomainNotificationContent
+import org.openedx.notifications.domain.model.NotificationItem as DomainNotificationItem
+
+
+data class InboxNotificationsResponse(
+    @SerializedName("next") val next: String?,
+    @SerializedName("previous") val previous: String?,
+    @SerializedName("count") val count: Int,
+    @SerializedName("num_pages") val numPages: Int,
+    @SerializedName("current_page") val currentPage: Int,
+    @SerializedName("start") val start: Int,
+    @SerializedName("results") val results: List<NotificationItem>,
+) {
+    fun mapToDomain(): InboxNotifications = InboxNotifications(
+        pagination = Pagination(
+            next = next ?: "",
+            previous = previous ?: "",
+            count = count,
+            numPages = numPages,
+            currentPage = currentPage,
+            start = start
+        ),
+        notifications = results.map { it.mapToDomain() }
+    )
+}
+
+data class NotificationItem(
+    @SerializedName("id") val id: Int,
+    @SerializedName("app_name") val appName: String,
+    @SerializedName("notification_type") val notificationType: String,
+    @SerializedName("content_context") val contentContext: NotificationContent,
+    @SerializedName("content") val content: String,
+    @SerializedName("content_url") val contentUrl: String,
+    @SerializedName("last_read") val lastRead: String?,
+    @SerializedName("last_seen") val lastSeen: String?,
+    @SerializedName("created") val created: String,
+) {
+    fun mapToDomain(): DomainNotificationItem = DomainNotificationItem(
+        id = id,
+        appName = appName,
+        notificationType = notificationType,
+        contentContext = contentContext.mapToDomain(),
+        content = content,
+        contentUrl = contentUrl,
+        lastRead = lastRead ?: "",
+        lastSeen = lastSeen ?: "",
+        created = created,
+    )
+}
+
+data class NotificationContent(
+    @SerializedName("p") val paragraph: String,
+    @SerializedName("strong") val strongText: String,
+    @SerializedName("topic_id") val topicId: String,
+    @SerializedName("parent_id") val parentId: String?,
+    @SerializedName("thread_id") val threadId: String,
+    @SerializedName("comment_id") val commentId: String,
+    @SerializedName("post_title") val postTitle: String,
+    @SerializedName("course_name") val courseName: String,
+    @SerializedName("replier_name") val replierName: String,
+    @SerializedName("email_content") val emailContent: String
+) {
+    fun mapToDomain(): DomainNotificationContent = DomainNotificationContent(
+        paragraph = paragraph,
+        strongText = strongText,
+        topicId = topicId,
+        parentId = parentId ?: "",
+        threadId = threadId,
+        commentId = commentId,
+        postTitle = postTitle,
+        courseName = courseName,
+        replierName = replierName,
+        emailContent = emailContent,
+    )
+}

--- a/notifications/src/main/java/org/openedx/notifications/data/model/InboxNotificationsResponse.kt
+++ b/notifications/src/main/java/org/openedx/notifications/data/model/InboxNotificationsResponse.kt
@@ -5,6 +5,7 @@ import org.openedx.core.utils.TimeUtils
 import org.openedx.notifications.domain.model.InboxNotifications
 import org.openedx.notifications.domain.model.InboxSection
 import org.openedx.notifications.domain.model.Pagination
+import org.openedx.notifications.utils.TextUtils
 import java.util.Date
 import org.openedx.notifications.domain.model.NotificationContent as DomainNotificationContent
 import org.openedx.notifications.domain.model.NotificationItem as DomainNotificationItem
@@ -74,7 +75,7 @@ data class NotificationItem(
         appName = appName,
         notificationType = notificationType,
         contentContext = contentContext.mapToDomain(),
-        content = content,
+        content = TextUtils.htmlContentToAnnotatedString(content),
         contentUrl = contentUrl,
         lastRead = TimeUtils.iso8601ToDate(lastRead ?: ""),
         lastSeen = TimeUtils.iso8601ToDate(lastSeen ?: ""),

--- a/notifications/src/main/java/org/openedx/notifications/data/model/InboxNotificationsResponse.kt
+++ b/notifications/src/main/java/org/openedx/notifications/data/model/InboxNotificationsResponse.kt
@@ -93,6 +93,8 @@ data class NotificationContent(
     @SerializedName("course_name") val courseName: String,
     @SerializedName("replier_name") val replierName: String,
     @SerializedName("email_content") val emailContent: String,
+    @SerializedName("author_name") val authorName: String?,
+    @SerializedName("author_pronoun") val authorPronoun: String?,
 ) {
     fun mapToDomain(): DomainNotificationContent = DomainNotificationContent(
         paragraph = paragraph,
@@ -105,5 +107,7 @@ data class NotificationContent(
         courseName = courseName,
         replierName = replierName,
         emailContent = emailContent,
+        authorName = authorName.orEmpty(),
+        authorPronoun = authorPronoun.orEmpty(),
     )
 }

--- a/notifications/src/main/java/org/openedx/notifications/data/model/InboxNotificationsResponse.kt
+++ b/notifications/src/main/java/org/openedx/notifications/data/model/InboxNotificationsResponse.kt
@@ -1,8 +1,11 @@
 package org.openedx.notifications.data.model
 
 import com.google.gson.annotations.SerializedName
+import org.openedx.core.utils.TimeUtils
 import org.openedx.notifications.domain.model.InboxNotifications
+import org.openedx.notifications.domain.model.InboxSection
 import org.openedx.notifications.domain.model.Pagination
+import java.util.Date
 import org.openedx.notifications.domain.model.NotificationContent as DomainNotificationContent
 import org.openedx.notifications.domain.model.NotificationItem as DomainNotificationItem
 
@@ -18,15 +21,41 @@ data class InboxNotificationsResponse(
 ) {
     fun mapToDomain(): InboxNotifications = InboxNotifications(
         pagination = Pagination(
-            next = next ?: "",
-            previous = previous ?: "",
+            next = next.orEmpty(),
+            previous = previous.orEmpty(),
             count = count,
             numPages = numPages,
             currentPage = currentPage,
-            start = start
+            start = start,
         ),
-        notifications = results.map { it.mapToDomain() }
+        notifications = organizeNotificationsBySection()
     )
+
+    private fun organizeNotificationsBySection(): Map<InboxSection, List<DomainNotificationItem>> {
+        val currentDate = Date()
+        val recentThresholdMillis = currentDate.time - DAY_IN_MILLIS
+        val weekThresholdMillis = currentDate.time - WEEK_IN_MILLIS
+
+        val notifications = results.map { it.mapToDomain() }
+
+        return mapOf(
+            InboxSection.RECENT to notifications.filter {
+                (it.created?.time ?: 0L) >= recentThresholdMillis
+            },
+            InboxSection.THIS_WEEK to notifications.filter {
+                val createdTime = it.created?.time ?: 0L
+                createdTime in (weekThresholdMillis + 1) until recentThresholdMillis
+            },
+            InboxSection.OLDER to notifications.filter {
+                (it.created?.time ?: 0L) < weekThresholdMillis
+            }
+        )
+    }
+
+    companion object {
+        private const val DAY_IN_MILLIS = 24 * 60 * 60 * 1000L
+        private const val WEEK_IN_MILLIS = 7 * DAY_IN_MILLIS
+    }
 }
 
 data class NotificationItem(
@@ -47,31 +76,31 @@ data class NotificationItem(
         contentContext = contentContext.mapToDomain(),
         content = content,
         contentUrl = contentUrl,
-        lastRead = lastRead ?: "",
-        lastSeen = lastSeen ?: "",
-        created = created,
+        lastRead = TimeUtils.iso8601ToDate(lastRead ?: ""),
+        lastSeen = TimeUtils.iso8601ToDate(lastSeen ?: ""),
+        created = TimeUtils.iso8601ToDate(created),
     )
 }
 
 data class NotificationContent(
     @SerializedName("p") val paragraph: String,
     @SerializedName("strong") val strongText: String,
-    @SerializedName("topic_id") val topicId: String,
+    @SerializedName("topic_id") val topicId: String?,
     @SerializedName("parent_id") val parentId: String?,
-    @SerializedName("thread_id") val threadId: String,
-    @SerializedName("comment_id") val commentId: String,
+    @SerializedName("thread_id") val threadId: String?,
+    @SerializedName("comment_id") val commentId: String?,
     @SerializedName("post_title") val postTitle: String,
     @SerializedName("course_name") val courseName: String,
     @SerializedName("replier_name") val replierName: String,
-    @SerializedName("email_content") val emailContent: String
+    @SerializedName("email_content") val emailContent: String,
 ) {
     fun mapToDomain(): DomainNotificationContent = DomainNotificationContent(
         paragraph = paragraph,
         strongText = strongText,
-        topicId = topicId,
-        parentId = parentId ?: "",
-        threadId = threadId,
-        commentId = commentId,
+        topicId = topicId.orEmpty(),
+        parentId = parentId.orEmpty(),
+        threadId = threadId.orEmpty(),
+        commentId = commentId.orEmpty(),
         postTitle = postTitle,
         courseName = courseName,
         replierName = replierName,

--- a/notifications/src/main/java/org/openedx/notifications/data/repository/NotificationsRepository.kt
+++ b/notifications/src/main/java/org/openedx/notifications/data/repository/NotificationsRepository.kt
@@ -1,10 +1,18 @@
 package org.openedx.notifications.data.repository
 
 import org.openedx.notifications.data.api.NotificationsApi
+import org.openedx.notifications.domain.model.InboxNotifications
 import org.openedx.notifications.domain.model.NotificationsCount
 
 class NotificationsRepository(private val api: NotificationsApi) {
     suspend fun getUnreadNotificationsCount(): NotificationsCount {
         return api.getUnreadNotificationsCount().mapToDomain()
+    }
+
+    suspend fun getInboxNotifications(page: Int): InboxNotifications {
+        return api.getInboxNotifications(
+            appName = "discussion",
+            page = page
+        ).mapToDomain()
     }
 }

--- a/notifications/src/main/java/org/openedx/notifications/data/repository/NotificationsRepository.kt
+++ b/notifications/src/main/java/org/openedx/notifications/data/repository/NotificationsRepository.kt
@@ -1,5 +1,6 @@
 package org.openedx.notifications.data.repository
 
+import org.openedx.notifications.data.api.APIConstants
 import org.openedx.notifications.data.api.NotificationsApi
 import org.openedx.notifications.domain.model.InboxNotifications
 import org.openedx.notifications.domain.model.NotificationsCount
@@ -11,7 +12,7 @@ class NotificationsRepository(private val api: NotificationsApi) {
 
     suspend fun getInboxNotifications(page: Int): InboxNotifications {
         return api.getInboxNotifications(
-            appName = "discussion",
+            appName = APIConstants.APP_NAME_DISCUSSION,
             page = page
         ).mapToDomain()
     }

--- a/notifications/src/main/java/org/openedx/notifications/domain/interactor/NotificationsInteractor.kt
+++ b/notifications/src/main/java/org/openedx/notifications/domain/interactor/NotificationsInteractor.kt
@@ -1,11 +1,16 @@
 package org.openedx.notifications.domain.interactor
 
 import org.openedx.notifications.data.repository.NotificationsRepository
+import org.openedx.notifications.domain.model.InboxNotifications
 import org.openedx.notifications.domain.model.NotificationsCount
 
 class NotificationsInteractor(private val repository: NotificationsRepository) {
 
     suspend fun getUnreadNotificationsCount(): NotificationsCount {
         return repository.getUnreadNotificationsCount()
+    }
+
+    suspend fun getInboxNotifications(page: Int): InboxNotifications {
+        return repository.getInboxNotifications(page)
     }
 }

--- a/notifications/src/main/java/org/openedx/notifications/domain/model/InboxNotifications.kt
+++ b/notifications/src/main/java/org/openedx/notifications/domain/model/InboxNotifications.kt
@@ -1,5 +1,6 @@
 package org.openedx.notifications.domain.model
 
+import androidx.compose.ui.text.AnnotatedString
 import java.util.Date
 
 data class InboxNotifications(
@@ -21,7 +22,7 @@ data class NotificationItem(
     val appName: String,
     val notificationType: String,
     val contentContext: NotificationContent,
-    val content: String,
+    val content: AnnotatedString,
     val contentUrl: String,
     val lastRead: Date?,
     val lastSeen: Date?,

--- a/notifications/src/main/java/org/openedx/notifications/domain/model/InboxNotifications.kt
+++ b/notifications/src/main/java/org/openedx/notifications/domain/model/InboxNotifications.kt
@@ -39,4 +39,6 @@ data class NotificationContent(
     val courseName: String,
     val replierName: String,
     val emailContent: String,
+    val authorName: String,
+    val authorPronoun: String,
 )

--- a/notifications/src/main/java/org/openedx/notifications/domain/model/InboxNotifications.kt
+++ b/notifications/src/main/java/org/openedx/notifications/domain/model/InboxNotifications.kt
@@ -1,8 +1,10 @@
 package org.openedx.notifications.domain.model
 
+import java.util.Date
+
 data class InboxNotifications(
     val pagination: Pagination,
-    val notifications: List<NotificationItem>
+    val notifications: Map<InboxSection, List<NotificationItem>>,
 )
 
 data class Pagination(
@@ -11,7 +13,7 @@ data class Pagination(
     val count: Int,
     val numPages: Int,
     val currentPage: Int,
-    val start: Int
+    val start: Int,
 )
 
 data class NotificationItem(
@@ -21,9 +23,9 @@ data class NotificationItem(
     val contentContext: NotificationContent,
     val content: String,
     val contentUrl: String,
-    val lastRead: String,
-    val lastSeen: String,
-    val created: String
+    val lastRead: Date?,
+    val lastSeen: Date?,
+    val created: Date?,
 )
 
 data class NotificationContent(
@@ -36,5 +38,5 @@ data class NotificationContent(
     val postTitle: String,
     val courseName: String,
     val replierName: String,
-    val emailContent: String
+    val emailContent: String,
 )

--- a/notifications/src/main/java/org/openedx/notifications/domain/model/InboxNotifications.kt
+++ b/notifications/src/main/java/org/openedx/notifications/domain/model/InboxNotifications.kt
@@ -1,6 +1,5 @@
 package org.openedx.notifications.domain.model
 
-import androidx.compose.ui.text.AnnotatedString
 import java.util.Date
 
 data class InboxNotifications(
@@ -22,7 +21,7 @@ data class NotificationItem(
     val appName: String,
     val notificationType: String,
     val contentContext: NotificationContent,
-    val content: AnnotatedString,
+    val content: String,
     val contentUrl: String,
     val lastRead: Date?,
     val lastSeen: Date?,

--- a/notifications/src/main/java/org/openedx/notifications/domain/model/InboxNotifications.kt
+++ b/notifications/src/main/java/org/openedx/notifications/domain/model/InboxNotifications.kt
@@ -1,0 +1,40 @@
+package org.openedx.notifications.domain.model
+
+data class InboxNotifications(
+    val pagination: Pagination,
+    val notifications: List<NotificationItem>
+)
+
+data class Pagination(
+    val next: String,
+    val previous: String,
+    val count: Int,
+    val numPages: Int,
+    val currentPage: Int,
+    val start: Int
+)
+
+data class NotificationItem(
+    val id: Int,
+    val appName: String,
+    val notificationType: String,
+    val contentContext: NotificationContent,
+    val content: String,
+    val contentUrl: String,
+    val lastRead: String,
+    val lastSeen: String,
+    val created: String
+)
+
+data class NotificationContent(
+    val paragraph: String,
+    val strongText: String,
+    val topicId: String,
+    val parentId: String,
+    val threadId: String,
+    val commentId: String,
+    val postTitle: String,
+    val courseName: String,
+    val replierName: String,
+    val emailContent: String
+)

--- a/notifications/src/main/java/org/openedx/notifications/domain/model/InboxSection.kt
+++ b/notifications/src/main/java/org/openedx/notifications/domain/model/InboxSection.kt
@@ -1,0 +1,11 @@
+package org.openedx.notifications.domain.model
+
+import org.openedx.notifications.R
+
+enum class InboxSection(val titleResId: Int) {
+    RECENT(R.string.notifications_recent),
+
+    THIS_WEEK(R.string.notifications_this_week),
+
+    OLDER(R.string.notifications_older);
+}

--- a/notifications/src/main/java/org/openedx/notifications/presentation/inbox/InboxUIState.kt
+++ b/notifications/src/main/java/org/openedx/notifications/presentation/inbox/InboxUIState.kt
@@ -1,11 +1,12 @@
 package org.openedx.notifications.presentation.inbox
 
+import org.openedx.notifications.domain.model.InboxSection
 import org.openedx.notifications.domain.model.NotificationItem
 
 sealed class InboxUIState {
 
     data class Data(
-        val notifications: List<NotificationItem>
+        val notifications: Map<InboxSection, List<NotificationItem>>,
     ) : InboxUIState()
 
     data object Empty : InboxUIState()

--- a/notifications/src/main/java/org/openedx/notifications/presentation/inbox/InboxUIState.kt
+++ b/notifications/src/main/java/org/openedx/notifications/presentation/inbox/InboxUIState.kt
@@ -1,0 +1,14 @@
+package org.openedx.notifications.presentation.inbox
+
+import org.openedx.notifications.domain.model.NotificationItem
+
+sealed class InboxUIState {
+
+    data class Data(
+        val notifications: List<NotificationItem>
+    ) : InboxUIState()
+
+    data object Empty : InboxUIState()
+    data object Error : InboxUIState()
+    data object Loading : InboxUIState()
+}

--- a/notifications/src/main/java/org/openedx/notifications/presentation/inbox/NotificationsInboxFragment.kt
+++ b/notifications/src/main/java/org/openedx/notifications/presentation/inbox/NotificationsInboxFragment.kt
@@ -1,0 +1,168 @@
+package org.openedx.notifications.presentation.inbox
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.rememberScaffoldState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.fragment.app.Fragment
+import org.koin.androidx.viewmodel.ext.android.viewModel
+import org.openedx.core.ui.BackBtn
+import org.openedx.core.ui.WindowSize
+import org.openedx.core.ui.rememberWindowSize
+import org.openedx.core.ui.statusBarsInset
+import org.openedx.core.ui.theme.OpenEdXTheme
+import org.openedx.core.ui.theme.appColors
+import org.openedx.core.ui.theme.appTypography
+import org.openedx.core.ui.windowSizeValue
+import org.openedx.notifications.R
+
+class NotificationsInboxFragment : Fragment() {
+
+    private val viewModel by viewModel<NotificationsInboxViewModel>()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ) = ComposeView(requireContext()).apply {
+        setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+        setContent {
+            OpenEdXTheme {
+                val windowSize = rememberWindowSize()
+
+                InboxView(
+                    windowSize = windowSize,
+                    onBackClick = {
+                        requireActivity().supportFragmentManager.popBackStack()
+                    },
+                    onSettingsClick = {
+
+                    }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun InboxView(
+    windowSize: WindowSize,
+    onBackClick: () -> Unit,
+    onSettingsClick: () -> Unit,
+) {
+    val scaffoldState = rememberScaffoldState()
+    val contentWidth by remember(key1 = windowSize) {
+        mutableStateOf(
+            windowSize.windowSizeValue(
+                expanded = Modifier.widthIn(Dp.Unspecified, 560.dp),
+                compact = Modifier
+                    .fillMaxWidth()
+                    .padding(24.dp)
+            )
+        )
+    }
+
+    Scaffold(
+        scaffoldState = scaffoldState,
+        modifier = Modifier
+            .fillMaxSize()
+            .navigationBarsPadding(),
+        backgroundColor = MaterialTheme.appColors.background
+    ) {
+        Column(
+            Modifier
+                .fillMaxSize()
+                .padding(it)
+                .statusBarsInset(),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Header(
+                modifier = Modifier,
+                onBackClick = onBackClick,
+                onSettingsClick = onSettingsClick,
+            )
+
+            Surface(
+                modifier = contentWidth,
+                color = MaterialTheme.appColors.background
+            ) {
+
+            }
+        }
+    }
+}
+
+@Composable
+fun Header(
+    modifier: Modifier = Modifier,
+    onBackClick: () -> Unit,
+    onSettingsClick: () -> Unit,
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(48.dp),
+    ) {
+        BackBtn(
+            tint = MaterialTheme.appColors.textPrimary,
+            onBackClick = onBackClick
+        )
+
+        Text(
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag("txt_inbox_title")
+                .align(Alignment.Center)
+                .padding(horizontal = 48.dp),
+            text = stringResource(R.string.notifications_notifications),
+            color = MaterialTheme.appColors.textPrimary,
+            style = MaterialTheme.appTypography.titleMedium,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            textAlign = TextAlign.Center,
+        )
+
+        IconButton(
+            modifier = Modifier
+                .align(Alignment.CenterEnd)
+                .padding(end = 12.dp),
+            onClick = { onSettingsClick() }
+        ) {
+            Icon(
+                imageVector = Icons.Default.MoreVert,
+                tint = MaterialTheme.appColors.primary,
+                contentDescription = stringResource(id = R.string.notifications_accessibility_settings)
+            )
+        }
+    }
+}

--- a/notifications/src/main/java/org/openedx/notifications/presentation/inbox/NotificationsInboxFragment.kt
+++ b/notifications/src/main/java/org/openedx/notifications/presentation/inbox/NotificationsInboxFragment.kt
@@ -47,7 +47,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.PreviewLightDark
@@ -294,13 +293,13 @@ private fun SectionHeader(
     section: InboxSection,
 ) {
     Row(
-        modifier = modifier,
+        modifier = modifier.padding(bottom = 24.dp),
         horizontalArrangement = Arrangement.Start,
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Text(
             text = stringResource(id = section.titleResId),
-            modifier = Modifier.padding(bottom = 24.dp),
+            modifier = Modifier,
             style = MaterialTheme.appTypography.titleSmall,
             color = MaterialTheme.appColors.textPrimaryVariant,
         )
@@ -331,7 +330,7 @@ private fun NotificationItemView(
             ) {
                 Text(
                     modifier = Modifier.weight(1f),
-                    text = item.content,
+                    text = TextUtils.htmlContentToAnnotatedString(item),
                     style = MaterialTheme.appTypography.bodyMedium,
                     color = MaterialTheme.appColors.textPrimary,
                 )
@@ -348,14 +347,14 @@ private fun NotificationItemView(
             Text(
                 text = TextUtils.dateToRelativeTimeString(LocalContext.current, item.created),
                 style = MaterialTheme.appTypography.bodySmall,
-                color = MaterialTheme.appColors.notificationTimestamp,
+                color = MaterialTheme.appColors.inboxTimeMarkerColor,
             )
         }
     }
 }
 
 @Composable
-fun InboxStateView(
+private fun InboxStateView(
     modifier: Modifier = Modifier,
     uiState: InboxUIState,
     onReloadNotifications: () -> Unit = { },
@@ -448,7 +447,7 @@ private val mockNotificationItem = NotificationItem(
     created = Date(),
     lastRead = null,
     lastSeen = null,
-    content = AnnotatedString("Mock Content"),
+    content = "Mock Content",
     contentContext = NotificationContent(
         paragraph = "",
         strongText = "",
@@ -456,7 +455,7 @@ private val mockNotificationItem = NotificationItem(
         parentId = "",
         threadId = "",
         commentId = "",
-        postTitle = "",
+        postTitle = "Mock",
         courseName = "",
         replierName = "",
         emailContent = "",

--- a/notifications/src/main/java/org/openedx/notifications/presentation/inbox/NotificationsInboxFragment.kt
+++ b/notifications/src/main/java/org/openedx/notifications/presentation/inbox/NotificationsInboxFragment.kt
@@ -1,16 +1,27 @@
 package org.openedx.notifications.presentation.inbox
 
+import android.content.res.Configuration
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
@@ -19,32 +30,48 @@ import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.outlined.Forum
 import androidx.compose.material.rememberScaffoldState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.fragment.app.Fragment
 import org.koin.androidx.viewmodel.ext.android.viewModel
+import org.openedx.core.extension.isNull
 import org.openedx.core.ui.BackBtn
 import org.openedx.core.ui.WindowSize
+import org.openedx.core.ui.WindowType
+import org.openedx.core.ui.displayCutoutForLandscape
 import org.openedx.core.ui.rememberWindowSize
+import org.openedx.core.ui.shouldLoadMore
 import org.openedx.core.ui.statusBarsInset
 import org.openedx.core.ui.theme.OpenEdXTheme
 import org.openedx.core.ui.theme.appColors
 import org.openedx.core.ui.theme.appTypography
 import org.openedx.core.ui.windowSizeValue
 import org.openedx.notifications.R
+import org.openedx.notifications.domain.model.InboxSection
+import org.openedx.notifications.domain.model.NotificationContent
+import org.openedx.notifications.domain.model.NotificationItem
+import org.openedx.notifications.utils.TextUtils
+import java.util.Date
 
 class NotificationsInboxFragment : Fragment() {
 
@@ -59,15 +86,22 @@ class NotificationsInboxFragment : Fragment() {
         setContent {
             OpenEdXTheme {
                 val windowSize = rememberWindowSize()
+                val uiState by viewModel.uiState.collectAsState()
+                val canLoadMore by viewModel.canLoadMore.collectAsState()
 
                 InboxView(
                     windowSize = windowSize,
+                    uiState = uiState,
+                    canLoadMore = canLoadMore,
                     onBackClick = {
                         requireActivity().supportFragmentManager.popBackStack()
                     },
                     onSettingsClick = {
 
-                    }
+                    },
+                    paginationCallBack = {
+                        viewModel.fetchMore()
+                    },
                 )
             }
         }
@@ -77,17 +111,33 @@ class NotificationsInboxFragment : Fragment() {
 @Composable
 private fun InboxView(
     windowSize: WindowSize,
+    uiState: InboxUIState,
+    canLoadMore: Boolean,
     onBackClick: () -> Unit,
     onSettingsClick: () -> Unit,
+    paginationCallBack: () -> Unit,
 ) {
     val scaffoldState = rememberScaffoldState()
+    val scrollState = rememberLazyListState()
+    val firstVisibleIndex = remember {
+        mutableIntStateOf(scrollState.firstVisibleItemIndex)
+    }
+    val topBarWidth by remember(key1 = windowSize) {
+        mutableStateOf(
+            windowSize.windowSizeValue(
+                expanded = Modifier.widthIn(Dp.Unspecified, 560.dp),
+                compact = Modifier
+                    .fillMaxWidth()
+            )
+        )
+    }
     val contentWidth by remember(key1 = windowSize) {
         mutableStateOf(
             windowSize.windowSizeValue(
                 expanded = Modifier.widthIn(Dp.Unspecified, 560.dp),
                 compact = Modifier
                     .fillMaxWidth()
-                    .padding(24.dp)
+                    .padding(horizontal = 24.dp, vertical = 16.dp)
             )
         )
     }
@@ -98,16 +148,17 @@ private fun InboxView(
             .fillMaxSize()
             .navigationBarsPadding(),
         backgroundColor = MaterialTheme.appColors.background
-    ) {
+    ) { paddingValues ->
         Column(
             Modifier
                 .fillMaxSize()
-                .padding(it)
-                .statusBarsInset(),
-            horizontalAlignment = Alignment.CenterHorizontally
+                .padding(paddingValues)
+                .statusBarsInset()
+                .displayCutoutForLandscape(),
+            horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             Header(
-                modifier = Modifier,
+                modifier = topBarWidth,
                 onBackClick = onBackClick,
                 onSettingsClick = onSettingsClick,
             )
@@ -116,14 +167,65 @@ private fun InboxView(
                 modifier = contentWidth,
                 color = MaterialTheme.appColors.background
             ) {
+                when (uiState) {
+                    is InboxUIState.Data -> {
+                        LazyColumn(
+                            Modifier
+                                .weight(1f)
+                                .background(MaterialTheme.appColors.background),
+                            state = scrollState,
+                        ) {
+                            uiState.notifications.forEach { (section, items) ->
+                                if (items.isNotEmpty()) {
+                                    item {
+                                        SectionHeader(
+                                            section = section,
+                                        )
+                                    }
 
+                                    items(items) { item ->
+                                        NotificationItemView(item = item)
+                                    }
+
+                                    item {
+                                        Spacer(Modifier.height(24.dp))
+                                    }
+                                }
+                            }
+
+                            if (canLoadMore) {
+                                item {
+                                    Box(
+                                        modifier = Modifier.fillMaxWidth(),
+                                        contentAlignment = Alignment.Center
+                                    ) {
+                                        CircularProgressIndicator(color = MaterialTheme.appColors.primary)
+                                    }
+                                }
+                            }
+
+                            if (scrollState.shouldLoadMore(firstVisibleIndex, 4)) {
+                                paginationCallBack()
+                            }
+                        }
+                    }
+
+                    else -> {
+                        Box(
+                            modifier = Modifier.fillMaxSize(),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            CircularProgressIndicator(color = MaterialTheme.appColors.primary)
+                        }
+                    }
+                }
             }
         }
     }
 }
 
 @Composable
-fun Header(
+private fun Header(
     modifier: Modifier = Modifier,
     onBackClick: () -> Unit,
     onSettingsClick: () -> Unit,
@@ -134,16 +236,15 @@ fun Header(
             .height(48.dp),
     ) {
         BackBtn(
+            modifier = Modifier.align(Alignment.CenterStart),
             tint = MaterialTheme.appColors.textPrimary,
             onBackClick = onBackClick
         )
 
         Text(
             modifier = Modifier
-                .fillMaxWidth()
                 .testTag("txt_inbox_title")
-                .align(Alignment.Center)
-                .padding(horizontal = 48.dp),
+                .align(Alignment.Center),
             text = stringResource(R.string.notifications_notifications),
             color = MaterialTheme.appColors.textPrimary,
             style = MaterialTheme.appTypography.titleMedium,
@@ -153,9 +254,7 @@ fun Header(
         )
 
         IconButton(
-            modifier = Modifier
-                .align(Alignment.CenterEnd)
-                .padding(end = 12.dp),
+            modifier = Modifier.align(Alignment.CenterEnd),
             onClick = { onSettingsClick() }
         ) {
             Icon(
@@ -166,3 +265,119 @@ fun Header(
         }
     }
 }
+
+@Composable
+private fun SectionHeader(
+    modifier: Modifier = Modifier,
+    section: InboxSection,
+) {
+    Row(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.Start,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = stringResource(id = section.titleResId),
+            modifier = Modifier.padding(bottom = 24.dp),
+            style = MaterialTheme.appTypography.titleSmall,
+            color = MaterialTheme.appColors.textPrimaryVariant,
+        )
+    }
+}
+
+@Composable
+private fun NotificationItemView(
+    modifier: Modifier = Modifier,
+    item: NotificationItem,
+) {
+    Row(
+        modifier = modifier.padding(vertical = 8.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.Top,
+    ) {
+        Icon(
+            imageVector = Icons.Outlined.Forum,
+            contentDescription = null,
+            tint = MaterialTheme.appColors.textPrimary,
+        )
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                Text(
+                    modifier = Modifier.weight(1f),
+                    text = item.content,
+                    style = MaterialTheme.appTypography.bodyMedium,
+                    color = MaterialTheme.appColors.textPrimary,
+                )
+                if (item.lastRead.isNull()) {
+                    Box(
+                        modifier = Modifier
+                            .clip(CircleShape)
+                            .align(Alignment.CenterVertically)
+                            .size(8.dp)
+                            .background(MaterialTheme.appColors.primaryButtonBackground)
+                    )
+                }
+            }
+            Text(
+                text = TextUtils.dateToRelativeTimeString(LocalContext.current, item.created),
+                style = MaterialTheme.appTypography.bodySmall,
+                color = MaterialTheme.appColors.notificationTimestamp,
+            )
+        }
+    }
+}
+
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES, showBackground = true)
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_NO, showBackground = true)
+@Composable
+private fun InboxPreview() {
+    OpenEdXTheme {
+        InboxView(
+            windowSize = WindowSize(WindowType.Compact, WindowType.Compact),
+            uiState = InboxUIState.Data(
+                notifications = mapOf(
+                    InboxSection.RECENT to listOf(
+                        mockNotificationItem,
+                        mockNotificationItem
+                    ),
+                    InboxSection.OLDER to listOf(
+                        mockNotificationItem,
+                        mockNotificationItem
+                    )
+                )
+            ),
+            canLoadMore = true,
+            onBackClick = { },
+            onSettingsClick = { },
+            paginationCallBack = { },
+        )
+    }
+}
+
+private val mockNotificationItem = NotificationItem(
+    id = 0,
+    appName = "",
+    notificationType = "",
+    contentUrl = "",
+    created = Date(),
+    lastRead = null,
+    lastSeen = null,
+    content = AnnotatedString("Mock Content"),
+    contentContext = NotificationContent(
+        paragraph = "",
+        strongText = "",
+        topicId = "",
+        parentId = "",
+        threadId = "",
+        commentId = "",
+        postTitle = "",
+        courseName = "",
+        replierName = "",
+        emailContent = "",
+    )
+)

--- a/notifications/src/main/java/org/openedx/notifications/presentation/inbox/NotificationsInboxFragment.kt
+++ b/notifications/src/main/java/org/openedx/notifications/presentation/inbox/NotificationsInboxFragment.kt
@@ -142,7 +142,7 @@ private fun InboxView(
     val contentWidth by remember(key1 = windowSize) {
         mutableStateOf(
             windowSize.windowSizeValue(
-                expanded = Modifier.widthIn(Dp.Unspecified, 560.dp),
+                expanded = Modifier.widthIn(Dp.Unspecified, 420.dp),
                 compact = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = 24.dp, vertical = 16.dp)
@@ -459,6 +459,8 @@ private val mockNotificationItem = NotificationItem(
         courseName = "",
         replierName = "",
         emailContent = "",
+        authorName = "",
+        authorPronoun = "",
     )
 )
 

--- a/notifications/src/main/java/org/openedx/notifications/presentation/inbox/NotificationsInboxViewModel.kt
+++ b/notifications/src/main/java/org/openedx/notifications/presentation/inbox/NotificationsInboxViewModel.kt
@@ -1,0 +1,10 @@
+package org.openedx.notifications.presentation.inbox
+
+import org.openedx.core.BaseViewModel
+import org.openedx.notifications.domain.interactor.NotificationsInteractor
+
+class NotificationsInboxViewModel(
+    private val interactor: NotificationsInteractor,
+) : BaseViewModel() {
+
+}

--- a/notifications/src/main/java/org/openedx/notifications/presentation/inbox/NotificationsInboxViewModel.kt
+++ b/notifications/src/main/java/org/openedx/notifications/presentation/inbox/NotificationsInboxViewModel.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import org.openedx.core.BaseViewModel
 import org.openedx.notifications.domain.interactor.NotificationsInteractor
+import org.openedx.notifications.domain.model.InboxSection
 import org.openedx.notifications.domain.model.NotificationItem
 
 class NotificationsInboxViewModel(
@@ -18,7 +19,11 @@ class NotificationsInboxViewModel(
     private val _canLoadMore = MutableStateFlow(true)
     val canLoadMore = _canLoadMore.asStateFlow()
 
-    val notifications: MutableList<NotificationItem> = mutableListOf()
+    private val notifications: Map<InboxSection, MutableList<NotificationItem>> = mapOf(
+        InboxSection.RECENT to mutableListOf(),
+        InboxSection.THIS_WEEK to mutableListOf(),
+        InboxSection.OLDER to mutableListOf(),
+    )
 
     private var isLoading = false
     private var nextPage = 1
@@ -43,19 +48,24 @@ class NotificationsInboxViewModel(
             isLoading = true
             try {
                 val response = interactor.getInboxNotifications(nextPage)
-                if (response.pagination.next.isNotEmpty() && nextPage != response.pagination.numPages) {
+                if (response.pagination.next.isNotEmpty() && nextPage < response.pagination.numPages) {
                     nextPage++
                     _canLoadMore.value = true
                 } else {
                     nextPage = -1
                     _canLoadMore.value = false
                 }
-                notifications.addAll(response.notifications)
 
-                if (notifications.isNotEmpty()) {
-                    _uiState.value = InboxUIState.Data(notifications = notifications)
+                // Add the new notifications to their respective sections in the existing map
+                response.notifications.forEach { (section, items) ->
+                    notifications[section]?.addAll(items)
+                }
+
+                // Update the UI state based on whether any notifications exist
+                _uiState.value = if (notifications.values.any { it.isNotEmpty() }) {
+                    InboxUIState.Data(notifications = notifications)
                 } else {
-                    _uiState.value = InboxUIState.Empty
+                    InboxUIState.Empty
                 }
             } catch (e: Exception) {
                 _uiState.value = InboxUIState.Error

--- a/notifications/src/main/java/org/openedx/notifications/presentation/inbox/NotificationsInboxViewModel.kt
+++ b/notifications/src/main/java/org/openedx/notifications/presentation/inbox/NotificationsInboxViewModel.kt
@@ -68,10 +68,20 @@ class NotificationsInboxViewModel(
                     InboxUIState.Empty
                 }
             } catch (e: Exception) {
-                _uiState.value = InboxUIState.Error
+                if (nextPage == 1) {
+                    _uiState.value = InboxUIState.Error
+                } else {
+                    _canLoadMore.value = true
+                }
             } finally {
                 isLoading = false
             }
         }
+    }
+
+    fun onReloadNotifications() {
+        _canLoadMore.value = true
+        nextPage = 1
+        internalLoadNotifications()
     }
 }

--- a/notifications/src/main/java/org/openedx/notifications/presentation/inbox/NotificationsInboxViewModel.kt
+++ b/notifications/src/main/java/org/openedx/notifications/presentation/inbox/NotificationsInboxViewModel.kt
@@ -1,10 +1,67 @@
 package org.openedx.notifications.presentation.inbox
 
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 import org.openedx.core.BaseViewModel
 import org.openedx.notifications.domain.interactor.NotificationsInteractor
+import org.openedx.notifications.domain.model.NotificationItem
 
 class NotificationsInboxViewModel(
     private val interactor: NotificationsInteractor,
 ) : BaseViewModel() {
 
+    private val _uiState = MutableStateFlow<InboxUIState>(InboxUIState.Loading)
+    val uiState = _uiState.asStateFlow()
+
+    private val _canLoadMore = MutableStateFlow(true)
+    val canLoadMore = _canLoadMore.asStateFlow()
+
+    val notifications: MutableList<NotificationItem> = mutableListOf()
+
+    private var isLoading = false
+    private var nextPage = 1
+
+    init {
+        getInboxNotifications()
+    }
+
+    private fun getInboxNotifications() {
+        _uiState.value = InboxUIState.Loading
+        internalLoadNotifications()
+    }
+
+    fun fetchMore() {
+        if (!isLoading && nextPage != -1) {
+            internalLoadNotifications()
+        }
+    }
+
+    private fun internalLoadNotifications() {
+        viewModelScope.launch {
+            isLoading = true
+            try {
+                val response = interactor.getInboxNotifications(nextPage)
+                if (response.pagination.next.isNotEmpty() && nextPage != response.pagination.numPages) {
+                    nextPage++
+                    _canLoadMore.value = true
+                } else {
+                    nextPage = -1
+                    _canLoadMore.value = false
+                }
+                notifications.addAll(response.notifications)
+
+                if (notifications.isNotEmpty()) {
+                    _uiState.value = InboxUIState.Data(notifications = notifications)
+                } else {
+                    _uiState.value = InboxUIState.Empty
+                }
+            } catch (e: Exception) {
+                _uiState.value = InboxUIState.Error
+            } finally {
+                isLoading = false
+            }
+        }
+    }
 }

--- a/notifications/src/main/java/org/openedx/notifications/utils/TextUtils.kt
+++ b/notifications/src/main/java/org/openedx/notifications/utils/TextUtils.kt
@@ -1,0 +1,111 @@
+package org.openedx.notifications.utils
+
+import android.content.Context
+import android.graphics.Typeface
+import android.text.style.StyleSpan
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.core.text.HtmlCompat
+import org.openedx.notifications.R
+import java.util.Calendar
+import java.util.Date
+import java.util.concurrent.TimeUnit
+
+
+object TextUtils {
+
+    fun dateToRelativeTimeString(context: Context, date: Date?): String {
+        val inputDate = Calendar.getInstance().apply { time = date ?: return "" }
+        val currentDate = Calendar.getInstance()
+
+        val difference = currentDate.timeInMillis - inputDate.timeInMillis
+
+        return when {
+            difference == 0L -> {
+                context.getString(
+                    R.string.notification_now
+                )
+            }
+
+            difference < TimeUnit.MINUTES.toMillis(1) -> {
+                val seconds = TimeUnit.MILLISECONDS.toSeconds(difference).toInt()
+                context.resources.getQuantityString(
+                    R.plurals.notifications_date_format_seconds_ago,
+                    seconds,
+                    seconds
+                )
+            }
+
+            difference < TimeUnit.HOURS.toMillis(1) -> {
+                val minutes = TimeUnit.MILLISECONDS.toMinutes(difference).toInt()
+                context.resources.getQuantityString(
+                    R.plurals.notifications_date_format_minutes_ago,
+                    minutes,
+                    minutes
+                )
+            }
+
+            difference < TimeUnit.DAYS.toMillis(1) -> {
+                val hours = TimeUnit.MILLISECONDS.toHours(difference).toInt()
+                context.resources.getQuantityString(
+                    R.plurals.notifications_date_format_hours_ago,
+                    hours,
+                    hours
+                )
+            }
+
+            difference < TimeUnit.DAYS.toMillis(7) -> {
+                val days = TimeUnit.MILLISECONDS.toDays(difference).toInt()
+                context.resources.getQuantityString(
+                    R.plurals.notifications_date_format_days_ago,
+                    days,
+                    days
+                )
+            }
+
+            difference < TimeUnit.DAYS.toMillis(30) -> {
+                val weeks = (TimeUnit.MILLISECONDS.toDays(difference) / 7).toInt()
+                context.resources.getQuantityString(
+                    R.plurals.notifications_date_format_weeks_ago,
+                    weeks,
+                    weeks
+                )
+            }
+
+            difference < TimeUnit.DAYS.toMillis(365) -> {
+                val months = (TimeUnit.MILLISECONDS.toDays(difference) / 30).toInt()
+                context.resources.getQuantityString(
+                    R.plurals.notifications_date_format_months_ago,
+                    months,
+                    months
+                )
+            }
+
+            else -> {
+                ""
+            }
+        }
+    }
+
+    fun htmlContentToAnnotatedString(html: String): AnnotatedString {
+        val spanned = HtmlCompat.fromHtml(html, HtmlCompat.FROM_HTML_MODE_COMPACT)
+        val builder = AnnotatedString.Builder()
+
+        spanned.getSpans(0, spanned.length, Any::class.java).forEach { span ->
+            val start = spanned.getSpanStart(span)
+            val end = spanned.getSpanEnd(span)
+
+            if (span is StyleSpan && span.style == Typeface.BOLD) {
+                builder.addStyle(
+                    style = SpanStyle(fontWeight = FontWeight.Bold),
+                    start = start,
+                    end = end
+                )
+            }
+        }
+
+        builder.append(spanned.trimEnd())
+        return builder.toAnnotatedString()
+    }
+}

--- a/notifications/src/main/java/org/openedx/notifications/utils/TextUtils.kt
+++ b/notifications/src/main/java/org/openedx/notifications/utils/TextUtils.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.core.text.HtmlCompat
 import org.openedx.notifications.R
+import org.openedx.notifications.domain.model.NotificationItem
 import java.util.Calendar
 import java.util.Date
 import java.util.concurrent.TimeUnit
@@ -31,7 +32,7 @@ object TextUtils {
             difference < TimeUnit.MINUTES.toMillis(1) -> {
                 val seconds = TimeUnit.MILLISECONDS.toSeconds(difference).toInt()
                 context.resources.getQuantityString(
-                    R.plurals.notifications_date_format_seconds_ago,
+                    R.plurals.notifications_date_format_seconds,
                     seconds,
                     seconds
                 )
@@ -40,7 +41,7 @@ object TextUtils {
             difference < TimeUnit.HOURS.toMillis(1) -> {
                 val minutes = TimeUnit.MILLISECONDS.toMinutes(difference).toInt()
                 context.resources.getQuantityString(
-                    R.plurals.notifications_date_format_minutes_ago,
+                    R.plurals.notifications_date_format_minutes,
                     minutes,
                     minutes
                 )
@@ -49,7 +50,7 @@ object TextUtils {
             difference < TimeUnit.DAYS.toMillis(1) -> {
                 val hours = TimeUnit.MILLISECONDS.toHours(difference).toInt()
                 context.resources.getQuantityString(
-                    R.plurals.notifications_date_format_hours_ago,
+                    R.plurals.notifications_date_format_hours,
                     hours,
                     hours
                 )
@@ -58,7 +59,7 @@ object TextUtils {
             difference < TimeUnit.DAYS.toMillis(7) -> {
                 val days = TimeUnit.MILLISECONDS.toDays(difference).toInt()
                 context.resources.getQuantityString(
-                    R.plurals.notifications_date_format_days_ago,
+                    R.plurals.notifications_date_format_days,
                     days,
                     days
                 )
@@ -67,7 +68,7 @@ object TextUtils {
             difference < TimeUnit.DAYS.toMillis(30) -> {
                 val weeks = (TimeUnit.MILLISECONDS.toDays(difference) / 7).toInt()
                 context.resources.getQuantityString(
-                    R.plurals.notifications_date_format_weeks_ago,
+                    R.plurals.notifications_date_format_weeks,
                     weeks,
                     weeks
                 )
@@ -76,7 +77,7 @@ object TextUtils {
             difference < TimeUnit.DAYS.toMillis(365) -> {
                 val months = (TimeUnit.MILLISECONDS.toDays(difference) / 30).toInt()
                 context.resources.getQuantityString(
-                    R.plurals.notifications_date_format_months_ago,
+                    R.plurals.notifications_date_format_months,
                     months,
                     months
                 )
@@ -88,8 +89,15 @@ object TextUtils {
         }
     }
 
-    fun htmlContentToAnnotatedString(html: String): AnnotatedString {
-        val spanned = HtmlCompat.fromHtml(html, HtmlCompat.FROM_HTML_MODE_COMPACT)
+    fun htmlContentToAnnotatedString(item: NotificationItem): AnnotatedString {
+        val postTitle = item.contentContext.postTitle
+        val modifiedHtml = if (postTitle.isNotEmpty()) {
+            item.content.replace(postTitle, "\"${postTitle}\"")
+        } else {
+            item.content
+        }
+
+        val spanned = HtmlCompat.fromHtml(modifiedHtml, HtmlCompat.FROM_HTML_MODE_COMPACT)
         val builder = AnnotatedString.Builder()
 
         spanned.getSpans(0, spanned.length, Any::class.java).forEach { span ->
@@ -98,7 +106,7 @@ object TextUtils {
 
             if (span is StyleSpan && span.style == Typeface.BOLD) {
                 builder.addStyle(
-                    style = SpanStyle(fontWeight = FontWeight.Bold),
+                    style = SpanStyle(fontWeight = FontWeight.SemiBold),
                     start = start,
                     end = end
                 )

--- a/notifications/src/main/res/values/strings.xml
+++ b/notifications/src/main/res/values/strings.xml
@@ -5,6 +5,8 @@
     <string name="notifications_this_week">This Week</string>
     <string name="notifications_older">Older</string>
     <string name="notification_now">Now</string>
+    <string name="notifications_no_notifications_yet">No notifications yet</string>
+    <string name="notifications_no_notifications_yet_description">When you receive notifications they’ll show up here</string>
     <plurals name="notifications_date_format_seconds_ago">
         <item quantity="one">%1$s second ago</item>
         <item quantity="other">%1$s seconds ago</item>

--- a/notifications/src/main/res/values/strings.xml
+++ b/notifications/src/main/res/values/strings.xml
@@ -4,4 +4,29 @@
     <string name="notifications_recent">Recent</string>
     <string name="notifications_this_week">This Week</string>
     <string name="notifications_older">Older</string>
+    <string name="notification_now">Now</string>
+    <plurals name="notifications_date_format_seconds_ago">
+        <item quantity="one">%1$s second ago</item>
+        <item quantity="other">%1$s seconds ago</item>
+    </plurals>
+    <plurals name="notifications_date_format_minutes_ago">
+        <item quantity="one">%1$s minute ago</item>
+        <item quantity="other">%1$s minutes ago</item>
+    </plurals>
+    <plurals name="notifications_date_format_hours_ago">
+        <item quantity="one">%1$s hour ago</item>
+        <item quantity="other">%1$s hours ago</item>
+    </plurals>
+    <plurals name="notifications_date_format_days_ago">
+        <item quantity="one">%1$s day ago</item>
+        <item quantity="other">%1$s days ago</item>
+    </plurals>
+    <plurals name="notifications_date_format_weeks_ago">
+        <item quantity="one">%1$s week ago</item>
+        <item quantity="other">%1$s weeks ago</item>
+    </plurals>
+    <plurals name="notifications_date_format_months_ago">
+        <item quantity="one">%1$s month ago</item>
+        <item quantity="other">%1$s months ago</item>
+    </plurals>
 </resources>

--- a/notifications/src/main/res/values/strings.xml
+++ b/notifications/src/main/res/values/strings.xml
@@ -1,4 +1,7 @@
 <resources>
     <string name="notifications_notifications">Notifications</string>
     <string name="notifications_accessibility_settings">Settings</string>
+    <string name="notifications_recent">Recent</string>
+    <string name="notifications_this_week">This Week</string>
+    <string name="notifications_older">Older</string>
 </resources>

--- a/notifications/src/main/res/values/strings.xml
+++ b/notifications/src/main/res/values/strings.xml
@@ -7,28 +7,28 @@
     <string name="notification_now">Now</string>
     <string name="notifications_no_notifications_yet">No notifications yet</string>
     <string name="notifications_no_notifications_yet_description">When you receive notifications they’ll show up here</string>
-    <plurals name="notifications_date_format_seconds_ago">
-        <item quantity="one">%1$s second ago</item>
-        <item quantity="other">%1$s seconds ago</item>
+    <plurals name="notifications_date_format_seconds">
+        <item quantity="one">%1$s second</item>
+        <item quantity="other">%1$s seconds</item>
     </plurals>
-    <plurals name="notifications_date_format_minutes_ago">
-        <item quantity="one">%1$s minute ago</item>
-        <item quantity="other">%1$s minutes ago</item>
+    <plurals name="notifications_date_format_minutes">
+        <item quantity="one">%1$s minute</item>
+        <item quantity="other">%1$s minutes</item>
     </plurals>
-    <plurals name="notifications_date_format_hours_ago">
-        <item quantity="one">%1$s hour ago</item>
-        <item quantity="other">%1$s hours ago</item>
+    <plurals name="notifications_date_format_hours">
+        <item quantity="one">%1$s hour</item>
+        <item quantity="other">%1$s hours</item>
     </plurals>
-    <plurals name="notifications_date_format_days_ago">
-        <item quantity="one">%1$s day ago</item>
-        <item quantity="other">%1$s days ago</item>
+    <plurals name="notifications_date_format_days">
+        <item quantity="one">%1$s day</item>
+        <item quantity="other">%1$s days</item>
     </plurals>
-    <plurals name="notifications_date_format_weeks_ago">
-        <item quantity="one">%1$s week ago</item>
-        <item quantity="other">%1$s weeks ago</item>
+    <plurals name="notifications_date_format_weeks">
+        <item quantity="one">%1$s week</item>
+        <item quantity="other">%1$s weeks</item>
     </plurals>
-    <plurals name="notifications_date_format_months_ago">
-        <item quantity="one">%1$s month ago</item>
-        <item quantity="other">%1$s months ago</item>
+    <plurals name="notifications_date_format_months">
+        <item quantity="one">%1$s month</item>
+        <item quantity="other">%1$s months</item>
     </plurals>
 </resources>

--- a/notifications/src/main/res/values/strings.xml
+++ b/notifications/src/main/res/values/strings.xml
@@ -1,3 +1,4 @@
 <resources>
-
+    <string name="notifications_notifications">Notifications</string>
+    <string name="notifications_accessibility_settings">Settings</string>
 </resources>


### PR DESCRIPTION
### Description:

[LEARNER-10346](https://2u-internal.atlassian.net/browse/LEARNER-10346)

A Notification Inbox Screen that organizes notifications into three categories: **Recent** (last 24 hours), **This Week** (past 7 days), and **Older**.

### Screenshots:

| Inbox Screen | Empty Screen | Error Screen|
|--------|--------|--------|
| ![Screenshot_20250108_144055](https://github.com/user-attachments/assets/80515438-666a-492f-b444-18d6709fb190) | ![No Notifications Dark](https://github.com/user-attachments/assets/c1542ed6-aff1-48ce-bcd1-bbcab0c60eff) | ![Error Notifications Dark](https://github.com/user-attachments/assets/9a47b256-7f24-4bb7-a1da-b1c4bc3df4ca) |
| ![Screenshot_20250108_144151](https://github.com/user-attachments/assets/10a8f5b8-4504-49f1-b1e3-a081b9763c30) | ![No Notifications Light](https://github.com/user-attachments/assets/a4b71e56-c7dd-4aee-afe8-4c8d8accf90f) | ![Error Notifications Light](https://github.com/user-attachments/assets/7590bb2a-3e2b-4e5e-a540-eac8dc5c4001) |

### Figma:

[Mobile Notifications UI Screen](https://www.figma.com/design/I9xgrJzdTje5vKgh6DD57C/Mobile-UI-Screens-(2025)?node-id=1-4933&t=Q3n6mSTW27u9mk0t-0)
