### PR TITLE
chore: Remove Elevation from Brand and Primary Buttons

### DIFF
--- a/core/src/main/java/org/openedx/core/ui/ComposeCommon.kt
+++ b/core/src/main/java/org/openedx/core/ui/ComposeCommon.kt
@@ -1087,6 +1087,7 @@ fun OpenEdXBrandButton(
             backgroundColor = backgroundColor,
             disabledBackgroundColor = backgroundColor.copy(alpha = 0.3f)
         ),
+        elevation = null,
         enabled = enabled,
         onClick = onClick,
     ) {


### PR DESCRIPTION
### Description:

[LEARNER-10366](https://2u-internal.atlassian.net/browse/LEARNER-10366)

The Brand and Primary Buttons display a shadow/elevation effect, which is inconsistent with the Paragon Elm Theme guidelines. This deviation from the design standard must be addressed by removing the shadow/elevation from these buttons.
