### PR TITLE
feat: Mark Notifications as Seen and Read

### DIFF
--- a/app/src/main/java/org/openedx/app/di/ScreenModule.kt
+++ b/app/src/main/java/org/openedx/app/di/ScreenModule.kt
@@ -486,7 +486,7 @@ val screenModule = module {
     single { NotificationsRepository(get()) }
     factory { NotificationsInteractor(get()) }
 
-    viewModel { NotificationsInboxViewModel(get()) }
+    viewModel { NotificationsInboxViewModel(get(), get()) }
 
     single { IAPRepository(get()) }
     factory { IAPInteractor(get(), get(), get(), get(), get()) }

--- a/core/src/main/java/org/openedx/core/ui/ComposeExtensions.kt
+++ b/core/src/main/java/org/openedx/core/ui/ComposeExtensions.kt
@@ -88,6 +88,11 @@ fun LazyGridState.shouldLoadMore(rememberedIndex: MutableState<Int>, threshold: 
     return false
 }
 
+fun LazyListState.shouldLoadMore(threshold: Int): Boolean {
+    val lastVisibleIndex = layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: return false
+    return lastVisibleIndex >= layoutInfo.totalItemsCount - 1 - threshold
+}
+
 fun Modifier.statusBarsInset(): Modifier = composed {
     val topInset = (LocalContext.current as? InsetHolder)?.topInset ?: 0
     return@composed this

--- a/notifications/src/main/java/org/openedx/notifications/data/api/APIConstants.kt
+++ b/notifications/src/main/java/org/openedx/notifications/data/api/APIConstants.kt
@@ -3,6 +3,8 @@ package org.openedx.notifications.data.api
 object APIConstants {
     const val NOTIFICATION_COUNT = "/api/notifications/count/"
     const val NOTIFICATIONS_INBOX = "/api/notifications/"
+    const val NOTIFICATIONS_SEEN = "/api/notifications/mark-seen/{app_name}/"
+    const val NOTIFICATION_READ = "/api/notifications/read/"
 
     const val APP_NAME_DISCUSSION = "discussion"
 }

--- a/notifications/src/main/java/org/openedx/notifications/data/api/NotificationsApi.kt
+++ b/notifications/src/main/java/org/openedx/notifications/data/api/NotificationsApi.kt
@@ -1,8 +1,14 @@
 package org.openedx.notifications.data.api
 
 import org.openedx.notifications.data.model.InboxNotificationsResponse
+import org.openedx.notifications.data.model.MarkNotificationReadBody
 import org.openedx.notifications.data.model.NotificationsCountResponse
+import org.openedx.notifications.data.model.NotificationsMarkResponse
+import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.PATCH
+import retrofit2.http.PUT
+import retrofit2.http.Path
 import retrofit2.http.Query
 
 interface NotificationsApi {
@@ -14,4 +20,14 @@ interface NotificationsApi {
         @Query("app_name") appName: String,
         @Query("page") page: Int,
     ): InboxNotificationsResponse
+
+    @PUT(APIConstants.NOTIFICATIONS_SEEN)
+    suspend fun markNotificationsAsSeen(
+        @Path("app_name") appName: String,
+    ): NotificationsMarkResponse
+
+    @PATCH(APIConstants.NOTIFICATION_READ)
+    suspend fun markNotificationAsRead(
+        @Body markNotification: MarkNotificationReadBody,
+    ): NotificationsMarkResponse
 }

--- a/notifications/src/main/java/org/openedx/notifications/data/model/MarkNotificationReadBody.kt
+++ b/notifications/src/main/java/org/openedx/notifications/data/model/MarkNotificationReadBody.kt
@@ -1,0 +1,8 @@
+package org.openedx.notifications.data.model
+
+import com.google.gson.annotations.SerializedName
+
+data class MarkNotificationReadBody(
+    @SerializedName("notification_id")
+    val notificationId: Int,
+)

--- a/notifications/src/main/java/org/openedx/notifications/data/model/NotificationsMarkResponse.kt
+++ b/notifications/src/main/java/org/openedx/notifications/data/model/NotificationsMarkResponse.kt
@@ -1,0 +1,8 @@
+package org.openedx.notifications.data.model
+
+import com.google.gson.annotations.SerializedName
+
+data class NotificationsMarkResponse(
+    @SerializedName("message")
+    val message: String,
+)

--- a/notifications/src/main/java/org/openedx/notifications/data/repository/NotificationsRepository.kt
+++ b/notifications/src/main/java/org/openedx/notifications/data/repository/NotificationsRepository.kt
@@ -1,7 +1,9 @@
 package org.openedx.notifications.data.repository
 
+import org.openedx.core.extension.isNotNull
 import org.openedx.notifications.data.api.APIConstants
 import org.openedx.notifications.data.api.NotificationsApi
+import org.openedx.notifications.data.model.MarkNotificationReadBody
 import org.openedx.notifications.domain.model.InboxNotifications
 import org.openedx.notifications.domain.model.NotificationsCount
 
@@ -15,5 +17,19 @@ class NotificationsRepository(private val api: NotificationsApi) {
             appName = APIConstants.APP_NAME_DISCUSSION,
             page = page
         ).mapToDomain()
+    }
+
+    suspend fun markNotificationsAsSeen(): Boolean {
+        return api.markNotificationsAsSeen(
+            appName = APIConstants.APP_NAME_DISCUSSION,
+        ).message.isNotNull()
+    }
+
+    suspend fun markNotificationAsRead(notificationId: Int): Boolean {
+        return api.markNotificationAsRead(
+            MarkNotificationReadBody(
+                notificationId = notificationId,
+            )
+        ).message.isNotNull()
     }
 }

--- a/notifications/src/main/java/org/openedx/notifications/domain/interactor/NotificationsInteractor.kt
+++ b/notifications/src/main/java/org/openedx/notifications/domain/interactor/NotificationsInteractor.kt
@@ -13,4 +13,12 @@ class NotificationsInteractor(private val repository: NotificationsRepository) {
     suspend fun getInboxNotifications(page: Int): InboxNotifications {
         return repository.getInboxNotifications(page)
     }
+
+    suspend fun markNotificationsAsSeen(): Boolean {
+        return repository.markNotificationsAsSeen()
+    }
+
+    suspend fun markNotificationAsRead(notificationId: Int): Boolean {
+        return repository.markNotificationAsRead(notificationId = notificationId)
+    }
 }

--- a/notifications/src/main/java/org/openedx/notifications/domain/model/InboxNotifications.kt
+++ b/notifications/src/main/java/org/openedx/notifications/domain/model/InboxNotifications.kt
@@ -1,5 +1,6 @@
 package org.openedx.notifications.domain.model
 
+import org.openedx.core.extension.isNull
 import java.util.Date
 
 data class InboxNotifications(
@@ -26,7 +27,11 @@ data class NotificationItem(
     val lastRead: Date?,
     val lastSeen: Date?,
     val created: Date?,
-)
+) {
+    fun isUnread(): Boolean {
+        return lastRead.isNull()
+    }
+}
 
 data class NotificationContent(
     val paragraph: String,

--- a/notifications/src/main/java/org/openedx/notifications/presentation/inbox/NotificationsInboxFragment.kt
+++ b/notifications/src/main/java/org/openedx/notifications/presentation/inbox/NotificationsInboxFragment.kt
@@ -158,6 +158,7 @@ private fun InboxView(
             )
         )
     }
+    val loadMoreTriggerThreshold = 4
 
     Scaffold(
         scaffoldState = scaffoldState,
@@ -229,7 +230,7 @@ private fun InboxView(
                                 }
                             }
 
-                            if (scrollState.shouldLoadMore(4)) {
+                            if (scrollState.shouldLoadMore(loadMoreTriggerThreshold)) {
                                 paginationCallBack()
                             }
                         }

--- a/notifications/src/main/java/org/openedx/notifications/presentation/inbox/NotificationsInboxViewModel.kt
+++ b/notifications/src/main/java/org/openedx/notifications/presentation/inbox/NotificationsInboxViewModel.kt
@@ -128,6 +128,10 @@ class NotificationsInboxViewModel(
                         notifications = notifications.toMap()
                     )
                 }
+
+                // Navigating the user to the related post or response in the Course Discussion Tab
+                // will be implemented in a separate PR.
+
             } catch (e: Exception) {
                 e.printStackTrace()
                 emitErrorMessage(e)

--- a/notifications/src/main/java/org/openedx/notifications/presentation/inbox/NotificationsInboxViewModel.kt
+++ b/notifications/src/main/java/org/openedx/notifications/presentation/inbox/NotificationsInboxViewModel.kt
@@ -1,40 +1,63 @@
 package org.openedx.notifications.presentation.inbox
 
 import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import org.openedx.core.BaseViewModel
+import org.openedx.core.UIMessage
+import org.openedx.core.extension.isInternetError
+import org.openedx.core.system.ResourceManager
 import org.openedx.notifications.domain.interactor.NotificationsInteractor
 import org.openedx.notifications.domain.model.InboxSection
 import org.openedx.notifications.domain.model.NotificationItem
+import java.util.Date
+import org.openedx.core.R as coreR
 
 class NotificationsInboxViewModel(
     private val interactor: NotificationsInteractor,
+    private val resourceManager: ResourceManager,
 ) : BaseViewModel() {
 
     private val _uiState = MutableStateFlow<InboxUIState>(InboxUIState.Loading)
     val uiState = _uiState.asStateFlow()
 
+    private val _uiMessage = MutableSharedFlow<UIMessage>()
+    val uiMessage = _uiMessage.asSharedFlow()
+
     private val _canLoadMore = MutableStateFlow(true)
     val canLoadMore = _canLoadMore.asStateFlow()
 
-    private val notifications: Map<InboxSection, MutableList<NotificationItem>> = mapOf(
-        InboxSection.RECENT to mutableListOf(),
-        InboxSection.THIS_WEEK to mutableListOf(),
-        InboxSection.OLDER to mutableListOf(),
-    )
+    private val notifications: MutableMap<InboxSection, MutableList<NotificationItem>> =
+        mutableMapOf(
+            InboxSection.RECENT to mutableListOf(),
+            InboxSection.THIS_WEEK to mutableListOf(),
+            InboxSection.OLDER to mutableListOf(),
+        )
 
     private var isLoading = false
     private var nextPage = 1
 
     init {
         getInboxNotifications()
+        markNotificationsAsSeen()
     }
 
     private fun getInboxNotifications() {
         _uiState.value = InboxUIState.Loading
         internalLoadNotifications()
+    }
+
+    private fun markNotificationsAsSeen() {
+        viewModelScope.launch {
+            try {
+                interactor.markNotificationsAsSeen()
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
+        }
     }
 
     fun fetchMore() {
@@ -83,5 +106,44 @@ class NotificationsInboxViewModel(
         _canLoadMore.value = true
         nextPage = 1
         internalLoadNotifications()
+    }
+
+    fun markNotificationAsRead(
+        notification: NotificationItem,
+        inboxSection: InboxSection,
+    ) {
+        viewModelScope.launch {
+            try {
+                if (notification.isUnread() && interactor.markNotificationAsRead(notification.id)) {
+                    val currentSection = notifications[inboxSection] ?: return@launch
+
+                    val index = currentSection.indexOfFirst { it.id == notification.id }
+                    if (index == -1) return@launch
+
+                    // Locally update the lastRead timestamp to avoid refreshing the entire list.
+                    currentSection[index] = currentSection[index].copy(lastRead = Date())
+
+                    notifications[inboxSection] = currentSection
+                    _uiState.value = InboxUIState.Data(
+                        notifications = notifications.toMap()
+                    )
+                }
+            } catch (e: Exception) {
+                e.printStackTrace()
+                emitErrorMessage(e)
+            }
+        }
+    }
+
+    private suspend fun emitErrorMessage(e: Exception) {
+        if (e.isInternetError()) {
+            _uiMessage.emit(
+                UIMessage.SnackBarMessage(resourceManager.getString(coreR.string.core_error_no_connection))
+            )
+        } else {
+            _uiMessage.emit(
+                UIMessage.SnackBarMessage(resourceManager.getString(coreR.string.core_error_unknown_error))
+            )
+        }
     }
 }


### PR DESCRIPTION
### Description:

[LEARNER-10290](https://2u-internal.atlassian.net/browse/LEARNER-10290)

This PR implements the following features for discussion notifications:

- Automatically marks all discussion notifications as "seen" when the inbox is opened.
- Marks individual notification as "read" when the user taps on it inside the inbox.

### Note: 
Currently, tapping a notification marks it as read. A separate PR will implement the redirection to the relevant course discussion tab.