### PR TITLE
fix: issue to load the video through chrome-cast device

### DIFF
--- a/course/src/main/java/org/openedx/course/presentation/unit/video/EncodedVideoUnitViewModel.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/video/EncodedVideoUnitViewModel.kt
@@ -120,6 +120,7 @@ class EncodedVideoUnitViewModel(
         val executor = Executors.newSingleThreadExecutor()
         CastContext.getSharedInstance(context, executor).addOnSuccessListener { castContext ->
             castPlayer = CastPlayer(castContext)
+            _isUpdated.value = true
         }.addOnFailureListener {
             logger.e(it, true)
         }

--- a/course/src/main/java/org/openedx/course/presentation/unit/video/VideoUnitViewModel.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/video/VideoUnitViewModel.kt
@@ -42,7 +42,7 @@ open class VideoUnitViewModel(
     val currentVideoTime: LiveData<Long>
         get() = _currentVideoTime
 
-    private val _isUpdated = MutableLiveData(true)
+    protected val _isUpdated = MutableLiveData(true)
     val isUpdated: LiveData<Boolean>
         get() = _isUpdated
 


### PR DESCRIPTION
### Description

 - Fix the issue by loading the video through the Chrome-cast device.
- This issue arises due to race conditions between the `setSessionAvailabilityListener` and `castPlayer` initialization.

**Steps to Reproduce:**

- Load the edX app 
- Connect the mobile device with the chrome-cast 
- After the device is connected successfully, try to play any video through chrome-cast
- Notice the video will play on the device instead of the LCD

Jira: [LEARNER-10350](https://2u-internal.atlassian.net/browse/LEARNER-10350)