### PR TITLE
feat: Infinite Scrolling Optimization and Swipe-to-Refresh for Notifications Inbox Screen

### DIFF
--- a/core/src/main/java/org/openedx/core/presentation/global/FullScreenState.kt
+++ b/core/src/main/java/org/openedx/core/presentation/global/FullScreenState.kt
@@ -1,0 +1,31 @@
+package org.openedx.core.presentation.global
+
+import androidx.annotation.StringRes
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.PriorityHigh
+import androidx.compose.material.icons.outlined.SignalWifiStatusbarConnectedNoInternet4
+import androidx.compose.ui.graphics.vector.ImageVector
+import org.openedx.core.R
+
+open class FullScreenState(
+    val imageVector: ImageVector,
+    @StringRes val titleResId: Int,
+    @StringRes val descriptionResId: Int,
+    @StringRes val actionButtonResId: Int? = null,
+) {
+    companion object {
+        val NetworkError = FullScreenState(
+            imageVector = Icons.Outlined.SignalWifiStatusbarConnectedNoInternet4,
+            titleResId = R.string.core_no_internet_connection,
+            descriptionResId = R.string.core_no_internet_connection_description,
+            actionButtonResId = R.string.core_reload
+        )
+
+        val ServerError = FullScreenState(
+            imageVector = Icons.Outlined.PriorityHigh,
+            titleResId = R.string.core_server_error,
+            descriptionResId = R.string.core_server_error_description,
+            actionButtonResId = R.string.core_reload
+        )
+    }
+}

--- a/core/src/main/java/org/openedx/core/ui/ComposeCommon.kt
+++ b/core/src/main/java/org/openedx/core/ui/ComposeCommon.kt
@@ -68,7 +68,6 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawWithContent
@@ -102,6 +101,9 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
@@ -120,6 +122,7 @@ import org.openedx.core.extension.tagId
 import org.openedx.core.extension.takeIfNotEmpty
 import org.openedx.core.extension.toastMessage
 import org.openedx.core.presentation.global.ErrorType
+import org.openedx.core.presentation.global.FullScreenState
 import org.openedx.core.ui.theme.OpenEdXTheme
 import org.openedx.core.ui.theme.appColors
 import org.openedx.core.ui.theme.appShapes
@@ -221,7 +224,6 @@ fun Toolbar(
     }
 }
 
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun SearchBar(
     modifier: Modifier,
@@ -321,7 +323,6 @@ fun SearchBar(
     )
 }
 
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun SearchBarStateless(
     modifier: Modifier,
@@ -1464,6 +1465,67 @@ private fun RoundTab(
     }
 }
 
+@Composable
+fun FullScreenStateView(
+    modifier: Modifier = Modifier,
+    state: FullScreenState,
+    onAction: () -> Unit = { },
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .background(MaterialTheme.appColors.background)
+            .padding(24.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Box(
+            modifier = Modifier
+                .clip(CircleShape)
+                .size(62.dp)
+                .background(MaterialTheme.appColors.primaryCardCautionBackground)
+                .padding(4.dp),
+        ) {
+            Icon(
+                modifier = Modifier
+                    .size(42.dp)
+                    .align(Alignment.Center),
+                imageVector = state.imageVector,
+                contentDescription = null,
+                tint = MaterialTheme.appColors.onSurface
+            )
+        }
+        Spacer(modifier = Modifier.height(12.dp))
+
+        Text(
+            text = stringResource(id = state.titleResId),
+            style = MaterialTheme.appTypography.titleLarge,
+            color = MaterialTheme.appColors.textPrimary,
+            textAlign = TextAlign.Center,
+        )
+        Spacer(modifier = Modifier.height(12.dp))
+
+        Text(
+            text = stringResource(id = state.descriptionResId),
+            style = MaterialTheme.appTypography.bodyLarge,
+            color = MaterialTheme.appColors.textPrimary,
+            textAlign = TextAlign.Center,
+        )
+        Spacer(modifier = Modifier.height(12.dp))
+
+        state.actionButtonResId?.let {
+            OpenEdXPrimaryButton(
+                modifier = Modifier
+                    .widthIn(Dp.Unspecified, 162.dp),
+                text = stringResource(id = it),
+                textColor = MaterialTheme.appColors.secondaryButtonText,
+                backgroundColor = MaterialTheme.appColors.secondaryButtonBackground,
+                onClick = onAction,
+            )
+        }
+    }
+}
+
 @Preview
 @Composable
 private fun StaticSearchBarPreview() {
@@ -1610,5 +1672,22 @@ private fun PreviewNoContentScreen() {
             "No Content available",
             rememberVectorPainter(image = Icons.Filled.Info)
         )
+    }
+}
+
+private class FullScreenStatePreviewParameterProvider : PreviewParameterProvider<FullScreenState> {
+    override val values = sequenceOf(
+        FullScreenState.NetworkError,
+        FullScreenState.ServerError,
+    )
+}
+
+@PreviewLightDark
+@Composable
+private fun FullScreenStatePreview(
+    @PreviewParameter(FullScreenStatePreviewParameterProvider::class) state: FullScreenState,
+) {
+    OpenEdXTheme {
+        FullScreenStateView(state = state)
     }
 }

--- a/core/src/main/java/org/openedx/core/ui/ComposeExtensions.kt
+++ b/core/src/main/java/org/openedx/core/ui/ComposeExtensions.kt
@@ -88,9 +88,39 @@ fun LazyGridState.shouldLoadMore(rememberedIndex: MutableState<Int>, threshold: 
     return false
 }
 
-fun LazyListState.shouldLoadMore(threshold: Int): Boolean {
-    val lastVisibleIndex = layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: return false
-    return lastVisibleIndex >= layoutInfo.totalItemsCount - 1 - threshold
+/**
+ * Tracks changes to both the first and last visible item indices and accounts for
+ * edge cases where all items on the current page might fit within the viewport (e.g., due to
+ * dynamic item sizes).
+ *
+ * Triggers a load when:
+ * - The first or last visible item index changes.
+ * - All items fit on the screen (e.g., due to dynamic sizes).
+ *
+ * @param rememberedFirstIndex Tracks the previous first visible item index.
+ * @param rememberedLastIndex Tracks the previous last visible item index.
+ * @param threshold Number of items from the end of the list to trigger loading.
+ * @return `true` if more items should be loaded; `false` otherwise.
+ */
+fun LazyListState.shouldLoadMore(
+    rememberedFirstIndex: MutableState<Int>,
+    rememberedLastIndex: MutableState<Int>,
+    threshold: Int
+): Boolean {
+    val firstVisibleIndex = this.firstVisibleItemIndex
+    val lastVisibleIndex = layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
+    val totalItemsCount = layoutInfo.totalItemsCount
+
+    if (
+        rememberedFirstIndex.value != firstVisibleIndex ||
+        rememberedLastIndex.value != lastVisibleIndex ||
+        (firstVisibleIndex == 0 && lastVisibleIndex == totalItemsCount - 1)
+    ) {
+        rememberedFirstIndex.value = firstVisibleIndex
+        rememberedLastIndex.value = lastVisibleIndex
+        return lastVisibleIndex >= totalItemsCount - 1 - threshold
+    }
+    return false
 }
 
 fun Modifier.statusBarsInset(): Modifier = composed {

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -77,6 +77,8 @@
     <string name="core_thank_you_dialog_negative_description">We received your feedback and will use it to help improve your learning experience going forward. Thank you for sharing!</string>
     <string name="core_no_internet_connection">No internet connection</string>
     <string name="core_no_internet_connection_description">Please connect to the internet to view this content.</string>
+    <string name="core_server_error">Server error</string>
+    <string name="core_server_error_description">Something went wrong on our end. Please try again later.</string>
     <string name="core_try_again">Try Again</string>
     <string name="core_something_went_wrong_description">Something went wrong</string>
     <string name="core_ok" tools:ignore="MissingTranslation">OK</string>

--- a/dashboard/src/main/java/org/openedx/learn/presentation/LearnViewModel.kt
+++ b/dashboard/src/main/java/org/openedx/learn/presentation/LearnViewModel.kt
@@ -78,8 +78,12 @@ class LearnViewModel(
     private fun checkNotificationCount() {
         if (config.isPushNotificationsEnabled()) {
             viewModelScope.launch(Dispatchers.IO) {
-                val unreadNotifications = pushManager.getUnreadNotificationsCount()
-                _uiState.update { it.copy(hasUnreadNotifications = unreadNotifications > 0) }
+                try {
+                    val unreadNotifications = pushManager.getUnreadNotificationsCount()
+                    _uiState.update { it.copy(hasUnreadNotifications = unreadNotifications > 0) }
+                } catch (e: Exception) {
+                    e.printStackTrace()
+                }
             }
         }
     }

--- a/notifications/src/main/java/org/openedx/notifications/presentation/inbox/InboxFullScreenState.kt
+++ b/notifications/src/main/java/org/openedx/notifications/presentation/inbox/InboxFullScreenState.kt
@@ -1,0 +1,16 @@
+package org.openedx.notifications.presentation.inbox
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Notifications
+import org.openedx.core.presentation.global.FullScreenState
+import org.openedx.notifications.R
+
+object InboxFullScreenState {
+    val Empty = FullScreenState(
+        imageVector = Icons.Outlined.Notifications,
+        titleResId = R.string.notifications_no_notifications_yet,
+        descriptionResId = R.string.notifications_no_notifications_yet_description
+    )
+    val NetworkError = FullScreenState.NetworkError
+    val ServerError = FullScreenState.ServerError
+}

--- a/notifications/src/main/java/org/openedx/notifications/presentation/inbox/InboxUIState.kt
+++ b/notifications/src/main/java/org/openedx/notifications/presentation/inbox/InboxUIState.kt
@@ -10,6 +10,7 @@ sealed class InboxUIState {
     ) : InboxUIState()
 
     data object Empty : InboxUIState()
-    data object Error : InboxUIState()
     data object Loading : InboxUIState()
+    data object NetworkError : InboxUIState()
+    data object ServerError : InboxUIState()
 }

--- a/notifications/src/main/java/org/openedx/notifications/presentation/inbox/InboxUIState.kt
+++ b/notifications/src/main/java/org/openedx/notifications/presentation/inbox/InboxUIState.kt
@@ -1,5 +1,6 @@
 package org.openedx.notifications.presentation.inbox
 
+import org.openedx.core.presentation.global.FullScreenState
 import org.openedx.notifications.domain.model.InboxSection
 import org.openedx.notifications.domain.model.NotificationItem
 
@@ -9,8 +10,9 @@ sealed class InboxUIState {
         val notifications: Map<InboxSection, List<NotificationItem>>,
     ) : InboxUIState()
 
-    data object Empty : InboxUIState()
     data object Loading : InboxUIState()
-    data object NetworkError : InboxUIState()
-    data object ServerError : InboxUIState()
+
+    data class Fallback(
+        val state: FullScreenState,
+    ) : InboxUIState()
 }

--- a/notifications/src/main/java/org/openedx/notifications/presentation/inbox/NotificationsInboxFragment.kt
+++ b/notifications/src/main/java/org/openedx/notifications/presentation/inbox/NotificationsInboxFragment.kt
@@ -33,9 +33,6 @@ import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.outlined.Forum
-import androidx.compose.material.icons.outlined.Notifications
-import androidx.compose.material.icons.outlined.PriorityHigh
-import androidx.compose.material.icons.outlined.SignalWifiStatusbarConnectedNoInternet4
 import androidx.compose.material.pullrefresh.PullRefreshIndicator
 import androidx.compose.material.pullrefresh.pullRefresh
 import androidx.compose.material.pullrefresh.rememberPullRefreshState
@@ -67,8 +64,8 @@ import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.openedx.core.UIMessage
 import org.openedx.core.extension.isNull
 import org.openedx.core.ui.BackBtn
+import org.openedx.core.ui.FullScreenStateView
 import org.openedx.core.ui.HandleUIMessage
-import org.openedx.core.ui.OpenEdXPrimaryButton
 import org.openedx.core.ui.WindowSize
 import org.openedx.core.ui.WindowType
 import org.openedx.core.ui.crop
@@ -87,7 +84,6 @@ import org.openedx.notifications.domain.model.NotificationContent
 import org.openedx.notifications.domain.model.NotificationItem
 import org.openedx.notifications.utils.TextUtils
 import java.util.Date
-import org.openedx.core.R as coreR
 
 class NotificationsInboxFragment : Fragment() {
 
@@ -291,23 +287,10 @@ private fun InboxView(
                             }
                         }
 
-                        is InboxUIState.Empty -> {
-                            InboxStateView(
-                                uiState = InboxUIState.Empty,
-                            )
-                        }
-
-                        is InboxUIState.NetworkError -> {
-                            InboxStateView(
-                                uiState = InboxUIState.NetworkError,
-                                onReloadNotifications = onReloadNotifications
-                            )
-                        }
-
-                        is InboxUIState.ServerError -> {
-                            InboxStateView(
-                                uiState = InboxUIState.ServerError,
-                                onReloadNotifications = onReloadNotifications
+                        is InboxUIState.Fallback -> {
+                            FullScreenStateView(
+                                state = uiState.state,
+                                onAction = onReloadNotifications,
                             )
                         }
                     }
@@ -487,85 +470,6 @@ private fun NotificationItemView(
     }
 }
 
-@Composable
-private fun InboxStateView(
-    modifier: Modifier = Modifier,
-    uiState: InboxUIState,
-    onReloadNotifications: () -> Unit = { },
-) {
-    val iconResId = when (uiState) {
-        InboxUIState.Empty -> Icons.Outlined.Notifications
-        InboxUIState.NetworkError -> Icons.Outlined.SignalWifiStatusbarConnectedNoInternet4
-        InboxUIState.ServerError -> Icons.Outlined.PriorityHigh
-        else -> return
-    }
-
-    val titleResId = when (uiState) {
-        InboxUIState.Empty -> R.string.notifications_no_notifications_yet
-        InboxUIState.NetworkError -> coreR.string.core_no_internet_connection
-        InboxUIState.ServerError -> coreR.string.core_server_error
-        else -> return
-    }
-
-    val descriptionResId = when (uiState) {
-        InboxUIState.Empty -> R.string.notifications_no_notifications_yet_description
-        InboxUIState.NetworkError -> coreR.string.core_no_internet_connection_description
-        InboxUIState.ServerError -> coreR.string.core_server_error_description
-        else -> return
-    }
-
-    Column(
-        modifier = modifier.fillMaxSize().padding(24.dp),
-        verticalArrangement = Arrangement.Center,
-        horizontalAlignment = Alignment.CenterHorizontally,
-    ) {
-        Box(
-            modifier = Modifier
-                .clip(CircleShape)
-                .size(62.dp)
-                .background(MaterialTheme.appColors.primaryCardCautionBackground)
-                .padding(4.dp),
-        ) {
-            Icon(
-                modifier = Modifier
-                    .size(42.dp)
-                    .align(Alignment.Center),
-                imageVector = iconResId,
-                contentDescription = null,
-                tint = MaterialTheme.appColors.onSurface
-            )
-        }
-        Spacer(modifier = Modifier.height(12.dp))
-
-        Text(
-            text = stringResource(titleResId),
-            style = MaterialTheme.appTypography.titleLarge,
-            color = MaterialTheme.appColors.textPrimary,
-            textAlign = TextAlign.Center,
-        )
-        Spacer(modifier = Modifier.height(12.dp))
-
-        Text(
-            text = stringResource(descriptionResId),
-            style = MaterialTheme.appTypography.bodyLarge,
-            color = MaterialTheme.appColors.textPrimary,
-            textAlign = TextAlign.Center,
-        )
-        Spacer(modifier = Modifier.height(12.dp))
-
-        if (uiState is InboxUIState.NetworkError || uiState is InboxUIState.ServerError) {
-            OpenEdXPrimaryButton(
-                modifier = Modifier
-                    .widthIn(Dp.Unspecified, 162.dp),
-                text = stringResource(id = coreR.string.core_reload),
-                textColor = MaterialTheme.appColors.secondaryButtonText,
-                backgroundColor = MaterialTheme.appColors.secondaryButtonBackground,
-                onClick = onReloadNotifications,
-            )
-        }
-    }
-}
-
 @PreviewLightDark
 @Composable
 private fun InboxPreview(
@@ -627,8 +531,8 @@ private class InboxUiStatePreviewParameterProvider : PreviewParameterProvider<In
                 )
             )
         ),
-        InboxUIState.Empty,
-        InboxUIState.NetworkError,
-        InboxUIState.ServerError,
+        InboxUIState.Fallback(state = InboxFullScreenState.Empty),
+        InboxUIState.Fallback(state = InboxFullScreenState.NetworkError),
+        InboxUIState.Fallback(state = InboxFullScreenState.ServerError),
     )
 }

--- a/notifications/src/main/java/org/openedx/notifications/presentation/inbox/NotificationsInboxFragment.kt
+++ b/notifications/src/main/java/org/openedx/notifications/presentation/inbox/NotificationsInboxFragment.kt
@@ -186,6 +186,12 @@ private fun InboxView(
         refreshing = refreshing,
         onRefresh = { onSwipeRefresh() },
     )
+    val firstVisibleIndex = remember {
+        mutableStateOf(scrollState.firstVisibleItemIndex)
+    }
+    val lastVisibleIndex = remember {
+        mutableStateOf(scrollState.firstVisibleItemIndex)
+    }
     val loadMoreTriggerThreshold = 4
 
     Scaffold(
@@ -253,7 +259,9 @@ private fun InboxView(
                                 if (canLoadMore) {
                                     item {
                                         Box(
-                                            modifier = Modifier.fillMaxWidth(),
+                                            modifier = Modifier
+                                                .fillMaxWidth()
+                                                .padding(bottom = 8.dp),
                                             contentAlignment = Alignment.Center
                                         ) {
                                             CircularProgressIndicator(color = MaterialTheme.appColors.primary)
@@ -261,7 +269,12 @@ private fun InboxView(
                                     }
                                 }
 
-                                if (scrollState.shouldLoadMore(loadMoreTriggerThreshold)) {
+                                if (scrollState.shouldLoadMore(
+                                        rememberedFirstIndex = firstVisibleIndex,
+                                        rememberedLastIndex = lastVisibleIndex,
+                                        threshold = loadMoreTriggerThreshold
+                                    )
+                                ) {
                                     paginationCallBack()
                                 }
                             }

--- a/notifications/src/main/java/org/openedx/notifications/presentation/inbox/NotificationsInboxFragment.kt
+++ b/notifications/src/main/java/org/openedx/notifications/presentation/inbox/NotificationsInboxFragment.kt
@@ -128,7 +128,7 @@ class NotificationsInboxFragment : Fragment() {
                         }
                     },
                     onSwipeRefresh = {
-                        viewModel.updateNotifications()
+                        viewModel.onRefreshNotifications()
                     },
                     onReloadNotifications = {
                         viewModel.onReloadNotifications()
@@ -515,7 +515,7 @@ private fun InboxStateView(
     }
 
     Column(
-        modifier = modifier.fillMaxSize(),
+        modifier = modifier.fillMaxSize().padding(24.dp),
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {

--- a/notifications/src/main/java/org/openedx/notifications/presentation/inbox/NotificationsInboxFragment.kt
+++ b/notifications/src/main/java/org/openedx/notifications/presentation/inbox/NotificationsInboxFragment.kt
@@ -34,6 +34,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.outlined.Forum
 import androidx.compose.material.icons.outlined.Notifications
+import androidx.compose.material.icons.outlined.PriorityHigh
 import androidx.compose.material.icons.outlined.SignalWifiStatusbarConnectedNoInternet4
 import androidx.compose.material.pullrefresh.PullRefreshIndicator
 import androidx.compose.material.pullrefresh.pullRefresh
@@ -42,6 +43,7 @@ import androidx.compose.material.rememberScaffoldState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -187,10 +189,10 @@ private fun InboxView(
         onRefresh = { onSwipeRefresh() },
     )
     val firstVisibleIndex = remember {
-        mutableStateOf(scrollState.firstVisibleItemIndex)
+        mutableIntStateOf(scrollState.firstVisibleItemIndex)
     }
     val lastVisibleIndex = remember {
-        mutableStateOf(scrollState.firstVisibleItemIndex)
+        mutableIntStateOf(scrollState.firstVisibleItemIndex)
     }
     val loadMoreTriggerThreshold = 4
 
@@ -295,9 +297,16 @@ private fun InboxView(
                             )
                         }
 
-                        is InboxUIState.Error -> {
+                        is InboxUIState.NetworkError -> {
                             InboxStateView(
-                                uiState = InboxUIState.Error,
+                                uiState = InboxUIState.NetworkError,
+                                onReloadNotifications = onReloadNotifications
+                            )
+                        }
+
+                        is InboxUIState.ServerError -> {
+                            InboxStateView(
+                                uiState = InboxUIState.ServerError,
                                 onReloadNotifications = onReloadNotifications
                             )
                         }
@@ -484,15 +493,26 @@ private fun InboxStateView(
     uiState: InboxUIState,
     onReloadNotifications: () -> Unit = { },
 ) {
-    val iconResId = if (uiState is InboxUIState.Empty) Icons.Outlined.Notifications
-    else Icons.Outlined.SignalWifiStatusbarConnectedNoInternet4
+    val iconResId = when (uiState) {
+        InboxUIState.Empty -> Icons.Outlined.Notifications
+        InboxUIState.NetworkError -> Icons.Outlined.SignalWifiStatusbarConnectedNoInternet4
+        InboxUIState.ServerError -> Icons.Outlined.PriorityHigh
+        else -> return
+    }
 
-    val titleResId = if (uiState is InboxUIState.Empty) R.string.notifications_no_notifications_yet
-    else coreR.string.core_no_internet_connection
+    val titleResId = when (uiState) {
+        InboxUIState.Empty -> R.string.notifications_no_notifications_yet
+        InboxUIState.NetworkError -> coreR.string.core_no_internet_connection
+        InboxUIState.ServerError -> coreR.string.core_server_error
+        else -> return
+    }
 
-    val descriptionResId =
-        if (uiState is InboxUIState.Empty) R.string.notifications_no_notifications_yet_description
-        else coreR.string.core_no_internet_connection_description
+    val descriptionResId = when (uiState) {
+        InboxUIState.Empty -> R.string.notifications_no_notifications_yet_description
+        InboxUIState.NetworkError -> coreR.string.core_no_internet_connection_description
+        InboxUIState.ServerError -> coreR.string.core_server_error_description
+        else -> return
+    }
 
     Column(
         modifier = modifier.fillMaxSize(),
@@ -533,7 +553,7 @@ private fun InboxStateView(
         )
         Spacer(modifier = Modifier.height(12.dp))
 
-        if (uiState is InboxUIState.Error) {
+        if (uiState is InboxUIState.NetworkError || uiState is InboxUIState.ServerError) {
             OpenEdXPrimaryButton(
                 modifier = Modifier
                     .widthIn(Dp.Unspecified, 162.dp),
@@ -608,6 +628,7 @@ private class InboxUiStatePreviewParameterProvider : PreviewParameterProvider<In
             )
         ),
         InboxUIState.Empty,
-        InboxUIState.Error
+        InboxUIState.NetworkError,
+        InboxUIState.ServerError,
     )
 }

--- a/notifications/src/main/java/org/openedx/notifications/presentation/inbox/NotificationsInboxFragment.kt
+++ b/notifications/src/main/java/org/openedx/notifications/presentation/inbox/NotificationsInboxFragment.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.DropdownMenu
 import androidx.compose.material.DropdownMenuItem
+import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
@@ -34,6 +35,9 @@ import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.outlined.Forum
 import androidx.compose.material.icons.outlined.Notifications
 import androidx.compose.material.icons.outlined.SignalWifiStatusbarConnectedNoInternet4
+import androidx.compose.material.pullrefresh.PullRefreshIndicator
+import androidx.compose.material.pullrefresh.pullRefresh
+import androidx.compose.material.pullrefresh.rememberPullRefreshState
 import androidx.compose.material.rememberScaffoldState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -99,11 +103,13 @@ class NotificationsInboxFragment : Fragment() {
                 val uiState by viewModel.uiState.collectAsState()
                 val uiMessage by viewModel.uiMessage.collectAsState(null)
                 val canLoadMore by viewModel.canLoadMore.collectAsState()
+                val refreshing by viewModel.isRefreshing.collectAsState()
 
                 InboxView(
                     windowSize = windowSize,
                     uiState = uiState,
                     uiMessage = uiMessage,
+                    refreshing = refreshing,
                     canLoadMore = canLoadMore,
                     onBackClick = {
                         requireActivity().supportFragmentManager.popBackStack()
@@ -118,6 +124,9 @@ class NotificationsInboxFragment : Fragment() {
                                 viewModel.navigateToPushNotificationsSettings(requireActivity().supportFragmentManager)
                             }
                         }
+                    },
+                    onSwipeRefresh = {
+                        viewModel.updateNotifications()
                     },
                     onReloadNotifications = {
                         viewModel.onReloadNotifications()
@@ -137,14 +146,17 @@ class NotificationsInboxFragment : Fragment() {
     }
 }
 
+@OptIn(ExperimentalMaterialApi::class)
 @Composable
 private fun InboxView(
     windowSize: WindowSize,
     uiState: InboxUIState,
     uiMessage: UIMessage?,
     canLoadMore: Boolean,
+    refreshing: Boolean,
     onBackClick: () -> Unit,
     onSettingsClick: (NotificationsMenuType) -> Unit,
+    onSwipeRefresh: () -> Unit,
     onReloadNotifications: () -> Unit,
     paginationCallBack: () -> Unit,
     markNotificationAsRead: (notificationItem: NotificationItem, inboxSection: InboxSection) -> Unit,
@@ -170,6 +182,10 @@ private fun InboxView(
             )
         )
     }
+    val pullRefreshState = rememberPullRefreshState(
+        refreshing = refreshing,
+        onRefresh = { onSwipeRefresh() },
+    )
     val loadMoreTriggerThreshold = 4
 
     Scaffold(
@@ -197,78 +213,88 @@ private fun InboxView(
             )
 
             Surface(
-                modifier = contentWidth,
                 color = MaterialTheme.appColors.background
             ) {
-                when (uiState) {
-                    is InboxUIState.Data -> {
-                        LazyColumn(
-                            Modifier
-                                .weight(1f)
-                                .background(MaterialTheme.appColors.background),
-                            state = scrollState,
-                        ) {
-                            uiState.notifications.forEach { (section, items) ->
-                                if (items.isNotEmpty()) {
-                                    item {
-                                        SectionHeader(
-                                            section = section,
-                                        )
-                                    }
+                Box(
+                    modifier = Modifier.pullRefresh(pullRefreshState),
+                    contentAlignment = Alignment.TopCenter
+                ) {
+                    when (uiState) {
+                        is InboxUIState.Data -> {
+                            LazyColumn(
+                                modifier = Modifier
+                                    .background(MaterialTheme.appColors.background)
+                                    .then(contentWidth),
+                                state = scrollState,
+                            ) {
+                                uiState.notifications.forEach { (section, items) ->
+                                    if (items.isNotEmpty()) {
+                                        item {
+                                            SectionHeader(
+                                                section = section,
+                                            )
+                                        }
 
-                                    items(items) { item ->
-                                        NotificationItemView(
-                                            modifier = Modifier.clickable {
-                                                markNotificationAsRead(item, section)
-                                            },
-                                            item = item,
-                                        )
-                                    }
+                                        items(items) { item ->
+                                            NotificationItemView(
+                                                modifier = Modifier.clickable {
+                                                    markNotificationAsRead(item, section)
+                                                },
+                                                item = item,
+                                            )
+                                        }
 
-                                    item {
-                                        Spacer(Modifier.height(24.dp))
-                                    }
-                                }
-                            }
-
-                            if (canLoadMore) {
-                                item {
-                                    Box(
-                                        modifier = Modifier.fillMaxWidth(),
-                                        contentAlignment = Alignment.Center
-                                    ) {
-                                        CircularProgressIndicator(color = MaterialTheme.appColors.primary)
+                                        item {
+                                            Spacer(Modifier.height(24.dp))
+                                        }
                                     }
                                 }
-                            }
 
-                            if (scrollState.shouldLoadMore(loadMoreTriggerThreshold)) {
-                                paginationCallBack()
+                                if (canLoadMore) {
+                                    item {
+                                        Box(
+                                            modifier = Modifier.fillMaxWidth(),
+                                            contentAlignment = Alignment.Center
+                                        ) {
+                                            CircularProgressIndicator(color = MaterialTheme.appColors.primary)
+                                        }
+                                    }
+                                }
+
+                                if (scrollState.shouldLoadMore(loadMoreTriggerThreshold)) {
+                                    paginationCallBack()
+                                }
                             }
+                        }
+
+                        is InboxUIState.Loading -> {
+                            Box(
+                                modifier = Modifier.fillMaxSize(),
+                                contentAlignment = Alignment.Center,
+                            ) {
+                                CircularProgressIndicator(color = MaterialTheme.appColors.primary)
+                            }
+                        }
+
+                        is InboxUIState.Empty -> {
+                            InboxStateView(
+                                uiState = InboxUIState.Empty,
+                            )
+                        }
+
+                        is InboxUIState.Error -> {
+                            InboxStateView(
+                                uiState = InboxUIState.Error,
+                                onReloadNotifications = onReloadNotifications
+                            )
                         }
                     }
 
-                    is InboxUIState.Loading -> {
-                        Box(
-                            modifier = Modifier.fillMaxSize(),
-                            contentAlignment = Alignment.Center,
-                        ) {
-                            CircularProgressIndicator(color = MaterialTheme.appColors.primary)
-                        }
-                    }
-
-                    is InboxUIState.Empty -> {
-                        InboxStateView(
-                            uiState = InboxUIState.Empty,
-                        )
-                    }
-
-                    is InboxUIState.Error -> {
-                        InboxStateView(
-                            uiState = InboxUIState.Error,
-                            onReloadNotifications = onReloadNotifications
-                        )
-                    }
+                    PullRefreshIndicator(
+                        refreshing,
+                        pullRefreshState,
+                        Modifier.align(Alignment.TopCenter)
+                    )
                 }
             }
         }
@@ -518,8 +544,10 @@ private fun InboxPreview(
             uiState = uiState,
             uiMessage = null,
             canLoadMore = true,
+            refreshing = true,
             onBackClick = { },
             onSettingsClick = { },
+            onSwipeRefresh = { },
             onReloadNotifications = { },
             paginationCallBack = { },
             markNotificationAsRead = { _, _ -> },

--- a/notifications/src/main/java/org/openedx/notifications/presentation/inbox/NotificationsInboxViewModel.kt
+++ b/notifications/src/main/java/org/openedx/notifications/presentation/inbox/NotificationsInboxViewModel.kt
@@ -10,7 +10,6 @@ import kotlinx.coroutines.launch
 import org.openedx.core.BaseViewModel
 import org.openedx.core.UIMessage
 import org.openedx.core.extension.isInternetError
-import org.openedx.core.presentation.global.FullScreenState
 import org.openedx.core.system.ResourceManager
 import org.openedx.notifications.domain.interactor.NotificationsInteractor
 import org.openedx.notifications.domain.model.InboxSection
@@ -101,9 +100,10 @@ class NotificationsInboxViewModel(
                 if (uiState.value is InboxUIState.Data || _isRefreshing.value) {
                     emitErrorMessage(e)
                 } else if (e.isInternetError()) {
-                    _uiState.value = InboxUIState.Fallback(state = FullScreenState.NetworkError)
+                    _uiState.value =
+                        InboxUIState.Fallback(state = InboxFullScreenState.NetworkError)
                 } else {
-                    _uiState.value = InboxUIState.Fallback(state = FullScreenState.ServerError)
+                    _uiState.value = InboxUIState.Fallback(state = InboxFullScreenState.ServerError)
                 }
             } finally {
                 isLoading = false

--- a/notifications/src/main/java/org/openedx/notifications/presentation/inbox/NotificationsInboxViewModel.kt
+++ b/notifications/src/main/java/org/openedx/notifications/presentation/inbox/NotificationsInboxViewModel.kt
@@ -99,8 +99,10 @@ class NotificationsInboxViewModel(
             } catch (e: Exception) {
                 if (uiState.value is InboxUIState.Data || _isRefreshing.value) {
                     emitErrorMessage(e)
+                } else if (e.isInternetError()) {
+                    _uiState.value = InboxUIState.NetworkError
                 } else {
-                    _uiState.value = InboxUIState.Error
+                    _uiState.value = InboxUIState.ServerError
                 }
             } finally {
                 isLoading = false

--- a/notifications/src/main/java/org/openedx/notifications/presentation/inbox/NotificationsInboxViewModel.kt
+++ b/notifications/src/main/java/org/openedx/notifications/presentation/inbox/NotificationsInboxViewModel.kt
@@ -97,10 +97,8 @@ class NotificationsInboxViewModel(
                     InboxUIState.Empty
                 }
             } catch (e: Exception) {
-                if (_isRefreshing.value) {
+                if (uiState.value is InboxUIState.Data || _isRefreshing.value) {
                     emitErrorMessage(e)
-                } else if (nextPage > 1) {
-                    _canLoadMore.value = true
                 } else {
                     _uiState.value = InboxUIState.Error
                 }

--- a/notifications/src/main/java/org/openedx/notifications/presentation/inbox/NotificationsInboxViewModel.kt
+++ b/notifications/src/main/java/org/openedx/notifications/presentation/inbox/NotificationsInboxViewModel.kt
@@ -67,7 +67,7 @@ class NotificationsInboxViewModel(
     }
 
     fun fetchMore() {
-        if (!isLoading && nextPage != -1) {
+        if (!isLoading && _canLoadMore.value) {
             internalLoadNotifications()
         }
     }
@@ -117,7 +117,7 @@ class NotificationsInboxViewModel(
         internalLoadNotifications()
     }
 
-    fun updateNotifications() {
+    fun onRefreshNotifications() {
         _isRefreshing.value = true
         nextPage = 1
         InboxSection.entries.forEach { section ->

--- a/notifications/src/main/java/org/openedx/notifications/presentation/inbox/NotificationsInboxViewModel.kt
+++ b/notifications/src/main/java/org/openedx/notifications/presentation/inbox/NotificationsInboxViewModel.kt
@@ -33,6 +33,9 @@ class NotificationsInboxViewModel(
     private val _canLoadMore = MutableStateFlow(true)
     val canLoadMore = _canLoadMore.asStateFlow()
 
+    private val _isRefreshing = MutableStateFlow(false)
+    val isRefreshing = _isRefreshing.asStateFlow()
+
     private val notifications: MutableMap<InboxSection, MutableList<NotificationItem>> =
         mutableMapOf(
             InboxSection.RECENT to mutableListOf(),
@@ -89,18 +92,21 @@ class NotificationsInboxViewModel(
 
                 // Update the UI state based on whether any notifications exist
                 _uiState.value = if (notifications.values.any { it.isNotEmpty() }) {
-                    InboxUIState.Data(notifications = notifications)
+                    InboxUIState.Data(notifications = notifications.toMap())
                 } else {
                     InboxUIState.Empty
                 }
             } catch (e: Exception) {
-                if (nextPage == 1) {
-                    _uiState.value = InboxUIState.Error
-                } else {
+                if (_isRefreshing.value) {
+                    emitErrorMessage(e)
+                } else if (nextPage > 1) {
                     _canLoadMore.value = true
+                } else {
+                    _uiState.value = InboxUIState.Error
                 }
             } finally {
                 isLoading = false
+                _isRefreshing.value = false
             }
         }
     }
@@ -108,6 +114,15 @@ class NotificationsInboxViewModel(
     fun onReloadNotifications() {
         _canLoadMore.value = true
         nextPage = 1
+        internalLoadNotifications()
+    }
+
+    fun updateNotifications() {
+        _isRefreshing.value = true
+        nextPage = 1
+        InboxSection.entries.forEach { section ->
+            notifications[section] = mutableListOf()
+        }
         internalLoadNotifications()
     }
 

--- a/notifications/src/main/java/org/openedx/notifications/presentation/inbox/NotificationsInboxViewModel.kt
+++ b/notifications/src/main/java/org/openedx/notifications/presentation/inbox/NotificationsInboxViewModel.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.launch
 import org.openedx.core.BaseViewModel
 import org.openedx.core.UIMessage
 import org.openedx.core.extension.isInternetError
+import org.openedx.core.presentation.global.FullScreenState
 import org.openedx.core.system.ResourceManager
 import org.openedx.notifications.domain.interactor.NotificationsInteractor
 import org.openedx.notifications.domain.model.InboxSection
@@ -94,15 +95,15 @@ class NotificationsInboxViewModel(
                 _uiState.value = if (notifications.values.any { it.isNotEmpty() }) {
                     InboxUIState.Data(notifications = notifications.toMap())
                 } else {
-                    InboxUIState.Empty
+                    InboxUIState.Fallback(state = InboxFullScreenState.Empty)
                 }
             } catch (e: Exception) {
                 if (uiState.value is InboxUIState.Data || _isRefreshing.value) {
                     emitErrorMessage(e)
                 } else if (e.isInternetError()) {
-                    _uiState.value = InboxUIState.NetworkError
+                    _uiState.value = InboxUIState.Fallback(state = FullScreenState.NetworkError)
                 } else {
-                    _uiState.value = InboxUIState.ServerError
+                    _uiState.value = InboxUIState.Fallback(state = FullScreenState.ServerError)
                 }
             } finally {
                 isLoading = false


### PR DESCRIPTION
### Description

[LEARNER-10364](https://2u-internal.atlassian.net/browse/LEARNER-10364)

- **Optimized Infinite Scrolling:**  
  - Checks if more items should be loaded in the LazyList based on visible indices and dynamic item sizes.  
  - Triggers loading when visible item indices change or all items fit on the screen.  

- **Swipe-to-Refresh Implementation:**  
  - Added pull-to-refresh functionality to the Notifications Inbox screen for seamless updates.  
  - On pull-to-refresh, retain existing notifications until new data is fetched successfully. Show an **error message toast** if the fetch fails.

- **UI States and Messages:**  
    - No error message when unable to fetch notifications count or mark notifications as seen (background operations).  
    - Show the **empty state** when there are no notifications.  
    - Show the **Network error state** when fetching the very first page fails due to network problems.
    - Show the **Server error state** when fetching the very first page fails due to an issue on the server.
    - On a second-page fetch error, show a **circular progress bar** at the bottom of the list and an **error message toast**.  
    - On "mark as read" or "mark all as read" failure, show an **error message toast**. 