### PR TITLE
fix: black screen in ExoPlayer on rotate

### DIFF
--- a/app/src/main/java/org/openedx/app/AppRouter.kt
+++ b/app/src/main/java/org/openedx/app/AppRouter.kt
@@ -22,7 +22,6 @@ import org.openedx.course.presentation.handouts.HandoutsType
 import org.openedx.course.presentation.handouts.HandoutsWebViewFragment
 import org.openedx.course.presentation.section.CourseSectionFragment
 import org.openedx.course.presentation.unit.container.CourseUnitContainerFragment
-import org.openedx.course.presentation.unit.video.VideoFullScreenFragment
 import org.openedx.course.presentation.unit.video.YoutubeVideoFullScreenFragment
 import org.openedx.course.settings.download.DownloadQueueFragment
 import org.openedx.courses.presentation.AllEnrolledCoursesFragment
@@ -267,30 +266,6 @@ class AppRouter : AuthRouter, DiscoveryRouter, DashboardRouter, CourseRouter, Di
                 mode = mode
             ),
             FragmentTransaction.TRANSIT_FRAGMENT_FADE
-        )
-    }
-
-    override fun navigateToFullScreenVideo(
-        fm: FragmentManager,
-        videoUrl: String,
-        videoTime: Long,
-        videoDuration: Long,
-        blockId: String,
-        courseId: String,
-        isPlaying: Boolean,
-        transcripts: Map<String, String>,
-    ) {
-        replaceFragmentWithBackStack(
-            fm,
-            VideoFullScreenFragment.newInstance(
-                videoUrl = videoUrl,
-                videoTime = videoTime,
-                videoDuration = videoDuration,
-                blockId = blockId,
-                courseId = courseId,
-                isPlaying = isPlaying,
-                transcripts = transcripts,
-            )
         )
     }
 

--- a/course/src/main/java/org/openedx/course/presentation/CourseRouter.kt
+++ b/course/src/main/java/org/openedx/course/presentation/CourseRouter.kt
@@ -37,17 +37,6 @@ interface CourseRouter {
         mode: CourseViewMode
     )
 
-    fun navigateToFullScreenVideo(
-        fm: FragmentManager,
-        videoUrl: String,
-        videoTime: Long,
-        videoDuration: Long,
-        blockId: String,
-        courseId: String,
-        isPlaying: Boolean,
-        transcripts: Map<String, String>
-    )
-
     fun navigateToFullScreenYoutubeVideo(
         fm: FragmentManager,
         videoUrl: String,

--- a/course/src/main/java/org/openedx/course/presentation/unit/video/EncodedVideoUnitViewModel.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/video/EncodedVideoUnitViewModel.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.media3.cast.CastPlayer
 import androidx.media3.common.C
 import androidx.media3.common.MediaItem
+import androidx.media3.common.MediaMetadata
 import androidx.media3.common.MimeTypes
 import androidx.media3.common.PlaybackParameters
 import androidx.media3.common.Player
@@ -74,8 +75,9 @@ class EncodedVideoUnitViewModel(
 
     var isPlayerSetUp = false
 
-    var selectedLanguage: String = ""
-    val subtitleConfigurations: List<MediaItem.SubtitleConfiguration>
+    var selectedLanguage: String = transcriptLanguage
+
+    private val subtitleConfigurations: List<MediaItem.SubtitleConfiguration>
         get() = transcripts
             .toSortedMap(
                 compareBy { LocaleUtils.getLanguageByLanguageCode(it) }
@@ -90,6 +92,10 @@ class EncodedVideoUnitViewModel(
                     .setLanguage(language)
                     .build()
             }
+
+    private val movieMetadata = MediaMetadata.Builder()
+        .setMediaType(MediaMetadata.MEDIA_TYPE_MOVIE)
+        .build()
 
     private val exoPlayerListener = object : Player.Listener {
 
@@ -215,12 +221,21 @@ class EncodedVideoUnitViewModel(
         logVideoLoadedEvent(videoUrl)
     }
 
-    fun applyPlayerMedia(mediaItem: MediaItem) {
+    fun applyPlayerMedia() {
         if (!isPlayerSetUp) {
-            setPlayerMedia(mediaItem)
+            setPlayerMedia(getMediaItem())
             getActivePlayer()?.prepare()
             isPlayerSetUp = true
         }
+    }
+
+    fun getMediaItem() = MediaItem.Builder().setMediaMetadata(movieMetadata)
+        .setUri(videoUrl)
+        .setSubtitleConfigurations(subtitleConfigurations)
+        .build()
+
+    fun updated() {
+        _isUpdated.value = true
     }
 
     @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)

--- a/course/src/main/java/org/openedx/course/presentation/unit/video/EncodedVideoUnitViewModel.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/video/EncodedVideoUnitViewModel.kt
@@ -6,6 +6,8 @@ import android.net.Uri
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.asFlow
+import androidx.lifecycle.viewModelScope
 import androidx.media3.cast.CastPlayer
 import androidx.media3.common.C
 import androidx.media3.common.MediaItem
@@ -15,6 +17,7 @@ import androidx.media3.common.PlaybackParameters
 import androidx.media3.common.Player
 import androidx.media3.common.Tracks
 import androidx.media3.common.util.Clock
+import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.DefaultDataSource
 import androidx.media3.exoplayer.DefaultLoadControl
 import androidx.media3.exoplayer.DefaultRenderersFactory
@@ -27,6 +30,9 @@ import androidx.media3.exoplayer.trackselection.DefaultTrackSelector
 import androidx.media3.exoplayer.upstream.DefaultBandwidthMeter
 import androidx.media3.extractor.DefaultExtractorsFactory
 import com.google.android.gms.cast.framework.CastContext
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.mapNotNull
 import org.openedx.core.data.storage.CorePreferences
 import org.openedx.core.domain.model.VideoPlaybackSpeed
 import org.openedx.core.domain.model.VideoQuality
@@ -75,7 +81,17 @@ class EncodedVideoUnitViewModel(
 
     var isPlayerSetUp = false
 
-    var selectedLanguage: String = transcriptLanguage
+    var selectedLanguage: String = ""
+
+    @UnstableApi
+    val onTranscriptLoaded = transcriptObject.asFlow().distinctUntilChanged().mapNotNull {
+        exoPlayer?.currentMediaItem?.buildUpon()
+            ?.setSubtitleConfigurations(subtitleConfigurations)?.build()
+            ?.let { mediaItem ->
+                exoPlayer?.clearMediaItems()
+                exoPlayer?.addMediaItem(mediaItem)
+            }
+    }.launchIn(viewModelScope)
 
     private val subtitleConfigurations: List<MediaItem.SubtitleConfiguration>
         get() = transcripts
@@ -143,7 +159,7 @@ class EncodedVideoUnitViewModel(
         }
     }
 
-    @androidx.media3.common.util.UnstableApi
+    @UnstableApi
     override fun onCreate(owner: LifecycleOwner) {
         super.onCreate(owner)
         if (exoPlayer != null) {
@@ -183,7 +199,7 @@ class EncodedVideoUnitViewModel(
         }
     }
 
-    @androidx.media3.common.util.UnstableApi
+    @UnstableApi
     fun releasePlayers() {
         exoPlayer?.release()
         castPlayer?.release()
@@ -191,22 +207,9 @@ class EncodedVideoUnitViewModel(
         castPlayer = null
     }
 
-    @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
+    @UnstableApi
     fun initPlayer() {
-        val videoQuality = getVideoQuality()
-        val params = DefaultTrackSelector.Parameters.Builder(context)
-            .apply {
-                if (videoQuality != VideoQuality.AUTO) {
-                    setMaxVideoSize(videoQuality.width, videoQuality.height)
-                    setViewportSize(videoQuality.width, videoQuality.height, false)
-                }
-            }
-            .build()
-
-        val factory = AdaptiveTrackSelection.Factory()
-        val selector = DefaultTrackSelector(context, factory)
-        selector.parameters = params
-
+        val selector = applyTrackSelector(isSubtitlesDisabled = true)
         exoPlayer = ExoPlayer.Builder(
             context,
             DefaultRenderersFactory(context),
@@ -221,6 +224,27 @@ class EncodedVideoUnitViewModel(
         logVideoLoadedEvent(videoUrl)
     }
 
+    @UnstableApi
+    private fun applyTrackSelector(isSubtitlesDisabled: Boolean): DefaultTrackSelector {
+        val videoQuality = getVideoQuality()
+        val params = DefaultTrackSelector.Parameters.Builder(context)
+            .apply {
+                if (videoQuality != VideoQuality.AUTO) {
+                    setMaxVideoSize(videoQuality.width, videoQuality.height)
+                    setViewportSize(videoQuality.width, videoQuality.height, false)
+                }
+            }
+            .setRendererDisabled(C.TRACK_TYPE_TEXT, isSubtitlesDisabled)
+            .build()
+
+        val factory = AdaptiveTrackSelection.Factory()
+        val selector = DefaultTrackSelector(context, factory)
+        selector.parameters = params
+        exoPlayer?.trackSelectionParameters = params
+        return selector
+    }
+
+    @UnstableApi
     fun applyPlayerMedia() {
         if (!isPlayerSetUp) {
             setPlayerMedia(getMediaItem())
@@ -231,14 +255,20 @@ class EncodedVideoUnitViewModel(
 
     fun getMediaItem() = MediaItem.Builder().setMediaMetadata(movieMetadata)
         .setUri(videoUrl)
-        .setSubtitleConfigurations(subtitleConfigurations)
         .build()
 
-    fun updated() {
+    @UnstableApi
+    fun enterFullscreen() {
+        applyTrackSelector(isSubtitlesDisabled = false)
+    }
+
+    @UnstableApi
+    fun leaveFullscreen() {
+        applyTrackSelector(isSubtitlesDisabled = true)
         _isUpdated.value = true
     }
 
-    @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
+    @UnstableApi
     private fun setPlayerMedia(mediaItem: MediaItem) {
         if (videoUrl.endsWith(HLS_EXT)) {
             val factory = DefaultDataSource.Factory(context)

--- a/course/src/main/java/org/openedx/course/presentation/unit/video/EncodedVideoUnitViewModel.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/video/EncodedVideoUnitViewModel.kt
@@ -4,8 +4,6 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.net.Uri
 import androidx.lifecycle.LifecycleOwner
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.asFlow
 import androidx.lifecycle.viewModelScope
 import androidx.media3.cast.CastPlayer
@@ -30,9 +28,12 @@ import androidx.media3.exoplayer.trackselection.DefaultTrackSelector
 import androidx.media3.exoplayer.upstream.DefaultBandwidthMeter
 import androidx.media3.extractor.DefaultExtractorsFactory
 import com.google.android.gms.cast.framework.CastContext
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.flow.update
 import org.openedx.core.data.storage.CorePreferences
 import org.openedx.core.domain.model.VideoPlaybackSpeed
 import org.openedx.core.domain.model.VideoQuality
@@ -66,9 +67,6 @@ class EncodedVideoUnitViewModel(
     courseAnalytics
 ) {
     private val logger = Logger(TAG)
-    private val _isVideoEnded = MutableLiveData(false)
-    val isVideoEnded: LiveData<Boolean>
-        get() = _isVideoEnded
 
     var exoPlayer: ExoPlayer? = null
         private set
@@ -77,21 +75,23 @@ class EncodedVideoUnitViewModel(
     var castPlayer: CastPlayer? = null
         private set
 
-    var isCastActive = false
+    private val _state = MutableStateFlow(PlayerState())
+    internal val state: StateFlow<PlayerState> = _state
 
-    var isPlayerSetUp = false
-
-    var selectedLanguage: String = ""
-
-    @UnstableApi
-    val onTranscriptLoaded = transcriptObject.asFlow().distinctUntilChanged().mapNotNull {
-        exoPlayer?.currentMediaItem?.buildUpon()
-            ?.setSubtitleConfigurations(subtitleConfigurations)?.build()
-            ?.let { mediaItem ->
-                exoPlayer?.clearMediaItems()
-                exoPlayer?.addMediaItem(mediaItem)
+    init {
+        transcriptObject.asFlow().distinctUntilChanged().mapNotNull {
+            if (!state.value.isSubtitlesReady) {
+                exoPlayer?.currentMediaItem?.buildUpon()
+                    ?.setSubtitleConfigurations(subtitleConfigurations)?.build()
+                    ?.let { mediaItem ->
+                        exoPlayer?.clearMediaItems()
+                        exoPlayer?.addMediaItem(mediaItem)
+                        exoPlayer?.seekTo(getCurrentVideoTime())
+                        _state.update { it.copy(isSubtitlesReady = true) }
+                    }
             }
-    }.launchIn(viewModelScope)
+        }.launchIn(viewModelScope)
+    }
 
     private val subtitleConfigurations: List<MediaItem.SubtitleConfiguration>
         get() = transcripts
@@ -100,7 +100,7 @@ class EncodedVideoUnitViewModel(
             )
             .map { (language, uri) ->
                 val selectionFlags =
-                    if (language == selectedLanguage) C.SELECTION_FLAG_DEFAULT else 0
+                    if (language == state.value.selectedLanguage) C.SELECTION_FLAG_DEFAULT else 0
 
                 MediaItem.SubtitleConfiguration.Builder(Uri.parse(uri))
                     .setMimeType(MimeTypes.APPLICATION_SUBRIP)
@@ -118,7 +118,7 @@ class EncodedVideoUnitViewModel(
         override fun onPlaybackStateChanged(playbackState: Int) {
             super.onPlaybackStateChanged(playbackState)
             if (playbackState == Player.STATE_ENDED) {
-                _isVideoEnded.value = true
+                _state.update { it.copy(isVideoEnded = true) }
                 markBlockCompleted(blockId)
             }
         }
@@ -152,10 +152,11 @@ class EncodedVideoUnitViewModel(
 
         override fun onTracksChanged(tracks: Tracks) {
             super.onTracksChanged(tracks)
-            selectedLanguage = tracks.groups
+            val selectedLanguage = tracks.groups
                 .firstOrNull { it.isSelected && it.type == C.TRACK_TYPE_TEXT }
                 ?.getTrackFormat(0)
                 ?.language ?: ""
+            _state.update { it.copy(selectedLanguage = selectedLanguage) }
         }
     }
 
@@ -183,7 +184,7 @@ class EncodedVideoUnitViewModel(
 
     override fun onPause(owner: LifecycleOwner) {
         super.onPause(owner)
-        if (isCastActive) {
+        if (state.value.isCastActive) {
             getActivePlayer()?.release()
         } else {
             exoPlayer?.removeListener(exoPlayerListener)
@@ -192,7 +193,7 @@ class EncodedVideoUnitViewModel(
     }
 
     fun getActivePlayer(): Player? {
-        return if (isCastActive) {
+        return if (state.value.isCastActive) {
             castPlayer
         } else {
             exoPlayer
@@ -201,6 +202,7 @@ class EncodedVideoUnitViewModel(
 
     @UnstableApi
     fun releasePlayers() {
+        _state.update { it.copy(isPlayerSetUp = false) }
         exoPlayer?.release()
         castPlayer?.release()
         exoPlayer = null
@@ -246,10 +248,10 @@ class EncodedVideoUnitViewModel(
 
     @UnstableApi
     fun applyPlayerMedia() {
-        if (!isPlayerSetUp) {
+        if (!state.value.isPlayerSetUp) {
             setPlayerMedia(getMediaItem())
             getActivePlayer()?.prepare()
-            isPlayerSetUp = true
+            _state.update { it.copy(isPlayerSetUp = true) }
         }
     }
 
@@ -266,6 +268,10 @@ class EncodedVideoUnitViewModel(
     fun leaveFullscreen() {
         applyTrackSelector(isSubtitlesDisabled = true)
         _isUpdated.value = true
+    }
+
+    fun changeCastState(isActive: Boolean) {
+        _state.update { it.copy(isCastActive = isActive) }
     }
 
     @UnstableApi

--- a/course/src/main/java/org/openedx/course/presentation/unit/video/EncodedVideoUnitViewModel.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/video/EncodedVideoUnitViewModel.kt
@@ -37,6 +37,7 @@ import kotlinx.coroutines.flow.update
 import org.openedx.core.data.storage.CorePreferences
 import org.openedx.core.domain.model.VideoPlaybackSpeed
 import org.openedx.core.domain.model.VideoQuality
+import org.openedx.core.extension.isTrue
 import org.openedx.core.module.TranscriptManager
 import org.openedx.core.system.connection.NetworkConnection
 import org.openedx.core.system.notifier.CourseNotifier
@@ -260,8 +261,11 @@ class EncodedVideoUnitViewModel(
         .build()
 
     @UnstableApi
-    fun enterFullscreen() {
+    fun enterFullscreen(): Boolean {
+        if (state.value.isCastActive) return false
+        isPlaying = getActivePlayer()?.isPlaying.isTrue()
         applyTrackSelector(isSubtitlesDisabled = false)
+        return true
     }
 
     @UnstableApi

--- a/course/src/main/java/org/openedx/course/presentation/unit/video/EncodedVideoUnitViewModel.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/video/EncodedVideoUnitViewModel.kt
@@ -2,17 +2,24 @@ package org.openedx.course.presentation.unit.video
 
 import android.annotation.SuppressLint
 import android.content.Context
+import android.net.Uri
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.media3.cast.CastPlayer
+import androidx.media3.common.C
+import androidx.media3.common.MediaItem
+import androidx.media3.common.MimeTypes
 import androidx.media3.common.PlaybackParameters
 import androidx.media3.common.Player
+import androidx.media3.common.Tracks
 import androidx.media3.common.util.Clock
+import androidx.media3.datasource.DefaultDataSource
 import androidx.media3.exoplayer.DefaultLoadControl
 import androidx.media3.exoplayer.DefaultRenderersFactory
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.analytics.DefaultAnalyticsCollector
+import androidx.media3.exoplayer.hls.HlsMediaSource
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.exoplayer.trackselection.AdaptiveTrackSelection
 import androidx.media3.exoplayer.trackselection.DefaultTrackSelector
@@ -25,6 +32,7 @@ import org.openedx.core.domain.model.VideoQuality
 import org.openedx.core.module.TranscriptManager
 import org.openedx.core.system.connection.NetworkConnection
 import org.openedx.core.system.notifier.CourseNotifier
+import org.openedx.core.utils.LocaleUtils
 import org.openedx.core.utils.Logger
 import org.openedx.course.data.repository.CourseRepository
 import org.openedx.course.presentation.CourseAnalytics
@@ -66,11 +74,24 @@ class EncodedVideoUnitViewModel(
 
     var isPlayerSetUp = false
 
+    var selectedLanguage: String = ""
+    val subtitleConfigurations: List<MediaItem.SubtitleConfiguration>
+        get() = transcripts
+            .toSortedMap(
+                compareBy { LocaleUtils.getLanguageByLanguageCode(it) }
+            )
+            .map { (language, uri) ->
+                val selectionFlags =
+                    if (language == selectedLanguage) C.SELECTION_FLAG_DEFAULT else 0
+
+                MediaItem.SubtitleConfiguration.Builder(Uri.parse(uri))
+                    .setMimeType(MimeTypes.APPLICATION_SUBRIP)
+                    .setSelectionFlags(selectionFlags)
+                    .setLanguage(language)
+                    .build()
+            }
+
     private val exoPlayerListener = object : Player.Listener {
-        override fun onPlayWhenReadyChanged(playWhenReady: Boolean, reason: Int) {
-            super.onPlayWhenReadyChanged(playWhenReady, reason)
-            isPlaying = playWhenReady
-        }
 
         override fun onPlaybackStateChanged(playbackState: Int) {
             super.onPlaybackStateChanged(playbackState)
@@ -78,7 +99,6 @@ class EncodedVideoUnitViewModel(
                 _isVideoEnded.value = true
                 markBlockCompleted(blockId)
             }
-
         }
 
         override fun onIsPlayingChanged(isPlaying: Boolean) {
@@ -107,6 +127,14 @@ class EncodedVideoUnitViewModel(
                 getActivePlayer()?.duration ?: 0L
             )
         }
+
+        override fun onTracksChanged(tracks: Tracks) {
+            super.onTracksChanged(tracks)
+            selectedLanguage = tracks.groups
+                .firstOrNull { it.isSelected && it.type == C.TRACK_TYPE_TEXT }
+                ?.getTrackFormat(0)
+                ?.language ?: ""
+        }
     }
 
     @androidx.media3.common.util.UnstableApi
@@ -129,7 +157,6 @@ class EncodedVideoUnitViewModel(
     override fun onResume(owner: LifecycleOwner) {
         super.onResume(owner)
         exoPlayer?.addListener(exoPlayerListener)
-        getActivePlayer()?.playWhenReady = isPlaying
     }
 
     override fun onPause(owner: LifecycleOwner) {
@@ -188,9 +215,33 @@ class EncodedVideoUnitViewModel(
         logVideoLoadedEvent(videoUrl)
     }
 
+    fun applyPlayerMedia(mediaItem: MediaItem) {
+        if (!isPlayerSetUp) {
+            setPlayerMedia(mediaItem)
+            getActivePlayer()?.prepare()
+            isPlayerSetUp = true
+        }
+    }
+
+    @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
+    private fun setPlayerMedia(mediaItem: MediaItem) {
+        if (videoUrl.endsWith(HLS_EXT)) {
+            val factory = DefaultDataSource.Factory(context)
+            val mediaSource: HlsMediaSource =
+                HlsMediaSource.Factory(factory).createMediaSource(mediaItem)
+            exoPlayer?.setMediaSource(mediaSource, getCurrentVideoTime())
+        } else {
+            getActivePlayer()?.setMediaItem(
+                mediaItem,
+                getCurrentVideoTime()
+            )
+        }
+    }
+
     private fun getVideoQuality() = preferencesManager.videoSettings.videoStreamingQuality
 
     private companion object {
         private const val TAG = "EncodedVideoUnitViewModel"
+        private const val HLS_EXT = ".m3u8"
     }
 }

--- a/course/src/main/java/org/openedx/course/presentation/unit/video/PlayerState.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/video/PlayerState.kt
@@ -1,0 +1,9 @@
+package org.openedx.course.presentation.unit.video
+
+internal data class PlayerState(
+    val selectedLanguage: String = "",
+    val isPlayerSetUp: Boolean = false,
+    val isCastActive: Boolean = false,
+    val isVideoEnded: Boolean = false,
+    val isSubtitlesReady: Boolean = false,
+)

--- a/course/src/main/java/org/openedx/course/presentation/unit/video/VideoFullScreenFragment.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/video/VideoFullScreenFragment.kt
@@ -83,8 +83,7 @@ class VideoFullScreenFragment : DialogFragment() {
         DisposableEffect(Unit) {
             onDispose {
                 currentView.keepScreenOn = false
-                viewModel.updated()
-                (parentFragment as? VideoUnitFragment)?.initPlayer()
+                viewModel.leaveFullscreen()
             }
         }
         AndroidView(

--- a/course/src/main/java/org/openedx/course/presentation/unit/video/VideoFullScreenFragment.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/video/VideoFullScreenFragment.kt
@@ -1,6 +1,5 @@
 package org.openedx.course.presentation.unit.video
 
-import android.content.DialogInterface
 import android.graphics.Color
 import android.graphics.drawable.ColorDrawable
 import android.os.Bundle
@@ -19,14 +18,11 @@ import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.view.WindowCompat
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
-import androidx.media3.common.MediaItem
-import androidx.media3.common.MediaMetadata
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.ui.PlayerView
 import org.koin.android.ext.android.inject
 import org.koin.core.parameter.parametersOf
-import org.openedx.core.extension.isTrue
 import org.openedx.core.presentation.dialog.appreview.AppReviewManager
 import org.openedx.core.ui.theme.OpenEdXTheme
 import org.openedx.core.R as CoreR
@@ -60,11 +56,6 @@ class VideoFullScreenFragment : DialogFragment() {
         }
     }
 
-    override fun onDismiss(dialog: DialogInterface) {
-        viewModel.isPlaying = viewModel.exoPlayer?.isPlaying.isTrue()
-        super.onDismiss(dialog)
-    }
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setStyle(STYLE_NO_FRAME, CoreR.style.Theme_OpenEdX_Dialog_FullScreen)
@@ -92,7 +83,7 @@ class VideoFullScreenFragment : DialogFragment() {
         DisposableEffect(Unit) {
             onDispose {
                 currentView.keepScreenOn = false
-                viewModel.isPlayerSetUp = false
+                viewModel.updated()
                 (parentFragment as? VideoUnitFragment)?.initPlayer()
             }
         }
@@ -107,17 +98,6 @@ class VideoFullScreenFragment : DialogFragment() {
                     setShowNextButton(false)
                     setShowPreviousButton(false)
                     setShowSubtitleButton(true)
-                    val movieMetadata = MediaMetadata.Builder()
-                        .setMediaType(MediaMetadata.MEDIA_TYPE_MOVIE)
-                        .build()
-                    val mediaItem = MediaItem.Builder().setMediaMetadata(movieMetadata)
-                        .setUri(viewModel.videoUrl)
-                        .setSubtitleConfigurations(viewModel.subtitleConfigurations)
-                        .build()
-                    viewModel.applyPlayerMedia(mediaItem)
-                    viewModel.getActivePlayer()?.seekTo(viewModel.getCurrentVideoTime())
-                    viewModel.exoPlayer?.addListener(exoPlayerListener)
-                    viewModel.exoPlayer?.playWhenReady = viewModel.isPlaying
                     setFullscreenButtonClickListener { _ ->
                         dismiss()
                     }

--- a/course/src/main/java/org/openedx/course/presentation/unit/video/VideoFullScreenFragment.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/video/VideoFullScreenFragment.kt
@@ -1,257 +1,148 @@
 package org.openedx.course.presentation.unit.video
 
-import android.annotation.SuppressLint
+import android.content.DialogInterface
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
 import android.os.Bundle
-import android.view.View
+import android.view.LayoutInflater
+import android.view.ViewGroup
 import android.view.WindowManager
-import android.widget.FrameLayout
-import androidx.core.os.bundleOf
-import androidx.core.view.WindowInsetsCompat
-import androidx.fragment.app.Fragment
-import androidx.media3.common.C
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.core.view.WindowCompat
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.viewModels
 import androidx.media3.common.MediaItem
-import androidx.media3.common.PlaybackParameters
+import androidx.media3.common.MediaMetadata
 import androidx.media3.common.Player
-import androidx.media3.common.Tracks
-import androidx.media3.common.util.Clock
-import androidx.media3.exoplayer.DefaultLoadControl
-import androidx.media3.exoplayer.DefaultRenderersFactory
-import androidx.media3.exoplayer.ExoPlayer
-import androidx.media3.exoplayer.analytics.DefaultAnalyticsCollector
-import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
-import androidx.media3.exoplayer.trackselection.AdaptiveTrackSelection
-import androidx.media3.exoplayer.trackselection.DefaultTrackSelector
-import androidx.media3.exoplayer.upstream.DefaultBandwidthMeter
-import androidx.media3.extractor.DefaultExtractorsFactory
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.ui.PlayerView
 import org.koin.android.ext.android.inject
-import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.koin.core.parameter.parametersOf
-import org.openedx.core.domain.model.VideoQuality
-import org.openedx.core.extension.objectToString
-import org.openedx.core.extension.requestApplyInsetsWhenAttached
-import org.openedx.core.extension.stringToObject
+import org.openedx.core.extension.isTrue
 import org.openedx.core.presentation.dialog.appreview.AppReviewManager
-import org.openedx.core.presentation.global.viewBinding
-import org.openedx.course.R
-import org.openedx.course.databinding.FragmentVideoFullScreenBinding
+import org.openedx.core.ui.theme.OpenEdXTheme
+import org.openedx.core.R as CoreR
 
-class VideoFullScreenFragment : Fragment(R.layout.fragment_video_full_screen) {
+class VideoFullScreenFragment : DialogFragment() {
 
-    private val binding by viewBinding(FragmentVideoFullScreenBinding::bind)
-    private val viewModel by viewModel<VideoViewModel> {
-        parametersOf(
-            requireArguments().getString(ARG_COURSE_ID, ""),
-            requireArguments().getString(ARG_BLOCK_ID, "")
-        )
-    }
+    private val viewModel: EncodedVideoUnitViewModel by viewModels({ requireParentFragment() })
     private val appReviewManager by inject<AppReviewManager> { parametersOf(requireActivity()) }
-
-    private var exoPlayer: ExoPlayer? = null
-    private var blockId = ""
     private val exoPlayerListener = object : Player.Listener {
-        override fun onPlayWhenReadyChanged(playWhenReady: Boolean, reason: Int) {
-            super.onPlayWhenReadyChanged(playWhenReady, reason)
-            viewModel.isPlaying = playWhenReady
-        }
-
         override fun onPlaybackStateChanged(playbackState: Int) {
             super.onPlaybackStateChanged(playbackState)
             if (playbackState == Player.STATE_ENDED) {
                 if (!appReviewManager.isDialogShowed) {
                     appReviewManager.tryToOpenRateDialog()
                 }
-                viewModel.markBlockCompleted(blockId)
+                viewModel.markBlockCompleted(viewModel.blockId)
             }
         }
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ) = ComposeView(requireContext()).apply {
+        setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+        setContent {
+            OpenEdXTheme {
+                PlayerComposeView()
+            }
+        }
+    }
+
+    override fun onDismiss(dialog: DialogInterface) {
+        viewModel.isPlaying = viewModel.exoPlayer?.isPlaying.isTrue()
+        super.onDismiss(dialog)
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        viewModel.videoUrl = requireArguments().getString(ARG_BLOCK_VIDEO_URL, "")
-        blockId = requireArguments().getString(ARG_BLOCK_ID, "")
-        if (viewModel.currentVideoTime == 0L) {
-            viewModel.currentVideoTime = requireArguments().getLong(ARG_VIDEO_TIME, 0)
-        }
-        if (viewModel.videoDuration == 0L) {
-            viewModel.videoDuration = requireArguments().getLong(ARG_VIDEO_DURATION, 0)
-        }
-        if (viewModel.isPlaying == null) {
-            viewModel.isPlaying = requireArguments().getBoolean(ARG_IS_PLAYING)
-        }
-        viewModel.transcripts = stringToObject<Map<String, String>>(
-            requireArguments().getString(ARG_TRANSCRIPTS, "")
-        ) ?: emptyMap()
+        setStyle(STYLE_NO_FRAME, CoreR.style.Theme_OpenEdX_Dialog_FullScreen)
     }
 
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-        binding.root.setOnApplyWindowInsetsListener { _, insets ->
-            val insetsCompat = WindowInsetsCompat.toWindowInsetsCompat(insets)
-                .getInsets(WindowInsetsCompat.Type.systemBars())
-
-            val statusBarParams = binding.playerView.layoutParams as FrameLayout.LayoutParams
-            statusBarParams.topMargin = insetsCompat.top
-            statusBarParams.bottomMargin = insetsCompat.bottom
-            statusBarParams.marginStart = insetsCompat.left
-            statusBarParams.marginEnd = insetsCompat.right
-            binding.playerView.layoutParams = statusBarParams
-            insets
+    override fun onStart() {
+        super.onStart()
+        dialog?.window?.apply {
+            setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT)
+            statusBarColor = Color.BLACK
+            navigationBarColor = Color.BLACK
+            WindowCompat.getInsetsController(this, this.decorView).apply {
+                isAppearanceLightStatusBars = false
+                isAppearanceLightNavigationBars = false
+            }
+            setBackgroundDrawable(ColorDrawable(Color.BLACK))
+            attributes = attributes.apply { dimAmount = 0f }
         }
-        binding.root.requestApplyInsetsWhenAttached()
-        initPlayer()
     }
 
-    @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
-    private fun initPlayer() {
-        with(binding) {
-            if (exoPlayer == null) {
-                val videoQuality = viewModel.getVideoQuality()
-                val params = DefaultTrackSelector.Parameters.Builder(requireContext())
-                    .apply {
-                        if (videoQuality != VideoQuality.AUTO) {
-                            setMaxVideoSize(videoQuality.width, videoQuality.height)
-                            setViewportSize(videoQuality.width, videoQuality.height, false)
-                        }
-                    }
-                    .build()
-
-                val factory = AdaptiveTrackSelection.Factory()
-                val selector = DefaultTrackSelector(requireContext(), factory)
-                selector.parameters = params
-
-                exoPlayer = ExoPlayer.Builder(
-                    requireContext(),
-                    DefaultRenderersFactory(requireContext()),
-                    DefaultMediaSourceFactory(requireContext(), DefaultExtractorsFactory()),
-                    selector,
-                    DefaultLoadControl(),
-                    DefaultBandwidthMeter.getSingletonInstance(requireContext()),
-                    DefaultAnalyticsCollector(Clock.DEFAULT)
-                ).build().apply {
-                    setPlaybackSpeed(viewModel.videoSettings.videoPlaybackSpeed.speedValue)
-                }
+    @androidx.annotation.OptIn(UnstableApi::class)
+    @Composable
+    private fun PlayerComposeView() {
+        val currentView = LocalView.current
+        DisposableEffect(Unit) {
+            onDispose {
+                currentView.keepScreenOn = false
+                viewModel.isPlayerSetUp = false
+                (parentFragment as? VideoUnitFragment)?.initPlayer()
             }
-            playerView.player = exoPlayer
-            playerView.setShowNextButton(false)
-            playerView.setShowPreviousButton(false)
-            playerView.setShowSubtitleButton(true)
-            val mediaItem = MediaItem.Builder()
-                .setUri(viewModel.videoUrl)
-                .setSubtitleConfigurations(viewModel.subtitleConfigurations)
-                .build()
-            exoPlayer?.setMediaItem(mediaItem, viewModel.currentVideoTime)
-            exoPlayer?.prepare()
-            exoPlayer?.playWhenReady = viewModel.isPlaying ?: false
-
-            playerView.setFullscreenButtonClickListener { _ ->
-                requireActivity().supportFragmentManager.popBackStackImmediate()
-            }
-
-            exoPlayer?.addListener(object : Player.Listener {
-                override fun onIsPlayingChanged(isPlaying: Boolean) {
-                    super.onIsPlayingChanged(isPlaying)
-                    viewModel.logPlayPauseEvent(
-                        viewModel.videoUrl,
-                        isPlaying,
-                        viewModel.currentVideoTime,
-                        viewModel.videoDuration,
-                    )
-                }
-
-                override fun onPlaybackStateChanged(playbackState: Int) {
-                    super.onPlaybackStateChanged(playbackState)
-                    if (playbackState == Player.STATE_ENDED) {
-                        viewModel.markBlockCompleted(blockId)
+        }
+        AndroidView(
+            modifier = Modifier
+                .fillMaxSize()
+                .systemBarsPadding(),
+            factory = {
+                currentView.keepScreenOn = true
+                PlayerView(it).apply {
+                    player = viewModel.exoPlayer
+                    setShowNextButton(false)
+                    setShowPreviousButton(false)
+                    setShowSubtitleButton(true)
+                    val movieMetadata = MediaMetadata.Builder()
+                        .setMediaType(MediaMetadata.MEDIA_TYPE_MOVIE)
+                        .build()
+                    val mediaItem = MediaItem.Builder().setMediaMetadata(movieMetadata)
+                        .setUri(viewModel.videoUrl)
+                        .setSubtitleConfigurations(viewModel.subtitleConfigurations)
+                        .build()
+                    viewModel.applyPlayerMedia(mediaItem)
+                    viewModel.getActivePlayer()?.seekTo(viewModel.getCurrentVideoTime())
+                    viewModel.exoPlayer?.addListener(exoPlayerListener)
+                    viewModel.exoPlayer?.playWhenReady = viewModel.isPlaying
+                    setFullscreenButtonClickListener { _ ->
+                        dismiss()
                     }
                 }
-
-                override fun onTracksChanged(tracks: Tracks) {
-                    super.onTracksChanged(tracks)
-                    viewModel.selectedLanguage = tracks.groups
-                        .firstOrNull { it.isSelected && it.type == C.TRACK_TYPE_TEXT }
-                        ?.getTrackFormat(0)
-                        ?.language ?: ""
-
-                    playerView.hideController()
-                }
-
-                override fun onPlaybackParametersChanged(playbackParameters: PlaybackParameters) {
-                    super.onPlaybackParametersChanged(playbackParameters)
-                    val oldSpeed = viewModel.videoSettings.videoPlaybackSpeed.speedValue
-                    viewModel.setVideoPlaybackSpeed(playbackParameters.speed)
-                    viewModel.logVideoSpeedEvent(
-                        viewModel.videoUrl,
-                        oldSpeed,
-                        playbackParameters.speed,
-                        viewModel.currentVideoTime,
-                        viewModel.videoDuration,
-                    )
-                }
-            })
-        }
-    }
-
-    private fun releasePlayer() {
-        exoPlayer?.stop()
-        exoPlayer?.release()
-        exoPlayer = null
+            },
+        )
     }
 
     override fun onPause() {
         requireActivity().window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
-        exoPlayer?.removeListener(exoPlayerListener)
-        exoPlayer?.pause()
+        viewModel.exoPlayer?.removeListener(exoPlayerListener)
+        if (!requireActivity().isChangingConfigurations) {
+            viewModel.exoPlayer?.pause()
+        }
         super.onPause()
-    }
-
-    override fun onDestroyView() {
-        viewModel.currentVideoTime = exoPlayer?.currentPosition ?: C.TIME_UNSET
-        viewModel.sendTime()
-        super.onDestroyView()
-    }
-
-
-    @SuppressLint("SourceLockedOrientationActivity")
-    override fun onDestroy() {
-        releasePlayer()
-        super.onDestroy()
     }
 
     override fun onResume() {
         super.onResume()
         requireActivity().window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
-        exoPlayer?.addListener(exoPlayerListener)
+        viewModel.exoPlayer?.addListener(exoPlayerListener)
     }
 
     companion object {
-        private const val ARG_BLOCK_VIDEO_URL = "blockVideoUrl"
-        private const val ARG_VIDEO_TIME = "videoTime"
-        private const val ARG_VIDEO_DURATION = "videoDuration"
-        private const val ARG_BLOCK_ID = "blockId"
-        private const val ARG_COURSE_ID = "courseId"
-        private const val ARG_IS_PLAYING = "isPlaying"
-        private const val ARG_TRANSCRIPTS = "transcripts"
-
-        fun newInstance(
-            videoUrl: String,
-            videoTime: Long,
-            videoDuration: Long,
-            blockId: String,
-            courseId: String,
-            isPlaying: Boolean,
-            transcripts: Map<String, String>,
-        ): VideoFullScreenFragment {
-            val fragment = VideoFullScreenFragment()
-            fragment.arguments = bundleOf(
-                ARG_BLOCK_VIDEO_URL to videoUrl,
-                ARG_VIDEO_TIME to videoTime,
-                ARG_VIDEO_DURATION to videoDuration,
-                ARG_BLOCK_ID to blockId,
-                ARG_COURSE_ID to courseId,
-                ARG_IS_PLAYING to isPlaying,
-                ARG_TRANSCRIPTS to objectToString(transcripts),
-            )
-            return fragment
-        }
+        const val TAG = "VideoFullScreenFragment"
+        fun newInstance() = VideoFullScreenFragment()
     }
 }

--- a/course/src/main/java/org/openedx/course/presentation/unit/video/VideoUnitFragment.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/video/VideoUnitFragment.kt
@@ -168,7 +168,7 @@ class VideoUnitFragment : Fragment(R.layout.fragment_video_unit) {
     }
 
     @androidx.annotation.OptIn(UnstableApi::class)
-    internal fun initPlayer() {
+    private fun initPlayer() {
         with(binding) {
             playerView.player = null
             playerView.player = viewModel.getActivePlayer()
@@ -209,6 +209,7 @@ class VideoUnitFragment : Fragment(R.layout.fragment_video_unit) {
                     return@setFullscreenButtonClickListener
 
                 viewModel.isPlaying = viewModel.getActivePlayer()?.isPlaying.isTrue()
+                viewModel.enterFullscreen()
                 VideoFullScreenFragment.newInstance().show(childFragmentManager, VideoFullScreenFragment.TAG)
             }
         }

--- a/course/src/main/java/org/openedx/course/presentation/unit/video/VideoUnitFragment.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/video/VideoUnitFragment.kt
@@ -25,7 +25,6 @@ import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.koin.core.parameter.parametersOf
 import org.openedx.core.extension.computeWindowSizeClasses
 import org.openedx.core.extension.dpToPixel
-import org.openedx.core.extension.isTrue
 import org.openedx.core.extension.objectToString
 import org.openedx.core.extension.stringToObject
 import org.openedx.core.presentation.dialog.appreview.AppReviewManager
@@ -208,12 +207,9 @@ class VideoUnitFragment : Fragment(R.layout.fragment_video_unit) {
             )
 
             playerView.setFullscreenButtonClickListener {
-                if (viewModel.state.value.isCastActive)
-                    return@setFullscreenButtonClickListener
-
-                viewModel.isPlaying = viewModel.getActivePlayer()?.isPlaying.isTrue()
-                viewModel.enterFullscreen()
-                VideoFullScreenFragment.newInstance().show(childFragmentManager, VideoFullScreenFragment.TAG)
+                if (viewModel.enterFullscreen()) {
+                    VideoFullScreenFragment.newInstance().show(childFragmentManager, VideoFullScreenFragment.TAG)
+                }
             }
         }
     }

--- a/course/src/main/java/org/openedx/course/presentation/unit/video/VideoUnitFragment.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/video/VideoUnitFragment.kt
@@ -14,9 +14,12 @@ import androidx.compose.runtime.livedata.observeAsState
 import androidx.core.os.bundleOf
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
 import androidx.media3.cast.SessionAvailabilityListener
 import androidx.media3.common.util.UnstableApi
 import androidx.window.layout.WindowMetricsCalculator
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.koin.core.parameter.parametersOf
@@ -160,11 +163,11 @@ class VideoUnitFragment : Fragment(R.layout.fragment_video_unit) {
             }
         }
 
-        viewModel.isVideoEnded.observe(viewLifecycleOwner) { isVideoEnded ->
-            if (isVideoEnded && !appReviewManager.isDialogShowed) {
+        viewModel.state.onEach {
+            if (it.isVideoEnded && !appReviewManager.isDialogShowed) {
                 appReviewManager.tryToOpenRateDialog()
             }
-        }
+        }.launchIn(lifecycleScope)
     }
 
     @androidx.annotation.OptIn(UnstableApi::class)
@@ -181,7 +184,7 @@ class VideoUnitFragment : Fragment(R.layout.fragment_video_unit) {
                 object : SessionAvailabilityListener {
                     override fun onCastSessionAvailable() {
                         viewModel.logCastConnection(CourseAnalyticsEvent.CAST_CONNECTED)
-                        viewModel.isCastActive = true
+                        viewModel.changeCastState(true)
                         viewModel.exoPlayer?.pause()
                         playerView.player = viewModel.castPlayer
                         viewModel.castPlayer?.setMediaItem(
@@ -194,7 +197,7 @@ class VideoUnitFragment : Fragment(R.layout.fragment_video_unit) {
 
                     override fun onCastSessionUnavailable() {
                         viewModel.logCastConnection(CourseAnalyticsEvent.CAST_DISCONNECTED)
-                        viewModel.isCastActive = false
+                        viewModel.changeCastState(false)
                         playerView.player = viewModel.exoPlayer
                         viewModel.exoPlayer?.seekTo(viewModel.castPlayer?.currentPosition ?: 0L)
                         viewModel.castPlayer?.stop()
@@ -205,7 +208,7 @@ class VideoUnitFragment : Fragment(R.layout.fragment_video_unit) {
             )
 
             playerView.setFullscreenButtonClickListener {
-                if (viewModel.isCastActive)
+                if (viewModel.state.value.isCastActive)
                     return@setFullscreenButtonClickListener
 
                 viewModel.isPlaying = viewModel.getActivePlayer()?.isPlaying.isTrue()
@@ -229,7 +232,6 @@ class VideoUnitFragment : Fragment(R.layout.fragment_video_unit) {
     override fun onDestroy() {
         if (!requireActivity().isChangingConfigurations) {
             viewModel.releasePlayers()
-            viewModel.isPlayerSetUp = false
         }
         handler.removeCallbacks(videoTimeRunnable)
         super.onDestroy()

--- a/course/src/main/java/org/openedx/course/presentation/unit/video/VideoUnitFragment.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/video/VideoUnitFragment.kt
@@ -15,8 +15,6 @@ import androidx.core.os.bundleOf
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.media3.cast.SessionAvailabilityListener
-import androidx.media3.common.MediaItem
-import androidx.media3.common.MediaMetadata
 import androidx.media3.common.util.UnstableApi
 import androidx.window.layout.WindowMetricsCalculator
 import org.koin.android.ext.android.inject
@@ -177,15 +175,7 @@ class VideoUnitFragment : Fragment(R.layout.fragment_video_unit) {
             playerView.setShowNextButton(false)
             playerView.setShowPreviousButton(false)
             showVideoControllerIndefinitely(false)
-            val movieMetadata = MediaMetadata.Builder()
-                .setMediaType(MediaMetadata.MEDIA_TYPE_MOVIE)
-                .build()
-            val mediaItem = MediaItem.Builder().setMediaMetadata(movieMetadata)
-                .setUri(viewModel.videoUrl)
-                .setSubtitleConfigurations(viewModel.subtitleConfigurations)
-                .build()
-            viewModel.applyPlayerMedia(mediaItem)
-            viewModel.getActivePlayer()?.seekTo(viewModel.getCurrentVideoTime())
+            viewModel.applyPlayerMedia()
             viewModel.exoPlayer?.playWhenReady = viewModel.isPlaying
             viewModel.castPlayer?.setSessionAvailabilityListener(
                 object : SessionAvailabilityListener {
@@ -195,8 +185,8 @@ class VideoUnitFragment : Fragment(R.layout.fragment_video_unit) {
                         viewModel.exoPlayer?.pause()
                         playerView.player = viewModel.castPlayer
                         viewModel.castPlayer?.setMediaItem(
-                            mediaItem,
-                            viewModel.exoPlayer?.currentPosition ?: 0L
+                            viewModel.getMediaItem(),
+                            viewModel.getCurrentVideoTime()
                         )
                         viewModel.castPlayer?.playWhenReady = true
                         showVideoControllerIndefinitely(true)

--- a/course/src/main/java/org/openedx/course/presentation/unit/video/VideoUnitFragment.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/video/VideoUnitFragment.kt
@@ -18,14 +18,13 @@ import androidx.media3.cast.SessionAvailabilityListener
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
 import androidx.media3.common.util.UnstableApi
-import androidx.media3.datasource.DefaultDataSource
-import androidx.media3.exoplayer.hls.HlsMediaSource
 import androidx.window.layout.WindowMetricsCalculator
 import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.koin.core.parameter.parametersOf
 import org.openedx.core.extension.computeWindowSizeClasses
 import org.openedx.core.extension.dpToPixel
+import org.openedx.core.extension.isTrue
 import org.openedx.core.extension.objectToString
 import org.openedx.core.extension.stringToObject
 import org.openedx.core.presentation.dialog.appreview.AppReviewManager
@@ -38,8 +37,6 @@ import org.openedx.core.utils.LocaleUtils
 import org.openedx.course.R
 import org.openedx.course.databinding.FragmentVideoUnitBinding
 import org.openedx.course.presentation.CourseAnalyticsEvent
-import org.openedx.course.presentation.CourseAnalyticsKey
-import org.openedx.course.presentation.CourseRouter
 import org.openedx.course.presentation.ui.VideoSubtitles
 import org.openedx.course.presentation.ui.VideoTitle
 import kotlin.math.roundToInt
@@ -53,7 +50,6 @@ class VideoUnitFragment : Fragment(R.layout.fragment_video_unit) {
             requireArguments().getString(ARG_BLOCK_ID, ""),
         )
     }
-    private val router by inject<CourseRouter>()
     private val appReviewManager by inject<AppReviewManager> { parametersOf(requireActivity()) }
 
     private var windowSize: WindowSize? = null
@@ -174,29 +170,23 @@ class VideoUnitFragment : Fragment(R.layout.fragment_video_unit) {
     }
 
     @androidx.annotation.OptIn(UnstableApi::class)
-    private fun initPlayer() {
+    internal fun initPlayer() {
         with(binding) {
+            playerView.player = null
             playerView.player = viewModel.getActivePlayer()
             playerView.setShowNextButton(false)
             playerView.setShowPreviousButton(false)
             showVideoControllerIndefinitely(false)
-
             val movieMetadata = MediaMetadata.Builder()
                 .setMediaType(MediaMetadata.MEDIA_TYPE_MOVIE)
                 .build()
             val mediaItem = MediaItem.Builder().setMediaMetadata(movieMetadata)
                 .setUri(viewModel.videoUrl)
-                .setMimeType("video/*")
+                .setSubtitleConfigurations(viewModel.subtitleConfigurations)
                 .build()
-
-            if (!viewModel.isPlayerSetUp) {
-                setPlayerMedia(mediaItem)
-                viewModel.getActivePlayer()?.prepare()
-                viewModel.getActivePlayer()?.playWhenReady = viewModel.isPlaying && isResumed
-                viewModel.isPlayerSetUp = true
-            }
+            viewModel.applyPlayerMedia(mediaItem)
             viewModel.getActivePlayer()?.seekTo(viewModel.getCurrentVideoTime())
-
+            viewModel.exoPlayer?.playWhenReady = viewModel.isPlaying
             viewModel.castPlayer?.setSessionAvailabilityListener(
                 object : SessionAvailabilityListener {
                     override fun onCastSessionAvailable() {
@@ -228,16 +218,8 @@ class VideoUnitFragment : Fragment(R.layout.fragment_video_unit) {
                 if (viewModel.isCastActive)
                     return@setFullscreenButtonClickListener
 
-                router.navigateToFullScreenVideo(
-                    requireActivity().supportFragmentManager,
-                    viewModel.videoUrl,
-                    viewModel.exoPlayer?.currentPosition ?: 0L,
-                    viewModel.exoPlayer?.duration?: 0L,
-                    viewModel.blockId,
-                    viewModel.courseId,
-                    viewModel.isPlaying,
-                    viewModel.transcripts,
-                )
+                viewModel.isPlaying = viewModel.getActivePlayer()?.isPlaying.isTrue()
+                VideoFullScreenFragment.newInstance().show(childFragmentManager, VideoFullScreenFragment.TAG)
             }
         }
     }
@@ -271,21 +253,6 @@ class VideoUnitFragment : Fragment(R.layout.fragment_video_unit) {
         } else {
             binding.playerView.controllerAutoShow = true
             binding.playerView.controllerShowTimeoutMs = 2000
-        }
-    }
-
-    @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
-    private fun setPlayerMedia(mediaItem: MediaItem) {
-        if (viewModel.videoUrl.endsWith(".m3u8")) {
-            val factory = DefaultDataSource.Factory(requireContext())
-            val mediaSource: HlsMediaSource =
-                HlsMediaSource.Factory(factory).createMediaSource(mediaItem)
-            viewModel.exoPlayer?.setMediaSource(mediaSource, viewModel.getCurrentVideoTime())
-        } else {
-            viewModel.getActivePlayer()?.setMediaItem(
-                mediaItem,
-                viewModel.getCurrentVideoTime()
-            )
         }
     }
 


### PR DESCRIPTION
Workaround with VideoPlayer flow on configuration changes.

What was done:
1. Shared EncodedVideoUnitViewModel between VideoUnitFragment and VideoFullScreenFragment and storing exoPlayer instance in it.
2. VideoFullScreenFragment became DialogFragment to have access to the shared viewModel
3. VideoFullScreenFragment moved to Compose
4. State in flow in  EncodedVideoUnitViewModel 