### PR TITLE
fix: App Crashes in Offline Mode while `getAllUserCourses`.

### DIFF
--- a/core/src/main/java/org/openedx/core/system/notifier/app/AppNotifier.kt
+++ b/core/src/main/java/org/openedx/core/system/notifier/app/AppNotifier.kt
@@ -24,4 +24,6 @@ class AppNotifier {
     suspend fun send(event: EnrolledCourseEvent) = channel.emit(event)
 
     suspend fun send(event: RequestEnrolledCourseEvent) = channel.emit(event)
+
+    suspend fun send(event: RequestEnrolledCourseErrorEvent) = channel.emit(event)
 }

--- a/core/src/main/java/org/openedx/core/system/notifier/app/RequestEnrolledCourseErrorEvent.kt
+++ b/core/src/main/java/org/openedx/core/system/notifier/app/RequestEnrolledCourseErrorEvent.kt
@@ -1,0 +1,3 @@
+package org.openedx.core.system.notifier.app
+
+object RequestEnrolledCourseErrorEvent : AppEvent

--- a/dashboard/src/main/java/org/openedx/courses/presentation/DashboardGalleryViewModel.kt
+++ b/dashboard/src/main/java/org/openedx/courses/presentation/DashboardGalleryViewModel.kt
@@ -45,9 +45,11 @@ import org.openedx.core.system.notifier.PushNotifier
 import org.openedx.core.system.notifier.UpdateCourseData
 import org.openedx.core.system.notifier.app.AppNotifier
 import org.openedx.core.system.notifier.app.EnrolledCourseEvent
+import org.openedx.core.system.notifier.app.RequestEnrolledCourseErrorEvent
 import org.openedx.core.system.notifier.app.RequestEnrolledCourseEvent
 import org.openedx.core.ui.WindowSize
 import org.openedx.core.utils.FileUtil
+import org.openedx.core.utils.Logger
 import org.openedx.dashboard.domain.CourseStatusFilter
 import org.openedx.dashboard.domain.interactor.DashboardInteractor
 import org.openedx.dashboard.presentation.DashboardRouter
@@ -69,6 +71,8 @@ class DashboardGalleryViewModel(
     private val windowSize: WindowSize,
     iapAnalytics: IAPAnalytics,
 ) : BaseViewModel() {
+
+    private val logger = Logger(TAG)
 
     val apiHostUrl get() = config.getApiHostURL()
 
@@ -111,9 +115,14 @@ class DashboardGalleryViewModel(
         appNotifier.notifier
             .onEach {
                 if (it is RequestEnrolledCourseEvent) {
-                    val enrolledCourses =
+                    runCatching {
                         interactor.getAllUserCourses(status = CourseStatusFilter.ALL).courses
-                    appNotifier.send(EnrolledCourseEvent(enrolledCourses))
+                    }.onSuccess { enrolledCourses ->
+                        appNotifier.send(EnrolledCourseEvent(enrolledCourses))
+                    }.onFailure {
+                        logger.e { "Error getting enrolled courses: $it" }
+                        appNotifier.send(RequestEnrolledCourseErrorEvent)
+                    }
                 }
             }
             .distinctUntilChanged()
@@ -277,35 +286,39 @@ class DashboardGalleryViewModel(
 
     private fun detectUnfulfilledPurchase() {
         viewModelScope.launch(Dispatchers.IO) {
-            val enrolledCourses =
+            runCatching {
                 interactor.getAllUserCourses(status = CourseStatusFilter.ALL).courses
-            iapInteractor.detectUnfulfilledPurchase(
-                enrolledCourses = enrolledCourses,
-                verificationInitiated = { purchaseFlowData ->
-                    eventLogger.apply {
-                        this.purchaseFlowData = purchaseFlowData
-                        this.logUnfulfilledPurchaseInitiatedEvent()
-                    }
-                },
-                onSuccess = { purchaseFlowData ->
-                    eventLogger.apply {
-                        this.purchaseFlowData = purchaseFlowData
-                        this.upgradeSuccessEvent()
-                    }
-                    _iapUiState.tryEmit(IAPUIState.PurchasesFulfillmentCompleted)
-                },
-                onFailure = {
-                    _iapUiState.tryEmit(
-                        IAPUIState.Error(
-                            IAPException(
-                                IAPRequestType.UNFULFILLED_CODE,
-                                it.httpErrorCode,
-                                it.errorMessage
+            }.onSuccess { enrolledCourses ->
+                iapInteractor.detectUnfulfilledPurchase(
+                    enrolledCourses = enrolledCourses,
+                    verificationInitiated = { purchaseFlowData ->
+                        eventLogger.apply {
+                            this.purchaseFlowData = purchaseFlowData
+                            this.logUnfulfilledPurchaseInitiatedEvent()
+                        }
+                    },
+                    onSuccess = { purchaseFlowData ->
+                        eventLogger.apply {
+                            this.purchaseFlowData = purchaseFlowData
+                            this.upgradeSuccessEvent()
+                        }
+                        _iapUiState.tryEmit(IAPUIState.PurchasesFulfillmentCompleted)
+                    },
+                    onFailure = {
+                        _iapUiState.tryEmit(
+                            IAPUIState.Error(
+                                IAPException(
+                                    IAPRequestType.UNFULFILLED_CODE,
+                                    it.httpErrorCode,
+                                    it.errorMessage
+                                )
                             )
                         )
-                    )
-                }
-            )
+                    }
+                )
+            }.onFailure {
+                logger.e { "Error getting enrolled courses: $it" }
+            }
         }
     }
 
@@ -321,6 +334,7 @@ class DashboardGalleryViewModel(
     }
 
     companion object {
+        private const val TAG = "DashboardGalleryViewModel"
         private const val PAGE_SIZE_TABLET = 7
         private const val PAGE_SIZE_PHONE = 5
     }

--- a/dashboard/src/main/java/org/openedx/courses/presentation/DashboardGalleryViewModel.kt
+++ b/dashboard/src/main/java/org/openedx/courses/presentation/DashboardGalleryViewModel.kt
@@ -120,7 +120,7 @@ class DashboardGalleryViewModel(
                     }.onSuccess { enrolledCourses ->
                         appNotifier.send(EnrolledCourseEvent(enrolledCourses))
                     }.onFailure {
-                        logger.e { "Error getting enrolled courses: $it" }
+                        logger.d { "Error getting enrolled courses: $it" }
                         appNotifier.send(RequestEnrolledCourseErrorEvent)
                     }
                 }
@@ -286,9 +286,9 @@ class DashboardGalleryViewModel(
 
     private fun detectUnfulfilledPurchase() {
         viewModelScope.launch(Dispatchers.IO) {
-            runCatching {
-                interactor.getAllUserCourses(status = CourseStatusFilter.ALL).courses
-            }.onSuccess { enrolledCourses ->
+            try {
+                val enrolledCourses =
+                    interactor.getAllUserCourses(status = CourseStatusFilter.ALL).courses
                 iapInteractor.detectUnfulfilledPurchase(
                     enrolledCourses = enrolledCourses,
                     verificationInitiated = { purchaseFlowData ->
@@ -316,8 +316,8 @@ class DashboardGalleryViewModel(
                         )
                     }
                 )
-            }.onFailure {
-                logger.e { "Error getting enrolled courses: $it" }
+            } catch (e: Exception) {
+                logger.d { "Error getting enrolled courses: $e" }
             }
         }
     }

--- a/dashboard/src/main/java/org/openedx/dashboard/presentation/DashboardListViewModel.kt
+++ b/dashboard/src/main/java/org/openedx/dashboard/presentation/DashboardListViewModel.kt
@@ -46,7 +46,9 @@ import org.openedx.core.system.notifier.UpdateCourseData
 import org.openedx.core.system.notifier.app.AppNotifier
 import org.openedx.core.system.notifier.app.AppUpgradeEvent
 import org.openedx.core.system.notifier.app.EnrolledCourseEvent
+import org.openedx.core.system.notifier.app.RequestEnrolledCourseErrorEvent
 import org.openedx.core.system.notifier.app.RequestEnrolledCourseEvent
+import org.openedx.core.utils.Logger
 import org.openedx.dashboard.domain.CourseStatusFilter
 import org.openedx.dashboard.domain.interactor.DashboardInteractor
 
@@ -66,6 +68,8 @@ class DashboardListViewModel(
     private val iapInteractor: IAPInteractor,
     iapAnalytics: IAPAnalytics,
 ) : BaseViewModel() {
+
+    private val logger = Logger(TAG)
 
     private val coursesList = mutableListOf<EnrolledCourse>()
     private var page = 1
@@ -302,9 +306,14 @@ class DashboardListViewModel(
                     _appUpgradeEvent.value = it
                 }
                 if (it is RequestEnrolledCourseEvent) {
-                    val enrolledCourses =
+                    runCatching {
                         interactor.getAllUserCourses(status = CourseStatusFilter.ALL).courses
-                    appNotifier.send(EnrolledCourseEvent(enrolledCourses))
+                    }.onSuccess { enrolledCourses ->
+                        appNotifier.send(EnrolledCourseEvent(enrolledCourses))
+                    }.onFailure {
+                        logger.e { "Error getting enrolled courses: $it" }
+                        appNotifier.send(RequestEnrolledCourseErrorEvent)
+                    }
                 }
             }
             .distinctUntilChanged()
@@ -317,35 +326,39 @@ class DashboardListViewModel(
 
     private fun detectUnfulfilledPurchase() {
         viewModelScope.launch(Dispatchers.IO) {
-            val enrolledCourses =
+            runCatching {
                 interactor.getAllUserCourses(status = CourseStatusFilter.ALL).courses
-            iapInteractor.detectUnfulfilledPurchase(
-                enrolledCourses = enrolledCourses,
-                verificationInitiated = { purchaseFlowData ->
-                    eventLogger.apply {
-                        this.purchaseFlowData = purchaseFlowData
-                        this.logUnfulfilledPurchaseInitiatedEvent()
-                    }
-                },
-                onSuccess = { purchaseFlowData ->
-                    eventLogger.apply {
-                        this.purchaseFlowData = purchaseFlowData
-                        this.upgradeSuccessEvent()
-                    }
-                    _iapUiState.tryEmit(IAPUIState.PurchasesFulfillmentCompleted)
-                },
-                onFailure = {
-                    _iapUiState.tryEmit(
-                        IAPUIState.Error(
-                            IAPException(
-                                IAPRequestType.UNFULFILLED_CODE,
-                                it.httpErrorCode,
-                                it.errorMessage,
+            }.onSuccess { enrolledCourses ->
+                iapInteractor.detectUnfulfilledPurchase(
+                    enrolledCourses = enrolledCourses,
+                    verificationInitiated = { purchaseFlowData ->
+                        eventLogger.apply {
+                            this.purchaseFlowData = purchaseFlowData
+                            this.logUnfulfilledPurchaseInitiatedEvent()
+                        }
+                    },
+                    onSuccess = { purchaseFlowData ->
+                        eventLogger.apply {
+                            this.purchaseFlowData = purchaseFlowData
+                            this.upgradeSuccessEvent()
+                        }
+                        _iapUiState.tryEmit(IAPUIState.PurchasesFulfillmentCompleted)
+                    },
+                    onFailure = {
+                        _iapUiState.tryEmit(
+                            IAPUIState.Error(
+                                IAPException(
+                                    IAPRequestType.UNFULFILLED_CODE,
+                                    it.httpErrorCode,
+                                    it.errorMessage,
+                                )
                             )
                         )
-                    )
-                }
-            )
+                    }
+                )
+            }.onFailure {
+                logger.e { "Error getting enrolled courses: $it" }
+            }
         }
     }
 
@@ -358,5 +371,9 @@ class DashboardListViewModel(
         viewModelScope.launch {
             _iapUiState.emit(null)
         }
+    }
+
+    companion object {
+        private const val TAG = "DashboardListViewModel"
     }
 }

--- a/dashboard/src/main/java/org/openedx/dashboard/presentation/DashboardListViewModel.kt
+++ b/dashboard/src/main/java/org/openedx/dashboard/presentation/DashboardListViewModel.kt
@@ -311,7 +311,7 @@ class DashboardListViewModel(
                     }.onSuccess { enrolledCourses ->
                         appNotifier.send(EnrolledCourseEvent(enrolledCourses))
                     }.onFailure {
-                        logger.e { "Error getting enrolled courses: $it" }
+                        logger.d { "Error getting enrolled courses: $it" }
                         appNotifier.send(RequestEnrolledCourseErrorEvent)
                     }
                 }
@@ -357,7 +357,7 @@ class DashboardListViewModel(
                     }
                 )
             }.onFailure {
-                logger.e { "Error getting enrolled courses: $it" }
+                logger.d { "Error getting enrolled courses: $it" }
             }
         }
     }

--- a/profile/src/main/java/org/openedx/profile/presentation/settings/SettingsViewModel.kt
+++ b/profile/src/main/java/org/openedx/profile/presentation/settings/SettingsViewModel.kt
@@ -37,6 +37,7 @@ import org.openedx.core.system.notifier.app.AppNotifier
 import org.openedx.core.system.notifier.app.AppUpgradeEvent
 import org.openedx.core.system.notifier.app.EnrolledCourseEvent
 import org.openedx.core.system.notifier.app.LogoutEvent
+import org.openedx.core.system.notifier.app.RequestEnrolledCourseErrorEvent
 import org.openedx.core.system.notifier.app.RequestEnrolledCourseEvent
 import org.openedx.core.utils.EmailUtil
 import org.openedx.profile.domain.interactor.ProfileInteractor
@@ -135,11 +136,18 @@ class SettingsViewModel(
     private fun collectAppEvent() {
         viewModelScope.launch {
             appNotifier.notifier.collect { event ->
-                if (event is AppUpgradeEvent) {
-                    _appUpgradeEvent.value = event
-                }
-                if (event is EnrolledCourseEvent) {
-                    restorePurchase(event.enrolledCourses)
+                when (event) {
+                    is AppUpgradeEvent -> {
+                        _appUpgradeEvent.value = event
+                    }
+
+                    is EnrolledCourseEvent -> {
+                        restorePurchase(event.enrolledCourses)
+                    }
+
+                    is RequestEnrolledCourseErrorEvent -> {
+                        _iapUiState.emit(IAPUIState.FakePurchasesFulfillmentCompleted)
+                    }
                 }
             }
         }


### PR DESCRIPTION
### Description

Fix the app crashes when `getAllUserCourses` for the unfulfilled, and restore purchases.

Jira ticket: [LEARNER-10407](https://2u-internal.atlassian.net/browse/LEARNER-10407)

**Steps to reproduce:**
- Open the app in offline mode (The learner should have at least one enrolled course).
- Wait some seconds, the leads the the crash.
- The app crashes when trying the `getAllUserCourses` in offline mode.