### PR TITLE
feat: System notification tray interaction considerations

### DIFF
--- a/app/src/main/java/org/openedx/app/AppActivity.kt
+++ b/app/src/main/java/org/openedx/app/AppActivity.kt
@@ -228,6 +228,7 @@ class AppActivity : AppCompatActivity(), InsetHolder, WindowSizeHolder {
 
     private fun handlePushNotification(data: Bundle) {
         val deepLink = DeepLink(data.toStringMap())
+        deepLink.notificationId?.let { viewModel.markNotificationAsRead(deepLink.notificationId) }
         viewModel.makeExternalRoute(supportFragmentManager, deepLink)
     }
 

--- a/app/src/main/java/org/openedx/app/AppActivity.kt
+++ b/app/src/main/java/org/openedx/app/AppActivity.kt
@@ -228,7 +228,7 @@ class AppActivity : AppCompatActivity(), InsetHolder, WindowSizeHolder {
 
     private fun handlePushNotification(data: Bundle) {
         val deepLink = DeepLink(data.toStringMap())
-        deepLink.notificationId?.let { viewModel.markNotificationAsRead(deepLink.notificationId) }
+        viewModel.markNotificationAsRead(deepLink.notificationId)
         viewModel.makeExternalRoute(supportFragmentManager, deepLink)
     }
 

--- a/app/src/main/java/org/openedx/app/AppViewModel.kt
+++ b/app/src/main/java/org/openedx/app/AppViewModel.kt
@@ -3,7 +3,6 @@ package org.openedx.app
 import android.annotation.SuppressLint
 import android.app.NotificationManager
 import android.content.Context
-import android.util.Log
 import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
@@ -21,12 +20,12 @@ import org.openedx.core.SingleEventLiveData
 import org.openedx.core.config.Config
 import org.openedx.core.data.model.User
 import org.openedx.core.data.storage.CorePreferences
+import org.openedx.core.system.PushGlobalManager
 import org.openedx.core.system.notifier.app.AppNotifier
 import org.openedx.core.system.notifier.app.LogoutEvent
 import org.openedx.core.system.notifier.app.SignInEvent
 import org.openedx.core.utils.FileUtil
-import org.openedx.notifications.domain.interactor.NotificationsInteractor
-
+import org.openedx.core.utils.Logger
 
 @SuppressLint("StaticFieldLeak")
 class AppViewModel(
@@ -39,8 +38,10 @@ class AppViewModel(
     private val deepLinkRouter: DeepLinkRouter,
     private val fileUtil: FileUtil,
     private val context: Context,
-    private val interactor: NotificationsInteractor,
+    private val pushManager: PushGlobalManager,
 ) : BaseViewModel() {
+
+    private val logger = Logger(TAG)
 
     private val _logoutUser = SingleEventLiveData<Unit>()
     val logoutUser: LiveData<Unit>
@@ -126,8 +127,15 @@ class AppViewModel(
 
     fun markNotificationAsRead(notificationId: Int) {
         viewModelScope.launch {
-            val marked = interactor.markNotificationAsRead(notificationId)
-            Log.d("AppViewModel", "Notification marked as read: $marked")
+            try {
+                pushManager.markNotificationAsRead(notificationId)
+            } catch (e: Exception) {
+                logger.e(throwable = e, submitCrashReport = true)
+            }
         }
+    }
+
+    companion object {
+        private const val TAG = "AppViewModel"
     }
 }

--- a/app/src/main/java/org/openedx/app/AppViewModel.kt
+++ b/app/src/main/java/org/openedx/app/AppViewModel.kt
@@ -3,6 +3,7 @@ package org.openedx.app
 import android.annotation.SuppressLint
 import android.app.NotificationManager
 import android.content.Context
+import android.util.Log
 import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
@@ -24,6 +25,7 @@ import org.openedx.core.system.notifier.app.AppNotifier
 import org.openedx.core.system.notifier.app.LogoutEvent
 import org.openedx.core.system.notifier.app.SignInEvent
 import org.openedx.core.utils.FileUtil
+import org.openedx.notifications.domain.interactor.NotificationsInteractor
 
 
 @SuppressLint("StaticFieldLeak")
@@ -36,7 +38,8 @@ class AppViewModel(
     private val analytics: AppAnalytics,
     private val deepLinkRouter: DeepLinkRouter,
     private val fileUtil: FileUtil,
-    private val context: Context
+    private val context: Context,
+    private val interactor: NotificationsInteractor,
 ) : BaseViewModel() {
 
     private val _logoutUser = SingleEventLiveData<Unit>()
@@ -118,6 +121,13 @@ class AppViewModel(
                     context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
                 notificationManager.cancelAll()
             }
+        }
+    }
+
+    fun markNotificationAsRead(notificationId: Int) {
+        viewModelScope.launch {
+            val marked = interactor.markNotificationAsRead(notificationId)
+            Log.d("AppViewModel", "Notification marked as read: $marked")
         }
     }
 }

--- a/app/src/main/java/org/openedx/app/AppViewModel.kt
+++ b/app/src/main/java/org/openedx/app/AppViewModel.kt
@@ -125,10 +125,10 @@ class AppViewModel(
         }
     }
 
-    fun markNotificationAsRead(notificationId: Int) {
+    fun markNotificationAsRead(notificationId: Int?) {
         viewModelScope.launch {
             try {
-                pushManager.markNotificationAsRead(notificationId)
+                notificationId?.let { pushManager.markNotificationAsRead(it) }
             } catch (e: Exception) {
                 logger.e(throwable = e, submitCrashReport = true)
             }

--- a/app/src/main/java/org/openedx/app/deeplink/DeepLink.kt
+++ b/app/src/main/java/org/openedx/app/deeplink/DeepLink.kt
@@ -4,6 +4,7 @@ class DeepLink(params: Map<String, String>) {
 
     private val screenName = params[Keys.SCREEN_NAME.value]
     private val notificationType = params[Keys.NOTIFICATION_TYPE.value]
+    val notificationId = params[Keys.NOTIFICATION_ID.value]?.toIntOrNull()
     val courseId = params[Keys.COURSE_ID.value]
     val pathId = params[Keys.PATH_ID.value]
     val componentId = params[Keys.COMPONENT_ID.value]
@@ -15,6 +16,7 @@ class DeepLink(params: Map<String, String>) {
 
     enum class Keys(val value: String) {
         SCREEN_NAME("screen_name"),
+        NOTIFICATION_ID("notification_id"),
         NOTIFICATION_TYPE("notification_type"),
         COURSE_ID("course_id"),
         PATH_ID("path_id"),

--- a/app/src/main/java/org/openedx/app/di/ScreenModule.kt
+++ b/app/src/main/java/org/openedx/app/di/ScreenModule.kt
@@ -88,6 +88,7 @@ val screenModule = module {
             get(),
             get(),
             get(),
+            get(),
             get()
         )
     }

--- a/app/src/test/java/org/openedx/AppViewModelTest.kt
+++ b/app/src/test/java/org/openedx/AppViewModelTest.kt
@@ -29,10 +29,10 @@ import org.openedx.app.room.AppDatabase
 import org.openedx.core.config.Config
 import org.openedx.core.config.FirebaseConfig
 import org.openedx.core.data.model.User
+import org.openedx.core.system.PushGlobalManager
 import org.openedx.core.system.notifier.app.AppNotifier
 import org.openedx.core.system.notifier.app.LogoutEvent
 import org.openedx.core.utils.FileUtil
-import org.openedx.notifications.domain.interactor.NotificationsInteractor
 
 @ExperimentalCoroutinesApi
 class AppViewModelTest {
@@ -50,7 +50,7 @@ class AppViewModelTest {
     private val fileUtil = mockk<FileUtil>()
     private val deepLinkRouter = mockk<DeepLinkRouter>()
     private val context = mockk<Context>()
-    private val interactor = mockk<NotificationsInteractor>()
+    private val pushManager = mockk<PushGlobalManager>()
 
     private val user = User(0, "", "", "")
 
@@ -82,7 +82,7 @@ class AppViewModelTest {
             deepLinkRouter,
             fileUtil,
             context,
-            interactor,
+            pushManager,
         )
 
         val mockLifeCycleOwner: LifecycleOwner = mockk()
@@ -118,7 +118,7 @@ class AppViewModelTest {
             deepLinkRouter,
             fileUtil,
             context,
-            interactor,
+            pushManager,
         )
 
         val mockLifeCycleOwner: LifecycleOwner = mockk()
@@ -156,7 +156,7 @@ class AppViewModelTest {
             deepLinkRouter,
             fileUtil,
             context,
-            interactor,
+            pushManager,
         )
 
         val mockLifeCycleOwner: LifecycleOwner = mockk()

--- a/app/src/test/java/org/openedx/AppViewModelTest.kt
+++ b/app/src/test/java/org/openedx/AppViewModelTest.kt
@@ -22,16 +22,17 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TestRule
 import org.openedx.app.AppAnalytics
-import org.openedx.app.deeplink.DeepLinkRouter
 import org.openedx.app.AppViewModel
 import org.openedx.app.data.storage.PreferencesManager
+import org.openedx.app.deeplink.DeepLinkRouter
 import org.openedx.app.room.AppDatabase
-import org.openedx.core.system.notifier.app.LogoutEvent
 import org.openedx.core.config.Config
 import org.openedx.core.config.FirebaseConfig
 import org.openedx.core.data.model.User
 import org.openedx.core.system.notifier.app.AppNotifier
+import org.openedx.core.system.notifier.app.LogoutEvent
 import org.openedx.core.utils.FileUtil
+import org.openedx.notifications.domain.interactor.NotificationsInteractor
 
 @ExperimentalCoroutinesApi
 class AppViewModelTest {
@@ -49,6 +50,7 @@ class AppViewModelTest {
     private val fileUtil = mockk<FileUtil>()
     private val deepLinkRouter = mockk<DeepLinkRouter>()
     private val context = mockk<Context>()
+    private val interactor = mockk<NotificationsInteractor>()
 
     private val user = User(0, "", "", "")
 
@@ -79,7 +81,8 @@ class AppViewModelTest {
             analytics,
             deepLinkRouter,
             fileUtil,
-            context
+            context,
+            interactor,
         )
 
         val mockLifeCycleOwner: LifecycleOwner = mockk()
@@ -114,7 +117,8 @@ class AppViewModelTest {
             analytics,
             deepLinkRouter,
             fileUtil,
-            context
+            context,
+            interactor,
         )
 
         val mockLifeCycleOwner: LifecycleOwner = mockk()
@@ -151,7 +155,8 @@ class AppViewModelTest {
             analytics,
             deepLinkRouter,
             fileUtil,
-            context
+            context,
+            interactor,
         )
 
         val mockLifeCycleOwner: LifecycleOwner = mockk()

--- a/core/src/main/java/org/openedx/core/system/PushGlobalManager.kt
+++ b/core/src/main/java/org/openedx/core/system/PushGlobalManager.kt
@@ -7,4 +7,6 @@ interface PushGlobalManager {
     suspend fun getUnreadNotificationsCount(): Int
 
     fun showNotificationsPrimer(context: Context, fragmentManager: FragmentManager)
+
+    suspend fun markNotificationAsRead(notificationId: Int)
 }

--- a/notifications/src/main/java/org/openedx/notifications/PushManager.kt
+++ b/notifications/src/main/java/org/openedx/notifications/PushManager.kt
@@ -92,6 +92,10 @@ class PushManager(
         )
     }
 
+    override suspend fun markNotificationAsRead(notificationId: Int) {
+        interactor.markNotificationAsRead(notificationId)
+    }
+
     companion object {
         const val PRIMER_MAX_DISMISSAL_COUNT = 3
         const val PRIMER_INITIAL_RESHOW_DAYS = 7


### PR DESCRIPTION
### Description

System notification tray interaction considerations

Jira: [LEARNER-10385](https://2u-internal.atlassian.net/browse/LEARNER-10385)

- Add functionality to mark a notification as read as soon as the app opens after the user taps on a notification from the system notification tray.

**Braze notification payload:**
```
{
  "external_user_id": "user_id",
  "send_to_existing_only": true | false,
  "trigger_properties": {
    "notification_id": notification_id,
    "notification_type": "discussion_comment",
    "course_id": "course_id",
    "topic_id": "topic_id",
    "thread_id": "thread_id",
    "comment_id": "comment_id",
    "replier_name": "replier_name",
    "course_name": "course_name"
  }
}
```

**Note:** The other points were already addressed earlier. I have conducted manual testing to ensure the scenarios are functioning as expected.




