### PR TITLE
feat: Add Loader in Notifications Primer

### DIFF
--- a/notifications/src/main/java/org/openedx/notifications/presentation/primer/NotificationsPrimerDialogFragment.kt
+++ b/notifications/src/main/java/org/openedx/notifications/presentation/primer/NotificationsPrimerDialogFragment.kt
@@ -1,18 +1,23 @@
 package org.openedx.notifications.presentation.primer
 
 import android.content.res.Configuration
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
@@ -63,6 +68,7 @@ class NotificationsPrimerDialogFragment : DialogFragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?,
     ) = ComposeView(requireContext()).apply {
+        dialog?.window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
         setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
         isCancelable = false
         setContent {
@@ -97,6 +103,15 @@ class NotificationsPrimerDialogFragment : DialogFragment() {
 
                     PrimerUIState.HideDialog -> {
                         // Do nothing
+                    }
+
+                    PrimerUIState.Loading -> {
+                        Box(
+                            modifier = Modifier.fillMaxSize(),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            CircularProgressIndicator(color = MaterialTheme.appColors.primary)
+                        }
                     }
                 }
             }

--- a/notifications/src/main/java/org/openedx/notifications/presentation/primer/NotificationsPrimerViewModel.kt
+++ b/notifications/src/main/java/org/openedx/notifications/presentation/primer/NotificationsPrimerViewModel.kt
@@ -21,11 +21,13 @@ class NotificationsPrimerViewModel(
     fun enableDiscussionNotificationsPreference() {
         viewModelScope.launch {
             try {
+                _uiState.value = PrimerUIState.Loading
                 interactor.updateNotificationsConfiguration(true)
                 resetNotificationsPrimerConfiguration()
-                _uiState.value = PrimerUIState.DismissDialog
             } catch (e: Exception) {
                 e.printStackTrace()
+            } finally {
+                _uiState.value = PrimerUIState.DismissDialog
             }
         }
     }

--- a/notifications/src/main/java/org/openedx/notifications/presentation/primer/PrimerUIState.kt
+++ b/notifications/src/main/java/org/openedx/notifications/presentation/primer/PrimerUIState.kt
@@ -4,4 +4,5 @@ sealed class PrimerUIState {
     data object ShowDialog : PrimerUIState()
     data object HideDialog : PrimerUIState()
     data object DismissDialog : PrimerUIState()
+    data object Loading: PrimerUIState()
 }


### PR DESCRIPTION
### Description

[Learner-10384](https://2u-internal.atlassian.net/browse/LEARNER-10384)

The app is in a halted state while sending the API call to update the notification preferences. As per UX design, a loader should be displayed during such states.

### Demo


https://github.com/user-attachments/assets/1964813a-0f19-4b5a-bdef-9d54929dc56b

_Note: A three-second delay has been added above for demo purposes only._