### PR TITLE
feat: Discussions Primer User Flow Optimization

### DIFF
--- a/discussion/src/main/java/org/openedx/discussion/presentation/threads/DiscussionThreadsViewModel.kt
+++ b/discussion/src/main/java/org/openedx/discussion/presentation/threads/DiscussionThreadsViewModel.kt
@@ -6,9 +6,9 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
 import org.openedx.core.R
 import org.openedx.core.SingleEventLiveData
@@ -54,8 +54,8 @@ class DiscussionThreadsViewModel(
     val canLoadMore: LiveData<Boolean>
         get() = _canLoadMore
 
-    private val _showPrimer = MutableStateFlow(false)
-    val showPrimer: StateFlow<Boolean> = _showPrimer.asStateFlow()
+    private val _showPrimer = MutableSharedFlow<Boolean>(0)
+    val showPrimer: SharedFlow<Boolean> = _showPrimer.asSharedFlow()
 
     private val threadsList = mutableListOf<org.openedx.discussion.domain.model.Thread>()
     private var nextPage = 1
@@ -88,7 +88,7 @@ class DiscussionThreadsViewModel(
                     is DiscussionCommentAdded,
                     is DiscussionResponseAdded,
                     is DiscussionThreadFollowed -> {
-                        _showPrimer.value = true
+                        _showPrimer.emit(true)
                     }
                 }
             }

--- a/notifications/src/main/java/org/openedx/notifications/presentation/primer/NotificationsPrimerDialogFragment.kt
+++ b/notifications/src/main/java/org/openedx/notifications/presentation/primer/NotificationsPrimerDialogFragment.kt
@@ -84,11 +84,12 @@ class NotificationsPrimerDialogFragment : DialogFragment() {
                                 viewModel.dismissDialog()
                             },
                             onNotifyClick = {
+                                viewModel.hideDialog()
                                 PermissionUtils.requestNotificationPermission(
                                     activity = requireActivity(),
                                     permissionLauncher = pushNotificationPermissionLauncher,
                                     onRationaleShown = {
-                                        viewModel.showRationalDialog()
+                                        viewModel.showRationaleDialog()
                                     },
                                 )
                             },
@@ -112,7 +113,7 @@ class NotificationsPrimerDialogFragment : DialogFragment() {
                         }
                     }
 
-                    PrimerUIState.ShowRationalDialog -> {
+                    PrimerUIState.ShowRationaleDialog -> {
                         ShowRationalePermissionDialog(
                             onNegativeButtonClick = {
                                 viewModel.dismissDialog()
@@ -129,24 +130,6 @@ class NotificationsPrimerDialogFragment : DialogFragment() {
                 }
             }
         }
-    }
-
-    @Composable
-    private fun ShowRationalePermissionDialog(
-        onPositiveButtonClick: () -> Unit = {},
-        onNegativeButtonClick: () -> Unit = {},
-    ) {
-        OpenEdxAlertDialog(
-            title = stringResource(id = CoreR.string.core_permission_dialog_title),
-            message = stringResource(
-                id = CoreR.string.core_permission_dialog_message,
-                stringResource(id = R.string.notifications_notifications).lowercase()
-            ),
-            positiveBtnText = stringResource(id = CoreR.string.core_continue),
-            negativeBtnText = stringResource(id = CoreR.string.core_cancel),
-            positiveBtnAction = onPositiveButtonClick,
-            negativeBtnAction = onNegativeButtonClick,
-        )
     }
 }
 
@@ -289,6 +272,24 @@ fun NotificationsPrimerButtons(
             }
         }
     }
+}
+
+@Composable
+private fun ShowRationalePermissionDialog(
+    onPositiveButtonClick: () -> Unit = {},
+    onNegativeButtonClick: () -> Unit = {},
+) {
+    OpenEdxAlertDialog(
+        title = stringResource(id = CoreR.string.core_permission_dialog_title),
+        message = stringResource(
+            id = CoreR.string.core_permission_dialog_message,
+            stringResource(id = R.string.notifications_notifications).lowercase()
+        ),
+        positiveBtnText = stringResource(id = CoreR.string.core_continue),
+        negativeBtnText = stringResource(id = CoreR.string.core_cancel),
+        positiveBtnAction = onPositiveButtonClick,
+        negativeBtnAction = onNegativeButtonClick,
+    )
 }
 
 @PreviewLightDark

--- a/notifications/src/main/java/org/openedx/notifications/presentation/primer/NotificationsPrimerDialogFragment.kt
+++ b/notifications/src/main/java/org/openedx/notifications/presentation/primer/NotificationsPrimerDialogFragment.kt
@@ -42,12 +42,14 @@ import androidx.fragment.app.DialogFragment
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.openedx.core.ui.OpenEdXBrandButton
 import org.openedx.core.ui.OpenEdXTertiaryButton
+import org.openedx.core.ui.OpenEdxAlertDialog
 import org.openedx.core.ui.rememberWindowSize
 import org.openedx.core.ui.theme.OpenEdXTheme
 import org.openedx.core.ui.theme.appColors
 import org.openedx.core.ui.theme.appTypography
 import org.openedx.notifications.R
 import org.openedx.notifications.utils.PermissionUtils
+import org.openedx.core.R as CoreR
 
 class NotificationsPrimerDialogFragment : DialogFragment() {
 
@@ -82,15 +84,11 @@ class NotificationsPrimerDialogFragment : DialogFragment() {
                                 viewModel.dismissDialog()
                             },
                             onNotifyClick = {
-                                viewModel.hideDialog()
                                 PermissionUtils.requestNotificationPermission(
                                     activity = requireActivity(),
                                     permissionLauncher = pushNotificationPermissionLauncher,
                                     onRationaleShown = {
-                                        PermissionUtils.navigateToNotificationSettings(
-                                            requireContext()
-                                        )
-                                        viewModel.dismissDialog()
+                                        viewModel.showRationalDialog()
                                     },
                                 )
                             },
@@ -113,9 +111,42 @@ class NotificationsPrimerDialogFragment : DialogFragment() {
                             CircularProgressIndicator(color = MaterialTheme.appColors.primary)
                         }
                     }
+
+                    PrimerUIState.ShowRationalDialog -> {
+                        ShowRationalePermissionDialog(
+                            onNegativeButtonClick = {
+                                viewModel.dismissDialog()
+                            },
+
+                            onPositiveButtonClick = {
+                                PermissionUtils.navigateToNotificationSettings(
+                                    requireContext()
+                                )
+                                viewModel.dismissDialog()
+                            },
+                        )
+                    }
                 }
             }
         }
+    }
+
+    @Composable
+    private fun ShowRationalePermissionDialog(
+        onPositiveButtonClick: () -> Unit = {},
+        onNegativeButtonClick: () -> Unit = {},
+    ) {
+        OpenEdxAlertDialog(
+            title = stringResource(id = CoreR.string.core_permission_dialog_title),
+            message = stringResource(
+                id = CoreR.string.core_permission_dialog_message,
+                stringResource(id = R.string.notifications_notifications).lowercase()
+            ),
+            positiveBtnText = stringResource(id = CoreR.string.core_continue),
+            negativeBtnText = stringResource(id = CoreR.string.core_cancel),
+            positiveBtnAction = onPositiveButtonClick,
+            negativeBtnAction = onNegativeButtonClick,
+        )
     }
 }
 

--- a/notifications/src/main/java/org/openedx/notifications/presentation/primer/NotificationsPrimerViewModel.kt
+++ b/notifications/src/main/java/org/openedx/notifications/presentation/primer/NotificationsPrimerViewModel.kt
@@ -44,7 +44,7 @@ class NotificationsPrimerViewModel(
         _uiState.value = PrimerUIState.DismissDialog
     }
 
-    fun showRationalDialog() {
-        _uiState.value = PrimerUIState.ShowRationalDialog
+    fun showRationaleDialog() {
+        _uiState.value = PrimerUIState.ShowRationaleDialog
     }
 }

--- a/notifications/src/main/java/org/openedx/notifications/presentation/primer/NotificationsPrimerViewModel.kt
+++ b/notifications/src/main/java/org/openedx/notifications/presentation/primer/NotificationsPrimerViewModel.kt
@@ -43,4 +43,8 @@ class NotificationsPrimerViewModel(
     fun dismissDialog() {
         _uiState.value = PrimerUIState.DismissDialog
     }
+
+    fun showRationalDialog() {
+        _uiState.value = PrimerUIState.ShowRationalDialog
+    }
 }

--- a/notifications/src/main/java/org/openedx/notifications/presentation/primer/PrimerUIState.kt
+++ b/notifications/src/main/java/org/openedx/notifications/presentation/primer/PrimerUIState.kt
@@ -4,6 +4,6 @@ sealed class PrimerUIState {
     data object ShowDialog : PrimerUIState()
     data object HideDialog : PrimerUIState()
     data object DismissDialog : PrimerUIState()
-    data object ShowRationalDialog : PrimerUIState()
+    data object ShowRationaleDialog : PrimerUIState()
     data object Loading: PrimerUIState()
 }

--- a/notifications/src/main/java/org/openedx/notifications/presentation/primer/PrimerUIState.kt
+++ b/notifications/src/main/java/org/openedx/notifications/presentation/primer/PrimerUIState.kt
@@ -4,5 +4,6 @@ sealed class PrimerUIState {
     data object ShowDialog : PrimerUIState()
     data object HideDialog : PrimerUIState()
     data object DismissDialog : PrimerUIState()
+    data object ShowRationalDialog : PrimerUIState()
     data object Loading: PrimerUIState()
 }


### PR DESCRIPTION
### Description

Jira: [LEARNER-10440](https://2u-internal.atlassian.net/browse/LEARNER-10440)

This ticket focuses on optimizing when the system permission prompt is shown after user interaction with the Discussion Notification Primer. The primer is already implemented, and the goal is to ensure a seamless user experience when requesting push notification permissions.

![image](https://github.com/user-attachments/assets/402ef741-fed2-4cb7-a942-183719fd24c6)

**Acceptance Criteria:**
- Show a custom message + settings redirection for users who have denied notifications.
- Ensure users don’t see the primer again after enabling notifications.
- Maintain the existing primer re-trigger logic.

**Example**
<video src="https://github.com/user-attachments/assets/f9291b6b-7951-4f29-96dc-7273436645f4"/>
