### PR TITLE
feat: Discussion Responses Order to Show Latest First & Fix Sorting and Filtering

### DIFF
--- a/discussion/src/main/java/org/openedx/discussion/data/api/DiscussionApi.kt
+++ b/discussion/src/main/java/org/openedx/discussion/data/api/DiscussionApi.kt
@@ -1,14 +1,23 @@
 package org.openedx.discussion.data.api
 
-import org.json.JSONObject
 import org.openedx.core.data.model.BlocksCompletionBody
-import org.openedx.discussion.data.model.request.*
+import org.openedx.discussion.data.model.request.CommentBody
+import org.openedx.discussion.data.model.request.FollowBody
+import org.openedx.discussion.data.model.request.ReadBody
+import org.openedx.discussion.data.model.request.ReportBody
+import org.openedx.discussion.data.model.request.ThreadBody
+import org.openedx.discussion.data.model.request.VoteBody
 import org.openedx.discussion.data.model.response.CommentResult
 import org.openedx.discussion.data.model.response.CommentsResponse
 import org.openedx.discussion.data.model.response.ThreadsResponse
-import org.openedx.discussion.data.model.response.ThreadsResponse.Thread
 import org.openedx.discussion.data.model.response.TopicsResponse
-import retrofit2.http.*
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.Headers
+import retrofit2.http.PATCH
+import retrofit2.http.POST
+import retrofit2.http.Path
+import retrofit2.http.Query
 
 interface DiscussionApi {
 
@@ -34,7 +43,7 @@ interface DiscussionApi {
         @Query("course_id") courseId: String,
         @Query("topic_id") topicId: String,
         @Query("requested_fields") requestedFields: List<String> = listOf("profile_image")
-    ): Thread
+    ): ThreadsResponse.Thread
 
     @GET("/api/discussion/v1/threads/")
     suspend fun searchThreads(
@@ -48,6 +57,7 @@ interface DiscussionApi {
     suspend fun getThreadComments(
         @Query("thread_id") threadId: String,
         @Query("page") page: Int,
+        @Query("reverse_order") reverseOrder: Boolean = true,
         @Query("requested_fields") requestedFields: List<String> = listOf("profile_image")
     ): CommentsResponse
 
@@ -62,6 +72,7 @@ interface DiscussionApi {
         @Query("thread_id") threadId: String,
         @Query("page") page: Int,
         @Query("endorsed") endorsed: Boolean,
+        @Query("reverse_order") reverseOrder: Boolean = true,
         @Query("requested_fields") requestedFields: List<String> = listOf("profile_image")
     ): CommentsResponse
 
@@ -111,16 +122,17 @@ interface DiscussionApi {
     suspend fun getCommentsResponses(
         @Path("comment_id") commentId: String,
         @Query("page") page: Int,
+        @Query("reverse_order") reverseOrder: Boolean = true,
         @Query("requested_fields") requestedFields: List<String> = listOf("profile_image")
     ): CommentsResponse
 
     @POST("/api/discussion/v1/comments/")
     suspend fun createComment(
         @Body commentBody: CommentBody
-    ) : CommentResult
+    ): CommentResult
 
     @POST("/api/discussion/v1/threads/")
-    suspend fun createThread(@Body threadBody: ThreadBody) : ThreadsResponse.Thread
+    suspend fun createThread(@Body threadBody: ThreadBody): ThreadsResponse.Thread
 
     @POST("/api/completion/v1/completion-batch")
     suspend fun markBlocksCompletion(

--- a/discussion/src/main/java/org/openedx/discussion/domain/interactor/DiscussionInteractor.kt
+++ b/discussion/src/main/java/org/openedx/discussion/domain/interactor/DiscussionInteractor.kt
@@ -16,10 +16,9 @@ class DiscussionInteractor(
 
     suspend fun getFollowingThreads(
         courseId: String,
-        following: Boolean,
         orderBy: String,
         page: Int
-    ) = repository.getCourseThreads(courseId, following, null, orderBy, null, page)
+    ) = repository.getCourseThreads(courseId, true, null, orderBy, null, page)
 
     suspend fun getThreads(
         courseId: String,

--- a/discussion/src/main/java/org/openedx/discussion/domain/interactor/DiscussionInteractor.kt
+++ b/discussion/src/main/java/org/openedx/discussion/domain/interactor/DiscussionInteractor.kt
@@ -18,10 +18,8 @@ class DiscussionInteractor(
         courseId: String,
         following: Boolean,
         orderBy: String,
-        view: String? = null,
         page: Int
-    ) =
-        repository.getCourseThreads(courseId, following, null, orderBy, view, page)
+    ) = repository.getCourseThreads(courseId, following, null, orderBy, null, page)
 
     suspend fun getThreads(
         courseId: String,

--- a/discussion/src/main/java/org/openedx/discussion/presentation/comments/DiscussionCommentsViewModel.kt
+++ b/discussion/src/main/java/org/openedx/discussion/presentation/comments/DiscussionCommentsViewModel.kt
@@ -286,7 +286,6 @@ class DiscussionCommentsViewModel(
                 sendThreadUpdated()
 
                 comments.add(0, response)
-
                 _uiState.value =
                     DiscussionCommentsUIState.Success(thread, comments.toList(), commentCount)
                 logResponseAddedEvent(

--- a/discussion/src/main/java/org/openedx/discussion/presentation/comments/DiscussionCommentsViewModel.kt
+++ b/discussion/src/main/java/org/openedx/discussion/presentation/comments/DiscussionCommentsViewModel.kt
@@ -320,12 +320,9 @@ class DiscussionCommentsViewModel(
 
                 thread = thread.copy(commentCount = thread.commentCount + 1)
                 sendThreadUpdated()
-                if (page == -1) {
-                    comments.add(response)
-                } else {
-                    _uiMessage.value =
-                        UIMessage.ToastMessage(resourceManager.getString(org.openedx.discussion.R.string.discussion_comment_added))
-                }
+
+                comments.add(0, response)
+
                 _uiState.value =
                     DiscussionCommentsUIState.Success(thread, comments.toList(), commentCount)
                 logResponseAddedEvent(

--- a/discussion/src/main/java/org/openedx/discussion/presentation/comments/DiscussionCommentsViewModel.kt
+++ b/discussion/src/main/java/org/openedx/discussion/presentation/comments/DiscussionCommentsViewModel.kt
@@ -133,13 +133,7 @@ class DiscussionCommentsViewModel(
                     markRead()
                 }
             } catch (e: Exception) {
-                if (e.isInternetError()) {
-                    _uiMessage.value =
-                        UIMessage.SnackBarMessage(resourceManager.getString(R.string.core_error_no_connection))
-                } else {
-                    _uiMessage.value =
-                        UIMessage.SnackBarMessage(resourceManager.getString(R.string.core_error_unknown_error))
-                }
+                handleException(e)
             } finally {
                 isLoading = false
                 _isUpdating.value = false
@@ -194,13 +188,7 @@ class DiscussionCommentsViewModel(
                     author = thread.author
                 )
             } catch (e: Exception) {
-                if (e.isInternetError()) {
-                    _uiMessage.value =
-                        UIMessage.SnackBarMessage(resourceManager.getString(R.string.core_error_no_connection))
-                } else {
-                    _uiMessage.value =
-                        UIMessage.SnackBarMessage(resourceManager.getString(R.string.core_error_unknown_error))
-                }
+                handleException(e)
             }
         }
     }
@@ -219,13 +207,7 @@ class DiscussionCommentsViewModel(
                     notifier.send(DiscussionThreadFollowed())
                 }
             } catch (e: Exception) {
-                if (e.isInternetError()) {
-                    _uiMessage.value =
-                        UIMessage.SnackBarMessage(resourceManager.getString(R.string.core_error_no_connection))
-                } else {
-                    _uiMessage.value =
-                        UIMessage.SnackBarMessage(resourceManager.getString(R.string.core_error_unknown_error))
-                }
+                handleException(e)
             }
         }
     }
@@ -244,13 +226,7 @@ class DiscussionCommentsViewModel(
                     author = thread.author
                 )
             } catch (e: Exception) {
-                if (e.isInternetError()) {
-                    _uiMessage.value =
-                        UIMessage.SnackBarMessage(resourceManager.getString(R.string.core_error_no_connection))
-                } else {
-                    _uiMessage.value =
-                        UIMessage.SnackBarMessage(resourceManager.getString(R.string.core_error_unknown_error))
-                }
+                handleException(e)
             }
         }
     }
@@ -273,13 +249,7 @@ class DiscussionCommentsViewModel(
                     author = response.author
                 )
             } catch (e: Exception) {
-                if (e.isInternetError()) {
-                    _uiMessage.value =
-                        UIMessage.SnackBarMessage(resourceManager.getString(R.string.core_error_no_connection))
-                } else {
-                    _uiMessage.value =
-                        UIMessage.SnackBarMessage(resourceManager.getString(R.string.core_error_unknown_error))
-                }
+                handleException(e)
             }
         }
     }
@@ -301,13 +271,7 @@ class DiscussionCommentsViewModel(
                     author = response.author
                 )
             } catch (e: Exception) {
-                if (e.isInternetError()) {
-                    _uiMessage.value =
-                        UIMessage.SnackBarMessage(resourceManager.getString(R.string.core_error_no_connection))
-                } else {
-                    _uiMessage.value =
-                        UIMessage.SnackBarMessage(resourceManager.getString(R.string.core_error_unknown_error))
-                }
+                handleException(e)
             }
         }
     }
@@ -332,15 +296,18 @@ class DiscussionCommentsViewModel(
 
                 notifier.send(DiscussionCommentAdded())
             } catch (e: Exception) {
-                if (e.isInternetError()) {
-                    _uiMessage.value =
-                        UIMessage.SnackBarMessage(resourceManager.getString(R.string.core_error_no_connection))
-                } else {
-                    _uiMessage.value =
-                        UIMessage.SnackBarMessage(resourceManager.getString(R.string.core_error_unknown_error))
-                }
+                handleException(e)
             }
         }
     }
 
+    private fun handleException(e: Exception) {
+        if (e.isInternetError()) {
+            _uiMessage.value =
+                UIMessage.SnackBarMessage(resourceManager.getString(R.string.core_error_no_connection))
+        } else {
+            _uiMessage.value =
+                UIMessage.SnackBarMessage(resourceManager.getString(R.string.core_error_unknown_error))
+        }
+    }
 }

--- a/discussion/src/main/java/org/openedx/discussion/presentation/responses/DiscussionResponsesViewModel.kt
+++ b/discussion/src/main/java/org/openedx/discussion/presentation/responses/DiscussionResponsesViewModel.kt
@@ -96,13 +96,7 @@ class DiscussionResponsesViewModel(
                 })
                 _uiState.value = DiscussionResponsesUIState.Success(comment, comments.toList())
             } catch (e: Exception) {
-                if (e.isInternetError()) {
-                    _uiMessage.value =
-                        UIMessage.SnackBarMessage(resourceManager.getString(R.string.core_error_no_connection))
-                } else {
-                    _uiMessage.value =
-                        UIMessage.SnackBarMessage(resourceManager.getString(R.string.core_error_unknown_error))
-                }
+                handleException(e)
             } finally {
                 isLoading = false
                 _isUpdating.value = false
@@ -139,13 +133,7 @@ class DiscussionResponsesViewModel(
                 }
                 _uiState.value = DiscussionResponsesUIState.Success(comment, comments.toList())
             } catch (e: Exception) {
-                if (e.isInternetError()) {
-                    _uiMessage.value =
-                        UIMessage.SnackBarMessage(resourceManager.getString(R.string.core_error_no_connection))
-                } else {
-                    _uiMessage.value =
-                        UIMessage.SnackBarMessage(resourceManager.getString(R.string.core_error_unknown_error))
-                }
+                handleException(e)
             }
         }
     }
@@ -178,13 +166,7 @@ class DiscussionResponsesViewModel(
                 }
                 _uiState.value = DiscussionResponsesUIState.Success(comment, comments.toList())
             } catch (e: Exception) {
-                if (e.isInternetError()) {
-                    _uiMessage.value =
-                        UIMessage.SnackBarMessage(resourceManager.getString(R.string.core_error_no_connection))
-                } else {
-                    _uiMessage.value =
-                        UIMessage.SnackBarMessage(resourceManager.getString(R.string.core_error_unknown_error))
-                }
+                handleException(e)
             }
         }
     }
@@ -210,15 +192,18 @@ class DiscussionResponsesViewModel(
 
                 notifier.send(DiscussionResponseAdded())
             } catch (e: Exception) {
-                if (e.isInternetError()) {
-                    _uiMessage.value =
-                        UIMessage.SnackBarMessage(resourceManager.getString(R.string.core_error_no_connection))
-                } else {
-                    _uiMessage.value =
-                        UIMessage.SnackBarMessage(resourceManager.getString(R.string.core_error_unknown_error))
-                }
+                handleException(e)
             }
         }
     }
 
+    private fun handleException(e: Exception) {
+        if (e.isInternetError()) {
+            _uiMessage.value =
+                UIMessage.SnackBarMessage(resourceManager.getString(R.string.core_error_no_connection))
+        } else {
+            _uiMessage.value =
+                UIMessage.SnackBarMessage(resourceManager.getString(R.string.core_error_unknown_error))
+        }
+    }
 }

--- a/discussion/src/main/java/org/openedx/discussion/presentation/responses/DiscussionResponsesViewModel.kt
+++ b/discussion/src/main/java/org/openedx/discussion/presentation/responses/DiscussionResponsesViewModel.kt
@@ -197,12 +197,9 @@ class DiscussionResponsesViewModel(
 
                 comment = comment.copy(childCount = comment.childCount + 1)
                 sendUpdatedComment()
-                if (page == -1) {
-                    comments.add(response)
-                } else {
-                    _uiMessage.value =
-                        UIMessage.ToastMessage(resourceManager.getString(org.openedx.discussion.R.string.discussion_comment_added))
-                }
+
+                comments.add(0, response)
+
                 _uiState.value =
                     DiscussionResponsesUIState.Success(comment, comments.toList())
                 logCommentAddedEvent(

--- a/discussion/src/main/java/org/openedx/discussion/presentation/responses/DiscussionResponsesViewModel.kt
+++ b/discussion/src/main/java/org/openedx/discussion/presentation/responses/DiscussionResponsesViewModel.kt
@@ -181,7 +181,6 @@ class DiscussionResponsesViewModel(
                 sendUpdatedComment()
 
                 comments.add(0, response)
-
                 _uiState.value =
                     DiscussionResponsesUIState.Success(comment, comments.toList())
                 logCommentAddedEvent(

--- a/discussion/src/main/java/org/openedx/discussion/presentation/threads/DiscussionThreadsFragment.kt
+++ b/discussion/src/main/java/org/openedx/discussion/presentation/threads/DiscussionThreadsFragment.kt
@@ -161,7 +161,7 @@ class DiscussionThreadsFragment : Fragment() {
                     viewType = viewType,
                     refreshing = refreshing,
                     onSwipeRefresh = {
-                        viewModel.refreshThreads(SortType.LAST_ACTIVITY_AT.queryParam)
+                        viewModel.refreshThreads()
                     },
                     updatedOrder = {
                         viewModel.sortThreads(it)

--- a/discussion/src/main/java/org/openedx/discussion/presentation/threads/DiscussionThreadsFragment.kt
+++ b/discussion/src/main/java/org/openedx/discussion/presentation/threads/DiscussionThreadsFragment.kt
@@ -417,6 +417,7 @@ private fun DiscussionThreadsScreen(
                         }
                         coroutine.launch {
                             bottomSheetScaffoldState.hide()
+                            scrollState.animateScrollToItem(index = 0)
                         }
                     },
                     searchValueChanged = {

--- a/discussion/src/main/java/org/openedx/discussion/presentation/threads/DiscussionThreadsFragment.kt
+++ b/discussion/src/main/java/org/openedx/discussion/presentation/threads/DiscussionThreadsFragment.kt
@@ -161,10 +161,10 @@ class DiscussionThreadsFragment : Fragment() {
                     viewType = viewType,
                     refreshing = refreshing,
                     onSwipeRefresh = {
-                        viewModel.updateThread(SortType.LAST_ACTIVITY_AT.queryParam)
+                        viewModel.refreshThreads(SortType.LAST_ACTIVITY_AT.queryParam)
                     },
                     updatedOrder = {
-                        viewModel.getThreadByType(it)
+                        viewModel.sortThreads(it)
                     },
                     updatedFilter = {
                         viewModel.filterThreads(it)

--- a/discussion/src/main/java/org/openedx/discussion/presentation/threads/DiscussionThreadsViewModel.kt
+++ b/discussion/src/main/java/org/openedx/discussion/presentation/threads/DiscussionThreadsViewModel.kt
@@ -96,31 +96,14 @@ class DiscussionThreadsViewModel(
     }
 
     init {
-        internalLoadThreads()
+        loadThreads()
         logTopicScreenEvent(topicId)
     }
 
-    private fun internalLoadThreads() {
+    private fun loadThreads() {
         viewModelScope.launch {
             try {
-                val response = when (threadType) {
-                    DiscussionTopicsViewModel.ALL_POSTS -> {
-                        interactor.getAllThreads(courseId, lastOrderBy, filterType, nextPage)
-                    }
-
-                    DiscussionTopicsViewModel.FOLLOWING_POSTS -> {
-                        interactor.getFollowingThreads(courseId, lastOrderBy, nextPage)
-                    }
-
-                    DiscussionTopicsViewModel.TOPIC -> {
-                        interactor.getThreads(courseId, topicId, lastOrderBy, filterType, nextPage)
-                    }
-
-                    else -> {
-                        throw Exception("")
-                    }
-                }
-
+                val response = fetchThreads()
                 if (response.pagination.next.isNotEmpty()) {
                     _canLoadMore.value = true
                     nextPage++
@@ -138,16 +121,33 @@ class DiscussionThreadsViewModel(
                     _uiMessage.value =
                         UIMessage.SnackBarMessage(resourceManager.getString(R.string.core_error_unknown_error))
                 }
+            } finally {
+                _isUpdating.value = false
+                isLoading = false
             }
-            _isUpdating.value = false
-            isLoading = false
         }
+    }
+
+    private suspend fun fetchThreads() = when (threadType) {
+        DiscussionTopicsViewModel.ALL_POSTS -> {
+            interactor.getAllThreads(courseId, lastOrderBy, filterType, nextPage)
+        }
+
+        DiscussionTopicsViewModel.FOLLOWING_POSTS -> {
+            interactor.getFollowingThreads(courseId, lastOrderBy, nextPage)
+        }
+
+        DiscussionTopicsViewModel.TOPIC -> {
+            interactor.getThreads(courseId, topicId, lastOrderBy, filterType, nextPage)
+        }
+
+        else -> throw IllegalArgumentException("Invalid thread type")
     }
 
     fun fetchMore() {
         if (!isLoading && nextPage != -1) {
             isLoading = true
-            internalLoadThreads()
+            loadThreads()
         }
     }
 
@@ -155,7 +155,7 @@ class DiscussionThreadsViewModel(
         _isUpdating.value = true
         threadsList.clear()
         nextPage = 1
-        internalLoadThreads()
+        loadThreads()
     }
 
     fun sortThreads(orderBy: String) {
@@ -164,35 +164,27 @@ class DiscussionThreadsViewModel(
             threadsList.clear()
             nextPage = 1
         }
-        internalLoadThreads()
+        loadThreads()
     }
 
     fun filterThreads(filter: String?) {
-        if (filterType != filter || (filter != FilterType.ALL_POSTS.value && filterType.isNullOrEmpty())) {
+        if (filterType != filter || filterType.isNullOrEmpty()) {
             threadsList.clear()
             nextPage = 1
         }
-        filterType = if (filter == FilterType.ALL_POSTS.value) {
-            null
-        } else {
-            filter
-        }
-        internalLoadThreads()
+        filterType = filter.takeUnless { it == FilterType.ALL_POSTS.value }
+        loadThreads()
     }
 
     fun markBlockCompleted(blockId: String) {
-        if (!isBlockAlreadyCompleted) {
-            viewModelScope.launch {
-                try {
-                    isBlockAlreadyCompleted = true
-                    interactor.markBlocksCompletion(
-                        courseId,
-                        listOf(blockId)
-                    )
-                } catch (e: Exception) {
-                    isBlockAlreadyCompleted = false
-                    e.printStackTrace()
-                }
+        if (isBlockAlreadyCompleted) return
+        viewModelScope.launch {
+            try {
+                isBlockAlreadyCompleted = true
+                interactor.markBlocksCompletion(courseId, listOf(blockId))
+            } catch (e: Exception) {
+                isBlockAlreadyCompleted = false
+                e.printStackTrace()
             }
         }
     }

--- a/discussion/src/main/java/org/openedx/discussion/presentation/threads/DiscussionThreadsViewModel.kt
+++ b/discussion/src/main/java/org/openedx/discussion/presentation/threads/DiscussionThreadsViewModel.kt
@@ -100,10 +100,6 @@ class DiscussionThreadsViewModel(
         logTopicScreenEvent(topicId)
     }
 
-    private fun internalLoadThreads() {
-        getThreads()
-    }
-
     private fun getThreads() {
         viewModelScope.launch {
             try {
@@ -151,7 +147,7 @@ class DiscussionThreadsViewModel(
     fun fetchMore() {
         if (!isLoading && nextPage != -1) {
             isLoading = true
-            internalLoadThreads()
+            getThreads()
         }
     }
 
@@ -159,7 +155,7 @@ class DiscussionThreadsViewModel(
         _isUpdating.value = true
         threadsList.clear()
         nextPage = 1
-        internalLoadThreads()
+        getThreads()
     }
 
     fun sortThreads(orderBy: String) {
@@ -168,7 +164,7 @@ class DiscussionThreadsViewModel(
             threadsList.clear()
             nextPage = 1
         }
-        internalLoadThreads()
+        getThreads()
     }
 
     fun filterThreads(filter: String?) {

--- a/discussion/src/main/java/org/openedx/discussion/presentation/threads/DiscussionThreadsViewModel.kt
+++ b/discussion/src/main/java/org/openedx/discussion/presentation/threads/DiscussionThreadsViewModel.kt
@@ -60,7 +60,7 @@ class DiscussionThreadsViewModel(
     private val threadsList = mutableListOf<org.openedx.discussion.domain.model.Thread>()
     private var nextPage = 1
     private var isLoading = false
-    private var lastOrderBy = ""
+    private var lastOrderBy = SortType.LAST_ACTIVITY_AT.queryParam
     private var filterType: String? = null
 
     private var isBlockAlreadyCompleted = false
@@ -96,47 +96,11 @@ class DiscussionThreadsViewModel(
     }
 
     init {
-        sortThreads(SortType.LAST_ACTIVITY_AT.queryParam)
+        getThreads()
         logTopicScreenEvent(topicId)
     }
 
-    fun sortThreads(orderBy: String) {
-        if (lastOrderBy != orderBy) {
-            lastOrderBy = orderBy
-            threadsList.clear()
-            nextPage = 1
-        }
-        internalLoadThreads()
-    }
-
-    fun refreshThreads() {
-        _isUpdating.value = true
-        threadsList.clear()
-        nextPage = 1
-        internalLoadThreads()
-    }
-
-    fun fetchMore() {
-        if (!isLoading && nextPage != -1) {
-            isLoading = true
-            internalLoadThreads()
-        }
-    }
-
     private fun internalLoadThreads() {
-        getThreads()
-    }
-
-    fun filterThreads(filter: String?) {
-        if (filterType != filter || (filter != FilterType.ALL_POSTS.value && filterType.isNullOrEmpty())) {
-            threadsList.clear()
-            nextPage = 1
-        }
-        filterType = if (filter == FilterType.ALL_POSTS.value) {
-            null
-        } else {
-            filter
-        }
         getThreads()
     }
 
@@ -182,6 +146,42 @@ class DiscussionThreadsViewModel(
             _isUpdating.value = false
             isLoading = false
         }
+    }
+
+    fun fetchMore() {
+        if (!isLoading && nextPage != -1) {
+            isLoading = true
+            internalLoadThreads()
+        }
+    }
+
+    fun refreshThreads() {
+        _isUpdating.value = true
+        threadsList.clear()
+        nextPage = 1
+        internalLoadThreads()
+    }
+
+    fun sortThreads(orderBy: String) {
+        if (lastOrderBy != orderBy) {
+            lastOrderBy = orderBy
+            threadsList.clear()
+            nextPage = 1
+        }
+        internalLoadThreads()
+    }
+
+    fun filterThreads(filter: String?) {
+        if (filterType != filter || (filter != FilterType.ALL_POSTS.value && filterType.isNullOrEmpty())) {
+            threadsList.clear()
+            nextPage = 1
+        }
+        filterType = if (filter == FilterType.ALL_POSTS.value) {
+            null
+        } else {
+            filter
+        }
+        getThreads()
     }
 
     fun markBlockCompleted(blockId: String) {

--- a/discussion/src/main/java/org/openedx/discussion/presentation/threads/DiscussionThreadsViewModel.kt
+++ b/discussion/src/main/java/org/openedx/discussion/presentation/threads/DiscussionThreadsViewModel.kt
@@ -71,7 +71,7 @@ class DiscussionThreadsViewModel(
             notifier.notifier.collect {
                 if (it is DiscussionThreadAdded) {
                     if (lastOrderBy.isNotEmpty()) {
-                        updateThread(lastOrderBy)
+                        refreshThreads(lastOrderBy)
                     }
                 } else if (it is DiscussionThreadDataChanged) {
                     val index = threadsList.indexOfFirst { thread ->
@@ -96,16 +96,16 @@ class DiscussionThreadsViewModel(
     }
 
     init {
-        getThreadByType(SortType.LAST_ACTIVITY_AT.queryParam)
+        sortThreads(SortType.LAST_ACTIVITY_AT.queryParam)
         logTopicScreenEvent(topicId)
     }
 
-    fun getThreadByType(orderBy: String) {
+    fun sortThreads(orderBy: String) {
         _uiState.value = DiscussionThreadsUIState.Loading
         internalLoadThreads(orderBy)
     }
 
-    fun updateThread(orderBy: String) {
+    fun refreshThreads(orderBy: String) {
         _isUpdating.value = true
         threadsList.clear()
         nextPage = 1

--- a/discussion/src/main/java/org/openedx/discussion/presentation/threads/DiscussionThreadsViewModel.kt
+++ b/discussion/src/main/java/org/openedx/discussion/presentation/threads/DiscussionThreadsViewModel.kt
@@ -38,7 +38,8 @@ class DiscussionThreadsViewModel(
     analytics: DiscussionAnalytics,
 ) : BaseDiscussionViewModel(courseId, "", analytics) {
 
-    private val _uiState = MutableLiveData<DiscussionThreadsUIState>()
+    private val _uiState =
+        MutableLiveData<DiscussionThreadsUIState>(DiscussionThreadsUIState.Loading)
     val uiState: LiveData<DiscussionThreadsUIState>
         get() = _uiState
 
@@ -159,20 +160,16 @@ class DiscussionThreadsViewModel(
     }
 
     fun sortThreads(orderBy: String) {
-        if (lastOrderBy != orderBy) {
-            lastOrderBy = orderBy
-            threadsList.clear()
-            nextPage = 1
-        }
+        lastOrderBy = orderBy
+        threadsList.clear()
+        nextPage = 1
         loadThreads()
     }
 
     fun filterThreads(filter: String?) {
-        if (filterType != filter || filterType.isNullOrEmpty()) {
-            threadsList.clear()
-            nextPage = 1
-        }
         filterType = filter.takeUnless { it == FilterType.ALL_POSTS.value }
+        threadsList.clear()
+        nextPage = 1
         loadThreads()
     }
 

--- a/discussion/src/main/java/org/openedx/discussion/presentation/threads/DiscussionThreadsViewModel.kt
+++ b/discussion/src/main/java/org/openedx/discussion/presentation/threads/DiscussionThreadsViewModel.kt
@@ -17,6 +17,7 @@ import org.openedx.core.extension.isInternetError
 import org.openedx.core.system.PushGlobalManager
 import org.openedx.core.system.ResourceManager
 import org.openedx.discussion.domain.interactor.DiscussionInteractor
+import org.openedx.discussion.domain.model.ThreadsData
 import org.openedx.discussion.presentation.BaseDiscussionViewModel
 import org.openedx.discussion.presentation.DiscussionAnalytics
 import org.openedx.discussion.presentation.topics.DiscussionTopicsViewModel
@@ -62,7 +63,7 @@ class DiscussionThreadsViewModel(
     private var nextPage = 1
     private var isLoading = false
     private var lastOrderBy = SortType.LAST_ACTIVITY_AT.queryParam
-    private var filterType: String? = null
+    private var lastFilterType = FilterType.ALL_POSTS.value
 
     private var isBlockAlreadyCompleted = false
 
@@ -129,20 +130,24 @@ class DiscussionThreadsViewModel(
         }
     }
 
-    private suspend fun fetchThreads() = when (threadType) {
-        DiscussionTopicsViewModel.ALL_POSTS -> {
-            interactor.getAllThreads(courseId, lastOrderBy, filterType, nextPage)
-        }
+    private suspend fun fetchThreads(): ThreadsData {
+        val filterValue = lastFilterType.takeUnless { it == FilterType.ALL_POSTS.value }
 
-        DiscussionTopicsViewModel.FOLLOWING_POSTS -> {
-            interactor.getFollowingThreads(courseId, lastOrderBy, nextPage)
-        }
+        return when (threadType) {
+            DiscussionTopicsViewModel.ALL_POSTS -> {
+                interactor.getAllThreads(courseId, lastOrderBy, filterValue, nextPage)
+            }
 
-        DiscussionTopicsViewModel.TOPIC -> {
-            interactor.getThreads(courseId, topicId, lastOrderBy, filterType, nextPage)
-        }
+            DiscussionTopicsViewModel.FOLLOWING_POSTS -> {
+                interactor.getFollowingThreads(courseId, lastOrderBy, nextPage)
+            }
 
-        else -> throw IllegalArgumentException("Invalid thread type")
+            DiscussionTopicsViewModel.TOPIC -> {
+                interactor.getThreads(courseId, topicId, lastOrderBy, filterValue, nextPage)
+            }
+
+            else -> throw IllegalArgumentException("Invalid thread type")
+        }
     }
 
     fun fetchMore() {
@@ -160,17 +165,21 @@ class DiscussionThreadsViewModel(
     }
 
     fun sortThreads(orderBy: String) {
-        lastOrderBy = orderBy
-        threadsList.clear()
-        nextPage = 1
-        loadThreads()
+        if (lastOrderBy != orderBy) {
+            lastOrderBy = orderBy
+            threadsList.clear()
+            nextPage = 1
+            loadThreads()
+        }
     }
 
-    fun filterThreads(filter: String?) {
-        filterType = filter.takeUnless { it == FilterType.ALL_POSTS.value }
-        threadsList.clear()
-        nextPage = 1
-        loadThreads()
+    fun filterThreads(filter: String) {
+        if (lastFilterType != filter) {
+            lastFilterType = filter
+            threadsList.clear()
+            nextPage = 1
+            loadThreads()
+        }
     }
 
     fun markBlockCompleted(blockId: String) {

--- a/discussion/src/main/java/org/openedx/discussion/presentation/threads/DiscussionThreadsViewModel.kt
+++ b/discussion/src/main/java/org/openedx/discussion/presentation/threads/DiscussionThreadsViewModel.kt
@@ -135,7 +135,6 @@ class DiscussionThreadsViewModel(
 
             DiscussionTopicsViewModel.TOPIC -> {
                 getThreads(
-                    topicId,
                     orderBy
                 )
             }
@@ -163,14 +162,13 @@ class DiscussionThreadsViewModel(
 
             DiscussionTopicsViewModel.TOPIC -> {
                 getThreads(
-                    topicId,
                     lastOrderBy
                 )
             }
         }
     }
 
-    private fun getThreads(topicId: String, orderBy: String) {
+    private fun getThreads(orderBy: String) {
         viewModelScope.launch {
             try {
                 val response =

--- a/discussion/src/main/java/org/openedx/discussion/presentation/threads/DiscussionThreadsViewModel.kt
+++ b/discussion/src/main/java/org/openedx/discussion/presentation/threads/DiscussionThreadsViewModel.kt
@@ -124,19 +124,7 @@ class DiscussionThreadsViewModel(
     }
 
     private fun internalLoadThreads() {
-        when (threadType) {
-            DiscussionTopicsViewModel.ALL_POSTS -> {
-                getAllThreads()
-            }
-
-            DiscussionTopicsViewModel.FOLLOWING_POSTS -> {
-                getFollowingThreads()
-            }
-
-            DiscussionTopicsViewModel.TOPIC -> {
-                getThreads()
-            }
-        }
+        getThreads()
     }
 
     fun filterThreads(filter: String?) {
@@ -149,81 +137,30 @@ class DiscussionThreadsViewModel(
         } else {
             filter
         }
-        when (threadType) {
-            DiscussionTopicsViewModel.ALL_POSTS -> {
-                getAllThreads()
-            }
-
-            DiscussionTopicsViewModel.FOLLOWING_POSTS -> {
-                getFollowingThreads()
-            }
-
-            DiscussionTopicsViewModel.TOPIC -> {
-                getThreads()
-            }
-        }
+        getThreads()
     }
 
     private fun getThreads() {
         viewModelScope.launch {
             try {
-                val response =
-                    interactor.getThreads(courseId, topicId, lastOrderBy, filterType, nextPage)
-                if (response.pagination.next.isNotEmpty()) {
-                    _canLoadMore.value = true
-                    nextPage++
-                } else {
-                    _canLoadMore.value = false
-                    nextPage = -1
-                }
-                threadsList.addAll(response.results)
-                _uiState.value = DiscussionThreadsUIState.Threads(threadsList.toList())
-            } catch (e: Exception) {
-                if (e.isInternetError()) {
-                    _uiMessage.value =
-                        UIMessage.SnackBarMessage(resourceManager.getString(R.string.core_error_no_connection))
-                } else {
-                    _uiMessage.value =
-                        UIMessage.SnackBarMessage(resourceManager.getString(R.string.core_error_unknown_error))
-                }
-            }
-            _isUpdating.value = false
-            isLoading = false
-        }
-    }
+                val response = when (threadType) {
+                    DiscussionTopicsViewModel.ALL_POSTS -> {
+                        interactor.getAllThreads(courseId, lastOrderBy, filterType, nextPage)
+                    }
 
-    private fun getAllThreads() {
-        viewModelScope.launch {
-            try {
-                val response = interactor.getAllThreads(courseId, lastOrderBy, filterType, nextPage)
-                if (response.pagination.next.isNotEmpty()) {
-                    _canLoadMore.value = true
-                    nextPage++
-                } else {
-                    _canLoadMore.value = false
-                    nextPage = -1
-                }
-                threadsList.addAll(response.results)
-                _uiState.value = DiscussionThreadsUIState.Threads(threadsList.toList())
-            } catch (e: Exception) {
-                if (e.isInternetError()) {
-                    _uiMessage.value =
-                        UIMessage.SnackBarMessage(resourceManager.getString(R.string.core_error_no_connection))
-                } else {
-                    _uiMessage.value =
-                        UIMessage.SnackBarMessage(resourceManager.getString(R.string.core_error_unknown_error))
-                }
-            }
-            _isUpdating.value = false
-            isLoading = false
-        }
-    }
+                    DiscussionTopicsViewModel.FOLLOWING_POSTS -> {
+                        interactor.getFollowingThreads(courseId, true, lastOrderBy, nextPage)
+                    }
 
-    private fun getFollowingThreads() {
-        viewModelScope.launch {
-            try {
-                val response =
-                    interactor.getFollowingThreads(courseId, true, lastOrderBy, page = nextPage)
+                    DiscussionTopicsViewModel.TOPIC -> {
+                        interactor.getThreads(courseId, topicId, lastOrderBy, filterType, nextPage)
+                    }
+
+                    else -> {
+                        throw Exception("")
+                    }
+                }
+
                 if (response.pagination.next.isNotEmpty()) {
                     _canLoadMore.value = true
                     nextPage++

--- a/discussion/src/main/java/org/openedx/discussion/presentation/threads/DiscussionThreadsViewModel.kt
+++ b/discussion/src/main/java/org/openedx/discussion/presentation/threads/DiscussionThreadsViewModel.kt
@@ -101,7 +101,6 @@ class DiscussionThreadsViewModel(
     }
 
     fun sortThreads(orderBy: String) {
-        _uiState.value = DiscussionThreadsUIState.Loading
         internalLoadThreads(orderBy)
     }
 

--- a/discussion/src/main/java/org/openedx/discussion/presentation/threads/DiscussionThreadsViewModel.kt
+++ b/discussion/src/main/java/org/openedx/discussion/presentation/threads/DiscussionThreadsViewModel.kt
@@ -96,11 +96,11 @@ class DiscussionThreadsViewModel(
     }
 
     init {
-        getThreads()
+        internalLoadThreads()
         logTopicScreenEvent(topicId)
     }
 
-    private fun getThreads() {
+    private fun internalLoadThreads() {
         viewModelScope.launch {
             try {
                 val response = when (threadType) {
@@ -147,7 +147,7 @@ class DiscussionThreadsViewModel(
     fun fetchMore() {
         if (!isLoading && nextPage != -1) {
             isLoading = true
-            getThreads()
+            internalLoadThreads()
         }
     }
 
@@ -155,7 +155,7 @@ class DiscussionThreadsViewModel(
         _isUpdating.value = true
         threadsList.clear()
         nextPage = 1
-        getThreads()
+        internalLoadThreads()
     }
 
     fun sortThreads(orderBy: String) {
@@ -164,7 +164,7 @@ class DiscussionThreadsViewModel(
             threadsList.clear()
             nextPage = 1
         }
-        getThreads()
+        internalLoadThreads()
     }
 
     fun filterThreads(filter: String?) {
@@ -177,7 +177,7 @@ class DiscussionThreadsViewModel(
         } else {
             filter
         }
-        getThreads()
+        internalLoadThreads()
     }
 
     fun markBlockCompleted(blockId: String) {

--- a/discussion/src/main/java/org/openedx/discussion/presentation/threads/DiscussionThreadsViewModel.kt
+++ b/discussion/src/main/java/org/openedx/discussion/presentation/threads/DiscussionThreadsViewModel.kt
@@ -71,7 +71,7 @@ class DiscussionThreadsViewModel(
             notifier.notifier.collect {
                 if (it is DiscussionThreadAdded) {
                     if (lastOrderBy.isNotEmpty()) {
-                        refreshThreads(lastOrderBy)
+                        refreshThreads()
                     }
                 } else if (it is DiscussionThreadDataChanged) {
                     val index = threadsList.indexOfFirst { thread ->
@@ -101,42 +101,40 @@ class DiscussionThreadsViewModel(
     }
 
     fun sortThreads(orderBy: String) {
-        internalLoadThreads(orderBy)
+        if (lastOrderBy != orderBy) {
+            lastOrderBy = orderBy
+            threadsList.clear()
+            nextPage = 1
+        }
+        internalLoadThreads()
     }
 
-    fun refreshThreads(orderBy: String) {
+    fun refreshThreads() {
         _isUpdating.value = true
         threadsList.clear()
         nextPage = 1
-        internalLoadThreads(orderBy)
+        internalLoadThreads()
     }
 
     fun fetchMore() {
         if (!isLoading && nextPage != -1) {
             isLoading = true
-            internalLoadThreads(lastOrderBy)
+            internalLoadThreads()
         }
     }
 
-    private fun internalLoadThreads(orderBy: String) {
-        if (lastOrderBy != orderBy) {
-            threadsList.clear()
-            nextPage = 1
-        }
-        lastOrderBy = orderBy
+    private fun internalLoadThreads() {
         when (threadType) {
             DiscussionTopicsViewModel.ALL_POSTS -> {
-                getAllThreads(orderBy)
+                getAllThreads()
             }
 
             DiscussionTopicsViewModel.FOLLOWING_POSTS -> {
-                getFollowingThreads(orderBy)
+                getFollowingThreads()
             }
 
             DiscussionTopicsViewModel.TOPIC -> {
-                getThreads(
-                    orderBy
-                )
+                getThreads()
             }
         }
     }
@@ -153,26 +151,24 @@ class DiscussionThreadsViewModel(
         }
         when (threadType) {
             DiscussionTopicsViewModel.ALL_POSTS -> {
-                getAllThreads(lastOrderBy)
+                getAllThreads()
             }
 
             DiscussionTopicsViewModel.FOLLOWING_POSTS -> {
-                getFollowingThreads(lastOrderBy)
+                getFollowingThreads()
             }
 
             DiscussionTopicsViewModel.TOPIC -> {
-                getThreads(
-                    lastOrderBy
-                )
+                getThreads()
             }
         }
     }
 
-    private fun getThreads(orderBy: String) {
+    private fun getThreads() {
         viewModelScope.launch {
             try {
                 val response =
-                    interactor.getThreads(courseId, topicId, orderBy, filterType, nextPage)
+                    interactor.getThreads(courseId, topicId, lastOrderBy, filterType, nextPage)
                 if (response.pagination.next.isNotEmpty()) {
                     _canLoadMore.value = true
                     nextPage++
@@ -196,10 +192,10 @@ class DiscussionThreadsViewModel(
         }
     }
 
-    private fun getAllThreads(orderBy: String) {
+    private fun getAllThreads() {
         viewModelScope.launch {
             try {
-                val response = interactor.getAllThreads(courseId, orderBy, filterType, nextPage)
+                val response = interactor.getAllThreads(courseId, lastOrderBy, filterType, nextPage)
                 if (response.pagination.next.isNotEmpty()) {
                     _canLoadMore.value = true
                     nextPage++
@@ -223,11 +219,11 @@ class DiscussionThreadsViewModel(
         }
     }
 
-    private fun getFollowingThreads(orderBy: String) {
+    private fun getFollowingThreads() {
         viewModelScope.launch {
             try {
                 val response =
-                    interactor.getFollowingThreads(courseId, true, orderBy, page = nextPage)
+                    interactor.getFollowingThreads(courseId, true, lastOrderBy, page = nextPage)
                 if (response.pagination.next.isNotEmpty()) {
                     _canLoadMore.value = true
                     nextPage++

--- a/discussion/src/main/java/org/openedx/discussion/presentation/threads/DiscussionThreadsViewModel.kt
+++ b/discussion/src/main/java/org/openedx/discussion/presentation/threads/DiscussionThreadsViewModel.kt
@@ -109,7 +109,7 @@ class DiscussionThreadsViewModel(
                     }
 
                     DiscussionTopicsViewModel.FOLLOWING_POSTS -> {
-                        interactor.getFollowingThreads(courseId, true, lastOrderBy, nextPage)
+                        interactor.getFollowingThreads(courseId, lastOrderBy, nextPage)
                     }
 
                     DiscussionTopicsViewModel.TOPIC -> {

--- a/discussion/src/main/res/values-uk/strings.xml
+++ b/discussion/src/main/res/values-uk/strings.xml
@@ -17,7 +17,6 @@
     <string name="discussion_unreport">Відмінити скаргу</string>
     <string name="discussion_add_comment">Додати коментар</string>
     <string name="discussion_comments_title">Коментар</string>
-    <string name="discussion_comment_added">Коментар успішно додано</string>
     <string name="discussion_discussion">Обговорення</string>
     <string name="discussion_question">Питання</string>
     <string name="discussion_title">Заголовок</string>

--- a/discussion/src/main/res/values/strings.xml
+++ b/discussion/src/main/res/values/strings.xml
@@ -17,7 +17,6 @@
     <string name="discussion_unreport">Unreport</string>
     <string name="discussion_add_comment">Add a comment</string>
     <string name="discussion_comments_title">Comment</string>
-    <string name="discussion_comment_added">Comment Successfully added</string>
     <string name="discussion_discussion">Discussion</string>
     <string name="discussion_question">Question</string>
     <string name="discussion_title">Title</string>

--- a/discussion/src/test/java/org/openedx/discussion/presentation/comments/DiscussionCommentsViewModelTest.kt
+++ b/discussion/src/test/java/org/openedx/discussion/presentation/comments/DiscussionCommentsViewModelTest.kt
@@ -59,7 +59,6 @@ class DiscussionCommentsViewModelTest {
 
     private val noInternet = "Slow or no internet connection"
     private val somethingWrong = "Something went wrong"
-    private val commentAddedSuccessfully = "Comment Successfully added"
 
     //region mockThread
 
@@ -144,7 +143,6 @@ class DiscussionCommentsViewModelTest {
         every { preferencesManager.user?.username } returns ""
         every { resourceManager.getString(R.string.core_error_no_connection) } returns noInternet
         every { resourceManager.getString(R.string.core_error_unknown_error) } returns somethingWrong
-        every { resourceManager.getString(org.openedx.discussion.R.string.discussion_comment_added) } returns commentAddedSuccessfully
     }
 
     @After

--- a/discussion/src/test/java/org/openedx/discussion/presentation/responses/DiscussionResponsesViewModelTest.kt
+++ b/discussion/src/test/java/org/openedx/discussion/presentation/responses/DiscussionResponsesViewModelTest.kt
@@ -49,7 +49,6 @@ class DiscussionResponsesViewModelTest {
 
     private val noInternet = "Slow or no internet connection"
     private val somethingWrong = "Something went wrong"
-    private val commentAddedSuccessfully = "Comment Successfully added"
 
     //region mockComment
 
@@ -94,7 +93,6 @@ class DiscussionResponsesViewModelTest {
         every { preferencesManager.user?.username } returns ""
         every { resourceManager.getString(R.string.core_error_no_connection) } returns noInternet
         every { resourceManager.getString(R.string.core_error_unknown_error) } returns somethingWrong
-        every { resourceManager.getString(org.openedx.discussion.R.string.discussion_comment_added) } returns commentAddedSuccessfully
     }
 
     @After

--- a/discussion/src/test/java/org/openedx/discussion/presentation/threads/DiscussionThreadsViewModelTest.kt
+++ b/discussion/src/test/java/org/openedx/discussion/presentation/threads/DiscussionThreadsViewModelTest.kt
@@ -479,7 +479,7 @@ class DiscussionThreadsViewModelTest {
             pushGlobalManager,
             analytics,
         )
-        viewModel.refreshThreads("")
+        viewModel.refreshThreads()
         advanceUntilIdle()
 
         coVerify(exactly = 2) { interactor.getThreads(any(), any(), any(), any(), any()) }
@@ -524,7 +524,7 @@ class DiscussionThreadsViewModelTest {
         lifecycleRegistry.addObserver(viewModel)
         lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_START)
 
-        viewModel.refreshThreads("date")
+        viewModel.refreshThreads()
         advanceUntilIdle()
 
         coVerify(exactly = 3) { interactor.getThreads(any(), any(), any(), any(), any()) }
@@ -564,7 +564,7 @@ class DiscussionThreadsViewModelTest {
         lifecycleRegistry.addObserver(viewModel)
         lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_START)
 
-        viewModel.refreshThreads("date")
+        viewModel.refreshThreads()
         advanceUntilIdle()
 
         coVerify(exactly = 2) { interactor.getThreads(any(), any(), any(), any(), any()) }

--- a/discussion/src/test/java/org/openedx/discussion/presentation/threads/DiscussionThreadsViewModelTest.kt
+++ b/discussion/src/test/java/org/openedx/discussion/presentation/threads/DiscussionThreadsViewModelTest.kt
@@ -389,6 +389,11 @@ class DiscussionThreadsViewModelTest {
 
     @Test
     fun `filterThreads All posts`() = runTest {
+        coEvery { interactor.getThreads(any(), any(), any(), any(), any()) } returns ThreadsData(
+            threads,
+            "",
+            pagination = Pagination(10, "", 2, "")
+        )
         val viewModel = DiscussionThreadsViewModel(
             "",
             "",
@@ -398,11 +403,6 @@ class DiscussionThreadsViewModelTest {
             notifier,
             pushGlobalManager,
             analytics,
-        )
-        coEvery { interactor.getThreads(any(), any(), any(), any(), any()) } returns ThreadsData(
-            threads,
-            "",
-            pagination = Pagination(10, "", 2, "")
         )
         viewModel.filterThreads(FilterType.ALL_POSTS.value)
         advanceUntilIdle()

--- a/discussion/src/test/java/org/openedx/discussion/presentation/threads/DiscussionThreadsViewModelTest.kt
+++ b/discussion/src/test/java/org/openedx/discussion/presentation/threads/DiscussionThreadsViewModelTest.kt
@@ -207,7 +207,6 @@ class DiscussionThreadsViewModelTest {
             interactor.getFollowingThreads(
                 any(),
                 any(),
-                any(),
                 any()
             )
         } throws UnknownHostException()
@@ -223,7 +222,7 @@ class DiscussionThreadsViewModelTest {
         )
         advanceUntilIdle()
 
-        coVerify(exactly = 1) { interactor.getFollowingThreads(any(), any(), any(), any()) }
+        coVerify(exactly = 1) { interactor.getFollowingThreads(any(), any(), any()) }
 
         val message = viewModel.uiMessage.value as? UIMessage.SnackBarMessage
         assertEquals(noInternet, message?.message)
@@ -247,13 +246,12 @@ class DiscussionThreadsViewModelTest {
             interactor.getFollowingThreads(
                 any(),
                 any(),
-                any(),
                 any()
             )
         } throws Exception()
         advanceUntilIdle()
 
-        coVerify(exactly = 1) { interactor.getFollowingThreads(any(), any(), any(), any()) }
+        coVerify(exactly = 1) { interactor.getFollowingThreads(any(), any(), any()) }
 
         val message = viewModel.uiMessage.value as? UIMessage.SnackBarMessage
         assertEquals(somethingWrong, message?.message)
@@ -267,7 +265,6 @@ class DiscussionThreadsViewModelTest {
             interactor.getFollowingThreads(
                 "",
                 any(),
-                any(),
                 range(1, 2)
             )
         } returns ThreadsData(
@@ -278,7 +275,6 @@ class DiscussionThreadsViewModelTest {
         coEvery {
             interactor.getFollowingThreads(
                 "",
-                any(),
                 any(),
                 eq(3)
             )
@@ -299,7 +295,7 @@ class DiscussionThreadsViewModelTest {
         )
         advanceUntilIdle()
 
-        coVerify(exactly = 1) { interactor.getFollowingThreads(any(), any(), any(), any()) }
+        coVerify(exactly = 1) { interactor.getFollowingThreads(any(), any(), any()) }
 
         assert(viewModel.uiMessage.value == null)
         assert(viewModel.isUpdating.value == false)

--- a/discussion/src/test/java/org/openedx/discussion/presentation/threads/DiscussionThreadsViewModelTest.kt
+++ b/discussion/src/test/java/org/openedx/discussion/presentation/threads/DiscussionThreadsViewModelTest.kt
@@ -32,6 +32,7 @@ import org.openedx.core.system.PushGlobalManager
 import org.openedx.core.system.ResourceManager
 import org.openedx.discussion.domain.interactor.DiscussionInteractor
 import org.openedx.discussion.domain.model.DiscussionType
+import org.openedx.discussion.domain.model.Thread
 import org.openedx.discussion.domain.model.ThreadsData
 import org.openedx.discussion.presentation.DiscussionAnalytics
 import org.openedx.discussion.presentation.topics.DiscussionTopicsViewModel
@@ -59,45 +60,45 @@ class DiscussionThreadsViewModelTest {
 
     //region mockThread
 
-    val mockThread = org.openedx.discussion.domain.model.Thread(
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
-        TextConverter.textToLinkedImageText(""),
-        false,
-        true,
-        20,
-        emptyList(),
-        false,
-        "",
-        "",
-        "",
-        "",
-        DiscussionType.DISCUSSION,
-        "",
-        "",
-        "Discussion title long Discussion title long good item",
-        true,
-        false,
-        true,
-        21,
-        4,
-        false,
-        false,
-        mapOf(),
-        0,
-        false,
-        false,
-        false,
+    private val mockThread = Thread(
+        id = "",
+        author = "",
+        authorLabel = "",
+        createdAt = "",
+        updatedAt = "",
+        rawBody = "",
+        renderedBody = "",
+        parsedRenderedBody = TextConverter.textToLinkedImageText(""),
+        abuseFlagged = false,
+        voted = true,
+        voteCount = 20,
+        editableFields = emptyList(),
+        canDelete = false,
+        courseId = "",
+        topicId = "",
+        groupId = "",
+        groupName = "",
+        type = DiscussionType.DISCUSSION,
+        previewBody = "",
+        abuseFlaggedCount = "",
+        title = "Discussion title long Discussion title long good item",
+        pinned = true,
+        closed = false,
+        following = true,
+        commentCount = 21,
+        unreadCommentCount = 4,
+        read = false,
+        hasEndorsed = false,
+        users = mapOf(),
+        responseCount = 10,
+        anonymous = false,
+        anonymousToPeers = false,
+        isAuthor = false,
     )
 
     //endregion
 
-    private val threads = listOf<org.openedx.discussion.domain.model.Thread>(
+    private val threads = listOf(
         mockThread.copy(id = "0"),
         mockThread.copy(id = "1"),
         mockThread.copy(id = "2")
@@ -207,7 +208,6 @@ class DiscussionThreadsViewModelTest {
                 any(),
                 any(),
                 any(),
-                any(),
                 any()
             )
         } throws UnknownHostException()
@@ -223,7 +223,7 @@ class DiscussionThreadsViewModelTest {
         )
         advanceUntilIdle()
 
-        coVerify(exactly = 1) { interactor.getFollowingThreads(any(), any(), any(), any(), any()) }
+        coVerify(exactly = 1) { interactor.getFollowingThreads(any(), any(), any(), any()) }
 
         val message = viewModel.uiMessage.value as? UIMessage.SnackBarMessage
         assertEquals(noInternet, message?.message)
@@ -248,13 +248,12 @@ class DiscussionThreadsViewModelTest {
                 any(),
                 any(),
                 any(),
-                any(),
                 any()
             )
         } throws Exception()
         advanceUntilIdle()
 
-        coVerify(exactly = 1) { interactor.getFollowingThreads(any(), any(), any(), any(), any()) }
+        coVerify(exactly = 1) { interactor.getFollowingThreads(any(), any(), any(), any()) }
 
         val message = viewModel.uiMessage.value as? UIMessage.SnackBarMessage
         assertEquals(somethingWrong, message?.message)
@@ -269,7 +268,6 @@ class DiscussionThreadsViewModelTest {
                 "",
                 any(),
                 any(),
-                null,
                 range(1, 2)
             )
         } returns ThreadsData(
@@ -282,7 +280,6 @@ class DiscussionThreadsViewModelTest {
                 "",
                 any(),
                 any(),
-                null,
                 eq(3)
             )
         } returns ThreadsData(
@@ -302,7 +299,7 @@ class DiscussionThreadsViewModelTest {
         )
         advanceUntilIdle()
 
-        coVerify(exactly = 1) { interactor.getFollowingThreads(any(), any(), any(), any(), any()) }
+        coVerify(exactly = 1) { interactor.getFollowingThreads(any(), any(), any(), any()) }
 
         assert(viewModel.uiMessage.value == null)
         assert(viewModel.isUpdating.value == false)

--- a/discussion/src/test/java/org/openedx/discussion/presentation/threads/DiscussionThreadsViewModelTest.kt
+++ b/discussion/src/test/java/org/openedx/discussion/presentation/threads/DiscussionThreadsViewModelTest.kt
@@ -118,7 +118,7 @@ class DiscussionThreadsViewModelTest {
     }
 
     @Test
-    fun `getThreadByType AllThreads no internet connection`() = runTest {
+    fun `sortThreads AllThreads no internet connection`() = runTest {
         coEvery {
             interactor.getAllThreads(
                 any(),
@@ -148,7 +148,7 @@ class DiscussionThreadsViewModelTest {
     }
 
     @Test
-    fun `getThreadByType AllThreads unknown exception`() = runTest {
+    fun `sortThreads AllThreads unknown exception`() = runTest {
         val viewModel = DiscussionThreadsViewModel(
             "",
             "",
@@ -171,7 +171,7 @@ class DiscussionThreadsViewModelTest {
     }
 
     @Test
-    fun `getThreadByType AllThreads success`() = runTest {
+    fun `sortThreads AllThreads success`() = runTest {
         coEvery { interactor.getAllThreads("", any(), null, range(1, 2)) } returns ThreadsData(
             threads,
             "",
@@ -202,7 +202,7 @@ class DiscussionThreadsViewModelTest {
     }
 
     @Test
-    fun `getThreadByType FollowingPosts no internet connection`() = runTest {
+    fun `sortThreads FollowingPosts no internet connection`() = runTest {
         coEvery {
             interactor.getFollowingThreads(
                 any(),
@@ -232,7 +232,7 @@ class DiscussionThreadsViewModelTest {
     }
 
     @Test
-    fun `getThreadByType FollowingPosts unknown exception`() = runTest {
+    fun `sortThreads FollowingPosts unknown exception`() = runTest {
         val viewModel = DiscussionThreadsViewModel(
             "",
             "",
@@ -262,7 +262,7 @@ class DiscussionThreadsViewModelTest {
     }
 
     @Test
-    fun `getThreadByType FollowingPosts success`() = runTest {
+    fun `sortThreads FollowingPosts success`() = runTest {
         coEvery {
             interactor.getFollowingThreads(
                 "",
@@ -307,7 +307,7 @@ class DiscussionThreadsViewModelTest {
     }
 
     @Test
-    fun `getThreadByType Topic no internet connection`() = runTest {
+    fun `sortThreads Topic no internet connection`() = runTest {
         coEvery {
             interactor.getThreads(
                 any(),
@@ -338,7 +338,7 @@ class DiscussionThreadsViewModelTest {
     }
 
     @Test
-    fun `getThreadByType Topic unknown exception`() = runTest {
+    fun `sortThreads Topic unknown exception`() = runTest {
         val viewModel = DiscussionThreadsViewModel(
             "",
             "",
@@ -361,7 +361,7 @@ class DiscussionThreadsViewModelTest {
     }
 
     @Test
-    fun `getThreadByType Topic success`() = runTest {
+    fun `sortThreads Topic success`() = runTest {
         coEvery { interactor.getThreads("", any(), any(), null, range(1, 2)) } returns ThreadsData(
             threads,
             "",
@@ -458,7 +458,7 @@ class DiscussionThreadsViewModelTest {
     }
 
     @Test
-    fun `updateThread Topic success`() = runTest {
+    fun `refreshThread Topic success`() = runTest {
         coEvery { interactor.getThreads("", any(), any(), null, range(1, 2)) } returns ThreadsData(
             threads,
             "",
@@ -479,7 +479,7 @@ class DiscussionThreadsViewModelTest {
             pushGlobalManager,
             analytics,
         )
-        viewModel.updateThread("")
+        viewModel.refreshThreads("")
         advanceUntilIdle()
 
         coVerify(exactly = 2) { interactor.getThreads(any(), any(), any(), any(), any()) }
@@ -524,7 +524,7 @@ class DiscussionThreadsViewModelTest {
         lifecycleRegistry.addObserver(viewModel)
         lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_START)
 
-        viewModel.updateThread("date")
+        viewModel.refreshThreads("date")
         advanceUntilIdle()
 
         coVerify(exactly = 3) { interactor.getThreads(any(), any(), any(), any(), any()) }
@@ -564,7 +564,7 @@ class DiscussionThreadsViewModelTest {
         lifecycleRegistry.addObserver(viewModel)
         lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_START)
 
-        viewModel.updateThread("date")
+        viewModel.refreshThreads("date")
         advanceUntilIdle()
 
         coVerify(exactly = 2) { interactor.getThreads(any(), any(), any(), any(), any()) }


### PR DESCRIPTION
### Description

[LEARNER-10450](https://2u-internal.atlassian.net/browse/LEARNER-10450)

**Reverse Order of Responses in API:**
- Responses on the post responses and comments screen should be displayed in reverse chronological order (latest first).  
- Update the API request to include `reverse_order=true` when fetching responses.  
- The order should match the web application’s behaviour.  

**Update "Add a Response" and "Add a Comment" Behavior:**
- Newly added responses and comments should appear at the top of the list instead of the bottom.  
- UI updates instantly to reflect the correct order after adding a response or comment.

**Sorting & Filtering:**  
- Clear the list and load the first page when sorting or filtering.  
- On refresh, retain the applied filter and sort order.