### PR TITLE
feat: Notifications Settings Permission Prompt Improvements

### DIFF
--- a/notifications/src/main/java/org/openedx/notifications/presentation/NotificationsAnalytics.kt
+++ b/notifications/src/main/java/org/openedx/notifications/presentation/NotificationsAnalytics.kt
@@ -99,4 +99,7 @@ enum class NotificationsAnalyticsKey(val key: String) {
     THREAD_ID("thread_id"),
     RESPONSE_ID("response_id"),
     COMMENT_ID("comment_id"),
+    SOURCE("source"),
+    DISCUSSION_PRIMER("discussion_primer"),
+    PUSH_SETTINGS("push_settings"),
 }

--- a/notifications/src/main/java/org/openedx/notifications/presentation/primer/NotificationsPrimerDialogFragment.kt
+++ b/notifications/src/main/java/org/openedx/notifications/presentation/primer/NotificationsPrimerDialogFragment.kt
@@ -48,6 +48,7 @@ import org.openedx.core.ui.theme.OpenEdXTheme
 import org.openedx.core.ui.theme.appColors
 import org.openedx.core.ui.theme.appTypography
 import org.openedx.notifications.R
+import org.openedx.notifications.presentation.NotificationsAnalyticsEvent
 import org.openedx.notifications.presentation.NotificationsAnalyticsKey
 import org.openedx.notifications.utils.PermissionUtils
 import org.openedx.core.R as CoreR
@@ -59,11 +60,7 @@ class NotificationsPrimerDialogFragment : DialogFragment() {
     private val pushNotificationPermissionLauncher = registerForActivityResult(
         ActivityResultContracts.RequestPermission()
     ) { granted ->
-        if (granted) {
-            viewModel.enableDiscussionNotificationsPreference()
-        } else {
-            viewModel.dismissDialog()
-        }
+        handlePermissionResult(granted)
     }
 
     override fun onCreateView(
@@ -91,6 +88,11 @@ class NotificationsPrimerDialogFragment : DialogFragment() {
                                 PermissionUtils.requestNotificationPermission(
                                     activity = requireActivity(),
                                     permissionLauncher = pushNotificationPermissionLauncher,
+                                    onSystemDialogShown = {
+                                        viewModel.logScreenEvent(
+                                            event = NotificationsAnalyticsEvent.SYSTEM_PERMISSION_DIALOG_VIEWED
+                                        )
+                                    },
                                     onRationaleShown = {
                                         viewModel.showRationaleDialog()
                                     },
@@ -118,11 +120,22 @@ class NotificationsPrimerDialogFragment : DialogFragment() {
 
                     PrimerUIState.ShowRationaleDialog -> {
                         ShowRationalePermissionDialog(
+                            onDialogShown = {
+                                viewModel.logScreenEvent(NotificationsAnalyticsEvent.APP_PERMISSION_RATIONALE_DIALOG_VIEWED)
+                            },
                             onNegativeButtonClick = {
+                                viewModel.logEvent(
+                                    NotificationsAnalyticsEvent.APP_PERMISSION_RATIONALE_DIALOG_ACTION,
+                                    mapOf(NotificationsAnalyticsKey.ACTION.key to NotificationsAnalyticsKey.CANCEL.key)
+                                )
                                 viewModel.dismissDialog()
                             },
 
                             onPositiveButtonClick = {
+                                viewModel.logEvent(
+                                    NotificationsAnalyticsEvent.APP_PERMISSION_RATIONALE_DIALOG_ACTION,
+                                    mapOf(NotificationsAnalyticsKey.ACTION.key to NotificationsAnalyticsKey.CONTINUE.key)
+                                )
                                 PermissionUtils.navigateToNotificationSettings(
                                     requireContext()
                                 )
@@ -133,6 +146,24 @@ class NotificationsPrimerDialogFragment : DialogFragment() {
                 }
             }
         }
+    }
+
+    private fun handlePermissionResult(granted: Boolean) {
+        if (granted) {
+            viewModel.enableDiscussionNotificationsPreference()
+        } else {
+            viewModel.dismissDialog()
+        }
+        viewModel.logEvent(
+            NotificationsAnalyticsEvent.SYSTEM_PERMISSION_DIALOG_ACTION,
+            buildMap {
+                put(
+                    NotificationsAnalyticsKey.ACTION.key,
+                    if (granted) NotificationsAnalyticsKey.ALLOW.key
+                    else NotificationsAnalyticsKey.DONT_ALLOW.key
+                )
+            }
+        )
     }
 }
 
@@ -279,6 +310,7 @@ fun NotificationsPrimerButtons(
 
 @Composable
 private fun ShowRationalePermissionDialog(
+    onDialogShown: () -> Unit = {},
     onPositiveButtonClick: () -> Unit = {},
     onNegativeButtonClick: () -> Unit = {},
 ) {
@@ -293,6 +325,7 @@ private fun ShowRationalePermissionDialog(
         positiveBtnAction = onPositiveButtonClick,
         negativeBtnAction = onNegativeButtonClick,
     )
+    onDialogShown()
 }
 
 @PreviewLightDark

--- a/notifications/src/main/java/org/openedx/notifications/presentation/primer/NotificationsPrimerDialogFragment.kt
+++ b/notifications/src/main/java/org/openedx/notifications/presentation/primer/NotificationsPrimerDialogFragment.kt
@@ -89,7 +89,7 @@ class NotificationsPrimerDialogFragment : DialogFragment() {
                                     activity = requireActivity(),
                                     permissionLauncher = pushNotificationPermissionLauncher,
                                     onSystemDialogShown = {
-                                        viewModel.logScreenEvent(
+                                        viewModel.logPermissionDialogScreenEvent(
                                             event = NotificationsAnalyticsEvent.SYSTEM_PERMISSION_DIALOG_VIEWED
                                         )
                                     },
@@ -121,20 +121,22 @@ class NotificationsPrimerDialogFragment : DialogFragment() {
                     PrimerUIState.ShowRationaleDialog -> {
                         ShowRationalePermissionDialog(
                             onDialogShown = {
-                                viewModel.logScreenEvent(NotificationsAnalyticsEvent.APP_PERMISSION_RATIONALE_DIALOG_VIEWED)
+                                viewModel.logPermissionDialogScreenEvent(
+                                    event = NotificationsAnalyticsEvent.APP_PERMISSION_RATIONALE_DIALOG_VIEWED
+                                )
                             },
                             onNegativeButtonClick = {
-                                viewModel.logEvent(
-                                    NotificationsAnalyticsEvent.APP_PERMISSION_RATIONALE_DIALOG_ACTION,
-                                    mapOf(NotificationsAnalyticsKey.ACTION.key to NotificationsAnalyticsKey.CANCEL.key)
+                                viewModel.logPermissionDialogActionEvent(
+                                    event = NotificationsAnalyticsEvent.APP_PERMISSION_RATIONALE_DIALOG_ACTION,
+                                    action = NotificationsAnalyticsKey.CANCEL
                                 )
                                 viewModel.dismissDialog()
                             },
 
                             onPositiveButtonClick = {
-                                viewModel.logEvent(
-                                    NotificationsAnalyticsEvent.APP_PERMISSION_RATIONALE_DIALOG_ACTION,
-                                    mapOf(NotificationsAnalyticsKey.ACTION.key to NotificationsAnalyticsKey.CONTINUE.key)
+                                viewModel.logPermissionDialogActionEvent(
+                                    event = NotificationsAnalyticsEvent.APP_PERMISSION_RATIONALE_DIALOG_ACTION,
+                                    action = NotificationsAnalyticsKey.CONTINUE
                                 )
                                 PermissionUtils.navigateToNotificationSettings(
                                     requireContext()
@@ -154,15 +156,9 @@ class NotificationsPrimerDialogFragment : DialogFragment() {
         } else {
             viewModel.dismissDialog()
         }
-        viewModel.logEvent(
-            NotificationsAnalyticsEvent.SYSTEM_PERMISSION_DIALOG_ACTION,
-            buildMap {
-                put(
-                    NotificationsAnalyticsKey.ACTION.key,
-                    if (granted) NotificationsAnalyticsKey.ALLOW.key
-                    else NotificationsAnalyticsKey.DONT_ALLOW.key
-                )
-            }
+        viewModel.logPermissionDialogActionEvent(
+            event = NotificationsAnalyticsEvent.SYSTEM_PERMISSION_DIALOG_ACTION,
+            action = if (granted) NotificationsAnalyticsKey.ALLOW else NotificationsAnalyticsKey.DONT_ALLOW
         )
     }
 }

--- a/notifications/src/main/java/org/openedx/notifications/presentation/primer/NotificationsPrimerViewModel.kt
+++ b/notifications/src/main/java/org/openedx/notifications/presentation/primer/NotificationsPrimerViewModel.kt
@@ -23,7 +23,10 @@ class NotificationsPrimerViewModel(
     val uiState: StateFlow<PrimerUIState> = _uiState.asStateFlow()
 
     init {
-        logPrimerScreenEvent()
+        val dialogFrequency = preferences.primer.dismissalCount
+        logScreenEvent(NotificationsAnalyticsEvent.DISCUSSION_PRIMER_VIEWED, buildMap {
+            put(NotificationsAnalyticsKey.PRIMER_DIALOG_FREQUENCY.key, dialogFrequency)
+        })
     }
 
     fun enableDiscussionNotificationsPreference() {
@@ -57,32 +60,38 @@ class NotificationsPrimerViewModel(
     }
 
     fun logPrimerActionEvent(action: NotificationsAnalyticsKey) {
-        val event = NotificationsAnalyticsEvent.DISCUSSION_PRIMER_ACTION
-        analytics.logEvent(
-            event = event.eventName,
-            params = buildMap {
-                put(NotificationsAnalyticsKey.NAME.key, event.biValue)
-                put(NotificationsAnalyticsKey.ACTION.key, action.key)
-                put(
-                    NotificationsAnalyticsKey.CATEGORY.key,
-                    NotificationsAnalyticsKey.NOTIFICATIONS.key
-                )
-            }
-        )
+        logEvent(
+            event = NotificationsAnalyticsEvent.DISCUSSION_PRIMER_ACTION,
+            params = buildMap { put(NotificationsAnalyticsKey.ACTION.key, action.key) })
     }
 
-    private fun logPrimerScreenEvent() {
-        val event = NotificationsAnalyticsEvent.DISCUSSION_PRIMER_VIEWED
-        val dialogFrequency = preferences.primer.dismissalCount
+    fun logScreenEvent(event: NotificationsAnalyticsEvent, params: Map<String, Any> = emptyMap()) {
         analytics.logScreenEvent(
             screenName = event.eventName,
             params = buildMap {
                 put(NotificationsAnalyticsKey.NAME.key, event.biValue)
-                put(NotificationsAnalyticsKey.PRIMER_DIALOG_FREQUENCY.key, dialogFrequency)
                 put(
                     NotificationsAnalyticsKey.CATEGORY.key,
                     NotificationsAnalyticsKey.NOTIFICATIONS.key
                 )
+                putAll(params)
+            }
+        )
+    }
+
+    fun logEvent(
+        event: NotificationsAnalyticsEvent,
+        params: Map<String, Any?> = emptyMap(),
+    ) {
+        analytics.logEvent(
+            event = event.eventName,
+            params = buildMap {
+                put(NotificationsAnalyticsKey.NAME.key, event.biValue)
+                put(
+                    NotificationsAnalyticsKey.CATEGORY.key,
+                    NotificationsAnalyticsKey.NOTIFICATIONS.key
+                )
+                putAll(params)
             }
         )
     }

--- a/notifications/src/main/java/org/openedx/notifications/presentation/primer/NotificationsPrimerViewModel.kt
+++ b/notifications/src/main/java/org/openedx/notifications/presentation/primer/NotificationsPrimerViewModel.kt
@@ -99,7 +99,7 @@ class NotificationsPrimerViewModel(
         )
     }
 
-    fun logScreenEvent(event: NotificationsAnalyticsEvent, params: Map<String, Any> = emptyMap()) {
+    private fun logScreenEvent(event: NotificationsAnalyticsEvent, params: Map<String, Any> = emptyMap()) {
         analytics.logScreenEvent(
             screenName = event.eventName,
             params = buildMap {
@@ -113,7 +113,7 @@ class NotificationsPrimerViewModel(
         )
     }
 
-    fun logEvent(
+    private fun logEvent(
         event: NotificationsAnalyticsEvent,
         params: Map<String, Any?> = emptyMap(),
     ) {

--- a/notifications/src/main/java/org/openedx/notifications/presentation/primer/NotificationsPrimerViewModel.kt
+++ b/notifications/src/main/java/org/openedx/notifications/presentation/primer/NotificationsPrimerViewModel.kt
@@ -24,9 +24,12 @@ class NotificationsPrimerViewModel(
 
     init {
         val dialogFrequency = preferences.primer.dismissalCount
-        logScreenEvent(NotificationsAnalyticsEvent.DISCUSSION_PRIMER_VIEWED, buildMap {
-            put(NotificationsAnalyticsKey.PRIMER_DIALOG_FREQUENCY.key, dialogFrequency)
-        })
+        logScreenEvent(
+            event = NotificationsAnalyticsEvent.DISCUSSION_PRIMER_VIEWED,
+            params = buildMap {
+                put(NotificationsAnalyticsKey.PRIMER_DIALOG_FREQUENCY.key, dialogFrequency)
+            }
+        )
     }
 
     fun enableDiscussionNotificationsPreference() {
@@ -62,7 +65,10 @@ class NotificationsPrimerViewModel(
     fun logPrimerActionEvent(action: NotificationsAnalyticsKey) {
         logEvent(
             event = NotificationsAnalyticsEvent.DISCUSSION_PRIMER_ACTION,
-            params = buildMap { put(NotificationsAnalyticsKey.ACTION.key, action.key) })
+            params = buildMap {
+                put(NotificationsAnalyticsKey.ACTION.key, action.key)
+            }
+        )
     }
 
     fun logScreenEvent(event: NotificationsAnalyticsEvent, params: Map<String, Any> = emptyMap()) {

--- a/notifications/src/main/java/org/openedx/notifications/presentation/primer/NotificationsPrimerViewModel.kt
+++ b/notifications/src/main/java/org/openedx/notifications/presentation/primer/NotificationsPrimerViewModel.kt
@@ -99,7 +99,10 @@ class NotificationsPrimerViewModel(
         )
     }
 
-    private fun logScreenEvent(event: NotificationsAnalyticsEvent, params: Map<String, Any> = emptyMap()) {
+    private fun logScreenEvent(
+        event: NotificationsAnalyticsEvent,
+        params: Map<String, Any> = emptyMap()
+    ) {
         analytics.logScreenEvent(
             screenName = event.eventName,
             params = buildMap {

--- a/notifications/src/main/java/org/openedx/notifications/presentation/primer/NotificationsPrimerViewModel.kt
+++ b/notifications/src/main/java/org/openedx/notifications/presentation/primer/NotificationsPrimerViewModel.kt
@@ -71,6 +71,34 @@ class NotificationsPrimerViewModel(
         )
     }
 
+    fun logPermissionDialogActionEvent(
+        event: NotificationsAnalyticsEvent,
+        action: NotificationsAnalyticsKey
+    ) {
+        logEvent(
+            event = event,
+            params = buildMap {
+                put(NotificationsAnalyticsKey.ACTION.key, action.key)
+                put(
+                    NotificationsAnalyticsKey.SOURCE.key,
+                    NotificationsAnalyticsKey.DISCUSSION_PRIMER.key
+                )
+            }
+        )
+    }
+
+    fun logPermissionDialogScreenEvent(event: NotificationsAnalyticsEvent) {
+        logScreenEvent(
+            event = event,
+            params = buildMap {
+                put(
+                    NotificationsAnalyticsKey.SOURCE.key,
+                    NotificationsAnalyticsKey.DISCUSSION_PRIMER.key
+                )
+            }
+        )
+    }
+
     fun logScreenEvent(event: NotificationsAnalyticsEvent, params: Map<String, Any> = emptyMap()) {
         analytics.logScreenEvent(
             screenName = event.eventName,

--- a/notifications/src/main/java/org/openedx/notifications/presentation/settings/NotificationsSettingsFragment.kt
+++ b/notifications/src/main/java/org/openedx/notifications/presentation/settings/NotificationsSettingsFragment.kt
@@ -64,6 +64,8 @@ import org.openedx.core.ui.theme.appShapes
 import org.openedx.core.ui.theme.appTypography
 import org.openedx.core.ui.windowSizeValue
 import org.openedx.notifications.R
+import org.openedx.notifications.presentation.NotificationsAnalyticsEvent
+import org.openedx.notifications.presentation.NotificationsAnalyticsKey
 import org.openedx.notifications.utils.PermissionUtils
 import org.openedx.core.R as CoreR
 
@@ -110,18 +112,40 @@ class NotificationsSettingsFragment : Fragment() {
                             } else {
                                 viewModel.enablePushNotifications(false)
                             }
+                            viewModel.logEvent(
+                                NotificationsAnalyticsEvent.SYSTEM_PERMISSION_DIALOG_ACTION,
+                                mapOf(
+                                    NotificationsAnalyticsKey.ACTION.key to
+                                            if (granted) NotificationsAnalyticsKey.ALLOW.key
+                                            else NotificationsAnalyticsKey.DONT_ALLOW.key
+                                )
+                            )
                         }
                         PermissionUtils.requestNotificationPermission(activity = requireActivity(),
                             permissionLauncher = pushNotificationPermissionLauncher,
+                            onSystemDialogShown = {
+                                viewModel.logScreenEvent(NotificationsAnalyticsEvent.SYSTEM_PERMISSION_DIALOG_VIEWED)
+                            },
                             onRationaleShown = {
                                 viewModel.showPermissionDialogRationale()
                             })
                     },
+                    onRationaleShown = {
+                        viewModel.logScreenEvent(NotificationsAnalyticsEvent.APP_PERMISSION_RATIONALE_DIALOG_VIEWED)
+                    },
                     onPositiveButtonClick = {
+                        viewModel.logEvent(
+                            NotificationsAnalyticsEvent.APP_PERMISSION_RATIONALE_DIALOG_ACTION,
+                            mapOf(NotificationsAnalyticsKey.ACTION.key to NotificationsAnalyticsKey.CONTINUE.key)
+                        )
                         viewModel.dismissPermissionDialog()
                         PermissionUtils.navigateToNotificationSettings(requireContext())
                     },
                     onNegativeButtonClick = {
+                        viewModel.logEvent(
+                            NotificationsAnalyticsEvent.APP_PERMISSION_RATIONALE_DIALOG_ACTION,
+                            mapOf(NotificationsAnalyticsKey.ACTION.key to NotificationsAnalyticsKey.CANCEL.key)
+                        )
                         viewModel.dismissPermissionDialog()
                     }
                 )
@@ -161,6 +185,7 @@ private fun NotificationsSettingsScreen(
     uiMessage: UIMessage? = null,
     discussionPreferenceChanged: (Boolean) -> Unit,
     onRequestPermission: () -> Unit = {},
+    onRationaleShown: () -> Unit = {},
     onPositiveButtonClick: () -> Unit = {},
     onNegativeButtonClick: () -> Unit = {},
     onBackClick: () -> Unit,
@@ -210,6 +235,7 @@ private fun NotificationsSettingsScreen(
                 positiveBtnAction = onPositiveButtonClick,
                 negativeBtnAction = onNegativeButtonClick,
             )
+            onRationaleShown()
         }
         if (uiState.requestPermission) {
             onRequestPermission()

--- a/notifications/src/main/java/org/openedx/notifications/presentation/settings/NotificationsSettingsFragment.kt
+++ b/notifications/src/main/java/org/openedx/notifications/presentation/settings/NotificationsSettingsFragment.kt
@@ -91,7 +91,7 @@ class NotificationsSettingsFragment : Fragment() {
 
                 val uiState by viewModel.uiState.collectAsState()
                 val uiMessage by viewModel.uiMessage.collectAsState(null)
-                val uiEvent by viewModel.uiEvent.collectAsState(NotificationsSettingsUiEvent.Nothing)
+                val uiEvent by viewModel.uiEvent.collectAsState(NotificationsSettingsUiEvent.None)
 
                 NotificationsSettingsScreen(
                     windowSize = windowSize,
@@ -148,7 +148,7 @@ class NotificationsSettingsFragment : Fragment() {
                         viewModel.logScreenEvent(NotificationsAnalyticsEvent.APP_PERMISSION_RATIONALE_DIALOG_VIEWED)
                     }
 
-                    NotificationsSettingsUiEvent.Nothing -> {
+                    NotificationsSettingsUiEvent.None -> {
                         // Do nothing
                     }
                 }

--- a/notifications/src/main/java/org/openedx/notifications/presentation/settings/NotificationsSettingsFragment.kt
+++ b/notifications/src/main/java/org/openedx/notifications/presentation/settings/NotificationsSettingsFragment.kt
@@ -71,15 +71,11 @@ class NotificationsSettingsFragment : Fragment() {
 
     private val viewModel by viewModel<NotificationsSettingsViewModel>()
 
-    private val pushNotificationPermissionLauncher = registerForActivityResult(
-        ActivityResultContracts.RequestPermission()
-    ) { granted ->
-        if (granted) {
-            viewModel.fetchAndUpdateNotificationsSettings()
-        } else {
-            viewModel.enablePushNotifications(false)
+    private var onPermissionResult: ((Boolean) -> Unit)? = null
+    private val pushNotificationPermissionLauncher =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
+            onPermissionResult?.invoke(granted)
         }
-    }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -104,13 +100,26 @@ class NotificationsSettingsFragment : Fragment() {
                     discussionPreferenceChanged = {
                         viewModel.setDiscussionNotificationPreference(it)
                     },
-                    onPositiveButtonClick = {
-                        viewModel.dismissPermissionDialog()
+                    onRequestPermission = {
+                        onPermissionResult = { granted ->
+                            if (granted) {
+                                viewModel.setDiscussionNotificationPreference(
+                                    (uiState as NotificationsSettingsUiState.Configuration)
+                                        .discussionsPushEnabled.not()
+                                )
+                            } else {
+                                viewModel.enablePushNotifications(false)
+                            }
+                        }
                         PermissionUtils.requestNotificationPermission(activity = requireActivity(),
                             permissionLauncher = pushNotificationPermissionLauncher,
                             onRationaleShown = {
-                                PermissionUtils.navigateToNotificationSettings(requireContext())
+                                viewModel.showPermissionDialogRationale()
                             })
+                    },
+                    onPositiveButtonClick = {
+                        viewModel.dismissPermissionDialog()
+                        PermissionUtils.navigateToNotificationSettings(requireContext())
                     },
                     onNegativeButtonClick = {
                         viewModel.dismissPermissionDialog()
@@ -151,6 +160,7 @@ private fun NotificationsSettingsScreen(
     uiState: NotificationsSettingsUiState.Configuration,
     uiMessage: UIMessage? = null,
     discussionPreferenceChanged: (Boolean) -> Unit,
+    onRequestPermission: () -> Unit = {},
     onPositiveButtonClick: () -> Unit = {},
     onNegativeButtonClick: () -> Unit = {},
     onBackClick: () -> Unit,
@@ -188,7 +198,7 @@ private fun NotificationsSettingsScreen(
         }
         HandleUIMessage(uiMessage = uiMessage, scaffoldState = scaffoldState)
 
-        if (uiState.showPermissionRequestDialog) {
+        if (uiState.showPermissionDialogRationale) {
             OpenEdxAlertDialog(
                 title = stringResource(id = CoreR.string.core_permission_dialog_title),
                 message = stringResource(
@@ -200,6 +210,9 @@ private fun NotificationsSettingsScreen(
                 positiveBtnAction = onPositiveButtonClick,
                 negativeBtnAction = onNegativeButtonClick,
             )
+        }
+        if (uiState.requestPermission) {
+            onRequestPermission()
         }
 
         Box(

--- a/notifications/src/main/java/org/openedx/notifications/presentation/settings/NotificationsSettingsFragment.kt
+++ b/notifications/src/main/java/org/openedx/notifications/presentation/settings/NotificationsSettingsFragment.kt
@@ -112,7 +112,9 @@ class NotificationsSettingsFragment : Fragment() {
                             activity = requireActivity(),
                             permissionLauncher = pushNotificationPermissionLauncher,
                             onSystemDialogShown = {
-                                viewModel.logScreenEvent(NotificationsAnalyticsEvent.SYSTEM_PERMISSION_DIALOG_VIEWED)
+                                viewModel.logPermissionDialogScreenEvent(
+                                    event = NotificationsAnalyticsEvent.SYSTEM_PERMISSION_DIALOG_VIEWED
+                                )
                             },
                             onRationaleShown = {
                                 viewModel.showPermissionDialogRationale()
@@ -130,22 +132,24 @@ class NotificationsSettingsFragment : Fragment() {
                             positiveBtnText = stringResource(id = CoreR.string.core_continue),
                             negativeBtnText = stringResource(id = CoreR.string.core_cancel),
                             positiveBtnAction = {
-                                viewModel.logEvent(
-                                    NotificationsAnalyticsEvent.APP_PERMISSION_RATIONALE_DIALOG_ACTION,
-                                    mapOf(NotificationsAnalyticsKey.ACTION.key to NotificationsAnalyticsKey.CONTINUE.key)
+                                viewModel.logPermissionDialogActionEvent(
+                                    event = NotificationsAnalyticsEvent.APP_PERMISSION_RATIONALE_DIALOG_ACTION,
+                                    action = NotificationsAnalyticsKey.CONTINUE
                                 )
                                 viewModel.dismissPermissionDialog()
                                 PermissionUtils.navigateToNotificationSettings(requireContext())
                             },
                             negativeBtnAction = {
-                                viewModel.logEvent(
-                                    NotificationsAnalyticsEvent.APP_PERMISSION_RATIONALE_DIALOG_ACTION,
-                                    mapOf(NotificationsAnalyticsKey.ACTION.key to NotificationsAnalyticsKey.CANCEL.key)
+                                viewModel.logPermissionDialogActionEvent(
+                                    event = NotificationsAnalyticsEvent.APP_PERMISSION_RATIONALE_DIALOG_ACTION,
+                                    action = NotificationsAnalyticsKey.CANCEL
                                 )
                                 viewModel.dismissPermissionDialog()
                             },
                         )
-                        viewModel.logScreenEvent(NotificationsAnalyticsEvent.APP_PERMISSION_RATIONALE_DIALOG_VIEWED)
+                        viewModel.logPermissionDialogScreenEvent(
+                            event = NotificationsAnalyticsEvent.APP_PERMISSION_RATIONALE_DIALOG_VIEWED
+                        )
                     }
 
                     NotificationsSettingsUiEvent.None -> {
@@ -186,15 +190,9 @@ class NotificationsSettingsFragment : Fragment() {
             viewModel.enablePushNotifications(false)
         }
 
-        viewModel.logEvent(
-            NotificationsAnalyticsEvent.SYSTEM_PERMISSION_DIALOG_ACTION,
-            buildMap {
-                put(
-                    NotificationsAnalyticsKey.ACTION.key,
-                    if (granted) NotificationsAnalyticsKey.ALLOW.key
-                    else NotificationsAnalyticsKey.DONT_ALLOW.key
-                )
-            }
+        viewModel.logPermissionDialogActionEvent(
+            event = NotificationsAnalyticsEvent.SYSTEM_PERMISSION_DIALOG_ACTION,
+            action = if (granted) NotificationsAnalyticsKey.ALLOW else NotificationsAnalyticsKey.DONT_ALLOW
         )
         viewModel.dismissPermissionDialog()
     }

--- a/notifications/src/main/java/org/openedx/notifications/presentation/settings/NotificationsSettingsFragment.kt
+++ b/notifications/src/main/java/org/openedx/notifications/presentation/settings/NotificationsSettingsFragment.kt
@@ -73,11 +73,11 @@ class NotificationsSettingsFragment : Fragment() {
 
     private val viewModel by viewModel<NotificationsSettingsViewModel>()
 
-    private var onPermissionResult: ((Boolean) -> Unit)? = null
-    private val pushNotificationPermissionLauncher =
-        registerForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
-            onPermissionResult?.invoke(granted)
-        }
+    private val pushNotificationPermissionLauncher = registerForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { granted ->
+        handlePermissionResult(granted)
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -91,64 +91,67 @@ class NotificationsSettingsFragment : Fragment() {
 
                 val uiState by viewModel.uiState.collectAsState()
                 val uiMessage by viewModel.uiMessage.collectAsState(null)
+                val uiEvent by viewModel.uiEvent.collectAsState(NotificationsSettingsUiEvent.Nothing)
 
-                NotificationsSettingsScreen(windowSize = windowSize,
+                NotificationsSettingsScreen(
+                    windowSize = windowSize,
                     uiState = uiState as NotificationsSettingsUiState.Configuration,
                     uiMessage = uiMessage,
-                    onBackClick = {
-                        viewModel.logBatchPermissionToggleEvent()
-                        requireActivity().supportFragmentManager.popBackStack()
-                    },
                     discussionPreferenceChanged = {
                         viewModel.setDiscussionNotificationPreference(it)
                     },
-                    onRequestPermission = {
-                        onPermissionResult = { granted ->
-                            if (granted) {
-                                viewModel.setDiscussionNotificationPreference(
-                                    (uiState as NotificationsSettingsUiState.Configuration)
-                                        .discussionsPushEnabled.not()
-                                )
-                            } else {
-                                viewModel.enablePushNotifications(false)
-                            }
-                            viewModel.logEvent(
-                                NotificationsAnalyticsEvent.SYSTEM_PERMISSION_DIALOG_ACTION,
-                                mapOf(
-                                    NotificationsAnalyticsKey.ACTION.key to
-                                            if (granted) NotificationsAnalyticsKey.ALLOW.key
-                                            else NotificationsAnalyticsKey.DONT_ALLOW.key
-                                )
-                            )
-                        }
-                        PermissionUtils.requestNotificationPermission(activity = requireActivity(),
+                    onBackClick = {
+                        viewModel.logBatchPermissionToggleEvent()
+                        requireActivity().supportFragmentManager.popBackStack()
+                    }
+                )
+
+                when (uiEvent) {
+                    NotificationsSettingsUiEvent.RequestPermission -> {
+                        PermissionUtils.requestNotificationPermission(
+                            activity = requireActivity(),
                             permissionLauncher = pushNotificationPermissionLauncher,
                             onSystemDialogShown = {
                                 viewModel.logScreenEvent(NotificationsAnalyticsEvent.SYSTEM_PERMISSION_DIALOG_VIEWED)
                             },
                             onRationaleShown = {
                                 viewModel.showPermissionDialogRationale()
-                            })
-                    },
-                    onRationaleShown = {
-                        viewModel.logScreenEvent(NotificationsAnalyticsEvent.APP_PERMISSION_RATIONALE_DIALOG_VIEWED)
-                    },
-                    onPositiveButtonClick = {
-                        viewModel.logEvent(
-                            NotificationsAnalyticsEvent.APP_PERMISSION_RATIONALE_DIALOG_ACTION,
-                            mapOf(NotificationsAnalyticsKey.ACTION.key to NotificationsAnalyticsKey.CONTINUE.key)
+                            }
                         )
-                        viewModel.dismissPermissionDialog()
-                        PermissionUtils.navigateToNotificationSettings(requireContext())
-                    },
-                    onNegativeButtonClick = {
-                        viewModel.logEvent(
-                            NotificationsAnalyticsEvent.APP_PERMISSION_RATIONALE_DIALOG_ACTION,
-                            mapOf(NotificationsAnalyticsKey.ACTION.key to NotificationsAnalyticsKey.CANCEL.key)
-                        )
-                        viewModel.dismissPermissionDialog()
                     }
-                )
+
+                    NotificationsSettingsUiEvent.ShowPermissionDialogRationale -> {
+                        OpenEdxAlertDialog(
+                            title = stringResource(id = CoreR.string.core_permission_dialog_title),
+                            message = stringResource(
+                                id = CoreR.string.core_permission_dialog_message,
+                                stringResource(id = R.string.notifications_notifications).lowercase()
+                            ),
+                            positiveBtnText = stringResource(id = CoreR.string.core_continue),
+                            negativeBtnText = stringResource(id = CoreR.string.core_cancel),
+                            positiveBtnAction = {
+                                viewModel.logEvent(
+                                    NotificationsAnalyticsEvent.APP_PERMISSION_RATIONALE_DIALOG_ACTION,
+                                    mapOf(NotificationsAnalyticsKey.ACTION.key to NotificationsAnalyticsKey.CONTINUE.key)
+                                )
+                                viewModel.dismissPermissionDialog()
+                                PermissionUtils.navigateToNotificationSettings(requireContext())
+                            },
+                            negativeBtnAction = {
+                                viewModel.logEvent(
+                                    NotificationsAnalyticsEvent.APP_PERMISSION_RATIONALE_DIALOG_ACTION,
+                                    mapOf(NotificationsAnalyticsKey.ACTION.key to NotificationsAnalyticsKey.CANCEL.key)
+                                )
+                                viewModel.dismissPermissionDialog()
+                            },
+                        )
+                        viewModel.logScreenEvent(NotificationsAnalyticsEvent.APP_PERMISSION_RATIONALE_DIALOG_VIEWED)
+                    }
+
+                    NotificationsSettingsUiEvent.Nothing -> {
+                        // Do nothing
+                    }
+                }
 
                 HandleBackNavigation()
             }
@@ -175,6 +178,26 @@ class NotificationsSettingsFragment : Fragment() {
             }
         }
     }
+
+    private fun handlePermissionResult(granted: Boolean) {
+        if (granted) {
+            viewModel.setDiscussionNotificationPreference(true)
+        } else {
+            viewModel.enablePushNotifications(false)
+        }
+
+        viewModel.logEvent(
+            NotificationsAnalyticsEvent.SYSTEM_PERMISSION_DIALOG_ACTION,
+            buildMap {
+                put(
+                    NotificationsAnalyticsKey.ACTION.key,
+                    if (granted) NotificationsAnalyticsKey.ALLOW.key
+                    else NotificationsAnalyticsKey.DONT_ALLOW.key
+                )
+            }
+        )
+        viewModel.dismissPermissionDialog()
+    }
 }
 
 @OptIn(ExperimentalComposeUiApi::class)
@@ -184,10 +207,6 @@ private fun NotificationsSettingsScreen(
     uiState: NotificationsSettingsUiState.Configuration,
     uiMessage: UIMessage? = null,
     discussionPreferenceChanged: (Boolean) -> Unit,
-    onRequestPermission: () -> Unit = {},
-    onRationaleShown: () -> Unit = {},
-    onPositiveButtonClick: () -> Unit = {},
-    onNegativeButtonClick: () -> Unit = {},
     onBackClick: () -> Unit,
 ) {
     val scaffoldState = rememberScaffoldState()
@@ -222,24 +241,6 @@ private fun NotificationsSettingsScreen(
             )
         }
         HandleUIMessage(uiMessage = uiMessage, scaffoldState = scaffoldState)
-
-        if (uiState.showPermissionDialogRationale) {
-            OpenEdxAlertDialog(
-                title = stringResource(id = CoreR.string.core_permission_dialog_title),
-                message = stringResource(
-                    id = CoreR.string.core_permission_dialog_message,
-                    stringResource(id = R.string.notifications_notifications).lowercase()
-                ),
-                positiveBtnText = stringResource(id = CoreR.string.core_continue),
-                negativeBtnText = stringResource(id = CoreR.string.core_cancel),
-                positiveBtnAction = onPositiveButtonClick,
-                negativeBtnAction = onNegativeButtonClick,
-            )
-            onRationaleShown()
-        }
-        if (uiState.requestPermission) {
-            onRequestPermission()
-        }
 
         Box(
             modifier = Modifier.fillMaxSize(),

--- a/notifications/src/main/java/org/openedx/notifications/presentation/settings/NotificationsSettingsUiState.kt
+++ b/notifications/src/main/java/org/openedx/notifications/presentation/settings/NotificationsSettingsUiState.kt
@@ -2,7 +2,8 @@ package org.openedx.notifications.presentation.settings
 
 sealed class NotificationsSettingsUiState {
     data class Configuration(
-        val showPermissionRequestDialog: Boolean = false,
+        val requestPermission: Boolean = false,
+        val showPermissionDialogRationale: Boolean = false,
         val discussionsPushEnabled: Boolean = false,
     ) : NotificationsSettingsUiState()
 }

--- a/notifications/src/main/java/org/openedx/notifications/presentation/settings/NotificationsSettingsUiState.kt
+++ b/notifications/src/main/java/org/openedx/notifications/presentation/settings/NotificationsSettingsUiState.kt
@@ -9,5 +9,5 @@ sealed class NotificationsSettingsUiState {
 sealed class NotificationsSettingsUiEvent {
     data object RequestPermission : NotificationsSettingsUiEvent()
     data object ShowPermissionDialogRationale : NotificationsSettingsUiEvent()
-    data object Nothing : NotificationsSettingsUiEvent()
+    data object None : NotificationsSettingsUiEvent()
 }

--- a/notifications/src/main/java/org/openedx/notifications/presentation/settings/NotificationsSettingsUiState.kt
+++ b/notifications/src/main/java/org/openedx/notifications/presentation/settings/NotificationsSettingsUiState.kt
@@ -2,8 +2,12 @@ package org.openedx.notifications.presentation.settings
 
 sealed class NotificationsSettingsUiState {
     data class Configuration(
-        val requestPermission: Boolean = false,
-        val showPermissionDialogRationale: Boolean = false,
         val discussionsPushEnabled: Boolean = false,
     ) : NotificationsSettingsUiState()
+}
+
+sealed class NotificationsSettingsUiEvent {
+    data object RequestPermission : NotificationsSettingsUiEvent()
+    data object ShowPermissionDialogRationale : NotificationsSettingsUiEvent()
+    data object Nothing : NotificationsSettingsUiEvent()
 }

--- a/notifications/src/main/java/org/openedx/notifications/presentation/settings/NotificationsSettingsViewModel.kt
+++ b/notifications/src/main/java/org/openedx/notifications/presentation/settings/NotificationsSettingsViewModel.kt
@@ -45,7 +45,7 @@ class NotificationsSettingsViewModel(
         } else {
             enablePushNotifications(enabled = false)
         }
-        logNotificationSettingsScreenEvent()
+        logScreenEvent(NotificationsAnalyticsEvent.PUSH_NOTIFICATIONS_SETTINGS)
     }
 
     fun setDiscussionNotificationPreference(value: Boolean) {
@@ -126,8 +126,18 @@ class NotificationsSettingsViewModel(
         )
     }
 
-    private fun logNotificationSettingsScreenEvent() {
-        val event = NotificationsAnalyticsEvent.PUSH_NOTIFICATIONS_SETTINGS
+    private fun logDiscussionPermissionToggleEvent(
+        isDiscussionPushEnabled: Boolean,
+    ) {
+        logEvent(
+            event = NotificationsAnalyticsEvent.DISCUSSION_PREFERENCE_TOGGLE,
+            params = buildMap {
+                put(NotificationsAnalyticsKey.ACTION.key, isDiscussionPushEnabled)
+            }
+        )
+    }
+
+    fun logScreenEvent(event: NotificationsAnalyticsEvent) {
         analytics.logScreenEvent(
             screenName = event.eventName,
             params = buildMap {
@@ -140,18 +150,7 @@ class NotificationsSettingsViewModel(
         )
     }
 
-    private fun logDiscussionPermissionToggleEvent(
-        isDiscussionPushEnabled: Boolean,
-    ) {
-        logEvent(
-            event = NotificationsAnalyticsEvent.DISCUSSION_PREFERENCE_TOGGLE,
-            params = buildMap {
-                put(NotificationsAnalyticsKey.ACTION.key, isDiscussionPushEnabled)
-            }
-        )
-    }
-
-    private fun logEvent(
+    fun logEvent(
         event: NotificationsAnalyticsEvent,
         params: Map<String, Any?> = emptyMap(),
     ) {

--- a/notifications/src/main/java/org/openedx/notifications/presentation/settings/NotificationsSettingsViewModel.kt
+++ b/notifications/src/main/java/org/openedx/notifications/presentation/settings/NotificationsSettingsViewModel.kt
@@ -103,8 +103,9 @@ class NotificationsSettingsViewModel(
 
     fun dismissPermissionDialog() {
         viewModelScope.launch {
-            _uiEvent.emit(NotificationsSettingsUiEvent.Nothing)
-        }    }
+            _uiEvent.emit(NotificationsSettingsUiEvent.None)
+        }
+    }
 
     private suspend fun showErrorMessage() {
         _uiMessage.emit(

--- a/notifications/src/main/java/org/openedx/notifications/presentation/settings/NotificationsSettingsViewModel.kt
+++ b/notifications/src/main/java/org/openedx/notifications/presentation/settings/NotificationsSettingsViewModel.kt
@@ -29,7 +29,8 @@ class NotificationsSettingsViewModel(
 
     private val _uiState = MutableStateFlow<NotificationsSettingsUiState>(
         NotificationsSettingsUiState.Configuration(
-            showPermissionRequestDialog = false,
+            requestPermission = false,
+            showPermissionDialogRationale = false,
             discussionsPushEnabled = preference.notifications.discussionsPushEnabled,
         )
     )
@@ -59,11 +60,11 @@ class NotificationsSettingsViewModel(
                 }
             }
         } else {
-            showPermissionDialog()
+            requestPermission()
         }
     }
 
-    fun fetchAndUpdateNotificationsSettings() {
+    private fun fetchAndUpdateNotificationsSettings() {
         viewModelScope.launch {
             try {
                 val response = interactor.fetchNotificationsConfiguration()
@@ -87,10 +88,19 @@ class NotificationsSettingsViewModel(
         return notificationManagerCompat.areNotificationsEnabled()
     }
 
-    private fun showPermissionDialog() {
+    private fun requestPermission() {
         _uiState.update {
             NotificationsSettingsUiState.Configuration(
-                showPermissionRequestDialog = true,
+                requestPermission = true,
+            )
+        }
+    }
+
+    fun showPermissionDialogRationale() {
+        _uiState.update {
+            NotificationsSettingsUiState.Configuration(
+                requestPermission = false,
+                showPermissionDialogRationale = true,
             )
         }
     }

--- a/notifications/src/main/java/org/openedx/notifications/presentation/settings/NotificationsSettingsViewModel.kt
+++ b/notifications/src/main/java/org/openedx/notifications/presentation/settings/NotificationsSettingsViewModel.kt
@@ -29,12 +29,13 @@ class NotificationsSettingsViewModel(
 
     private val _uiState = MutableStateFlow<NotificationsSettingsUiState>(
         NotificationsSettingsUiState.Configuration(
-            requestPermission = false,
-            showPermissionDialogRationale = false,
             discussionsPushEnabled = preference.notifications.discussionsPushEnabled,
         )
     )
     val uiState = _uiState.asStateFlow()
+
+    private val _uiEvent = MutableSharedFlow<NotificationsSettingsUiEvent>()
+    val uiEvent = _uiEvent.asSharedFlow()
 
     private val _uiMessage = MutableSharedFlow<UIMessage>()
     val uiMessage = _uiMessage.asSharedFlow()
@@ -89,25 +90,21 @@ class NotificationsSettingsViewModel(
     }
 
     private fun requestPermission() {
-        _uiState.update {
-            NotificationsSettingsUiState.Configuration(
-                requestPermission = true,
-            )
+        viewModelScope.launch {
+            _uiEvent.emit(NotificationsSettingsUiEvent.RequestPermission)
         }
     }
 
     fun showPermissionDialogRationale() {
-        _uiState.update {
-            NotificationsSettingsUiState.Configuration(
-                requestPermission = false,
-                showPermissionDialogRationale = true,
-            )
+        viewModelScope.launch {
+            _uiEvent.emit(NotificationsSettingsUiEvent.ShowPermissionDialogRationale)
         }
     }
 
     fun dismissPermissionDialog() {
-        _uiState.update { NotificationsSettingsUiState.Configuration() }
-    }
+        viewModelScope.launch {
+            _uiEvent.emit(NotificationsSettingsUiEvent.Nothing)
+        }    }
 
     private suspend fun showErrorMessage() {
         _uiMessage.emit(

--- a/notifications/src/main/java/org/openedx/notifications/presentation/settings/NotificationsSettingsViewModel.kt
+++ b/notifications/src/main/java/org/openedx/notifications/presentation/settings/NotificationsSettingsViewModel.kt
@@ -135,7 +135,38 @@ class NotificationsSettingsViewModel(
         )
     }
 
-    fun logScreenEvent(event: NotificationsAnalyticsEvent) {
+    fun logPermissionDialogActionEvent(
+        event: NotificationsAnalyticsEvent,
+        action: NotificationsAnalyticsKey
+    ) {
+        logEvent(
+            event = event,
+            params = buildMap {
+                put(NotificationsAnalyticsKey.ACTION.key, action.key)
+                put(
+                    NotificationsAnalyticsKey.SOURCE.key,
+                    NotificationsAnalyticsKey.PUSH_SETTINGS.key
+                )
+            }
+        )
+    }
+
+    fun logPermissionDialogScreenEvent(event: NotificationsAnalyticsEvent) {
+        logScreenEvent(
+            event = event,
+            params = buildMap {
+                put(
+                    NotificationsAnalyticsKey.SOURCE.key,
+                    NotificationsAnalyticsKey.PUSH_SETTINGS.key
+                )
+            }
+        )
+    }
+
+    fun logScreenEvent(
+        event: NotificationsAnalyticsEvent,
+        params: Map<String, Any?> = emptyMap(),
+    ) {
         analytics.logScreenEvent(
             screenName = event.eventName,
             params = buildMap {
@@ -144,6 +175,7 @@ class NotificationsSettingsViewModel(
                     NotificationsAnalyticsKey.CATEGORY.key,
                     NotificationsAnalyticsKey.NOTIFICATIONS.key
                 )
+                putAll(params)
             }
         )
     }

--- a/notifications/src/main/java/org/openedx/notifications/presentation/settings/NotificationsSettingsViewModel.kt
+++ b/notifications/src/main/java/org/openedx/notifications/presentation/settings/NotificationsSettingsViewModel.kt
@@ -163,7 +163,7 @@ class NotificationsSettingsViewModel(
         )
     }
 
-    fun logScreenEvent(
+    private fun logScreenEvent(
         event: NotificationsAnalyticsEvent,
         params: Map<String, Any?> = emptyMap(),
     ) {
@@ -180,7 +180,7 @@ class NotificationsSettingsViewModel(
         )
     }
 
-    fun logEvent(
+    private fun logEvent(
         event: NotificationsAnalyticsEvent,
         params: Map<String, Any?> = emptyMap(),
     ) {

--- a/notifications/src/main/java/org/openedx/notifications/utils/PermissionUtils.kt
+++ b/notifications/src/main/java/org/openedx/notifications/utils/PermissionUtils.kt
@@ -14,7 +14,7 @@ object PermissionUtils {
     fun requestNotificationPermission(
         activity: Activity,
         permissionLauncher: ActivityResultLauncher<String>,
-        onSystemDialogShown: () -> Unit = {},
+        onSystemDialogShown: () -> Unit,
         onRationaleShown: () -> Unit,
     ) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {

--- a/notifications/src/main/java/org/openedx/notifications/utils/PermissionUtils.kt
+++ b/notifications/src/main/java/org/openedx/notifications/utils/PermissionUtils.kt
@@ -14,6 +14,7 @@ object PermissionUtils {
     fun requestNotificationPermission(
         activity: Activity,
         permissionLauncher: ActivityResultLauncher<String>,
+        onSystemDialogShown: () -> Unit = {},
         onRationaleShown: () -> Unit,
     ) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
@@ -25,6 +26,7 @@ object PermissionUtils {
                 onRationaleShown()
             } else {
                 permissionLauncher.launch(android.Manifest.permission.POST_NOTIFICATIONS)
+                onSystemDialogShown()
             }
         } else {
             onRationaleShown()


### PR DESCRIPTION
### Description

Jira Ticket: [LEARNER-10451](https://2u-internal.atlassian.net/browse/LEARNER-10451)

Notifications Settings Permission Prompt Improvements.
- Skip rationale dialog if system permission dialog is available.
- Add events for the notification permission dialogs.

**Example:**
<video src="https://github.com/user-attachments/assets/17f67313-f6be-4166-846c-2bef21433315"/>
