### PR TITLE
feat: Highlight targeted response during notifications Inbox screen navigation

### DIFF
--- a/core/src/edx/org/openedx/core/ui/theme/Colors.kt
+++ b/core/src/edx/org/openedx/core/ui/theme/Colors.kt
@@ -93,6 +93,7 @@ val light_primary_card_info_background = Color(0xFFF2F0EF) // Light 300
 val light_inbox_time_marker_color = Color(0xFF707070)
 val light_notification_primer_badge = Color(0xFF132D26) // Accent a-900
 val light_notification_primer_card_background = light_primary_card_info_background
+val light_highlight_discussion_response = light_primary_card_info_background
 
 // Dark theme colors scheme
 val dark_primary = Color(0xFFFBFAF9) // Light 200
@@ -182,3 +183,4 @@ val dark_primary_card_info_background = Color(0xFF0E3639) // Dark 400
 val dark_inbox_time_marker_color = Color(0xFFADADAD)
 val dark_notification_primer_badge = Color(0xFF5DE3C0) // Accent a-500
 val dark_notification_primer_card_background = Color(0xFF132925)
+val dark_highlight_discussion_response = Color(0xFF4C6A64)

--- a/core/src/edx/org/openedx/core/ui/theme/Colors.kt
+++ b/core/src/edx/org/openedx/core/ui/theme/Colors.kt
@@ -88,7 +88,7 @@ val light_progress_bar_color = light_primary_button_background
 val light_progress_bar_background_color = Color(0xFFE7E4DB)
 
 val light_primary_card_caution_background = Color(0xFFF3F1ED)
-val light_primary_card_info_background = Color(0xFFE7E4DB)
+val light_primary_card_info_background = Color(0xFFF2F0EF) // Light 300
 
 val light_inbox_time_marker_color = Color(0xFF707070)
 val light_notification_primer_badge = Color(0xFF132D26) // Accent a-900
@@ -177,7 +177,7 @@ val dark_progress_bar_color = dark_primary_button_background
 val dark_progress_bar_background_color = Color(0xFF707070)
 
 val dark_primary_card_caution_background = Color(0xFF2D494E)
-val dark_primary_card_info_background = Color(0xFF0E3639)
+val dark_primary_card_info_background = Color(0xFF0E3639) // Dark 400
 
 val dark_inbox_time_marker_color = Color(0xFFADADAD)
 val dark_notification_primer_badge = Color(0xFF5DE3C0) // Accent a-500

--- a/core/src/main/java/org/openedx/core/ui/theme/AppColors.kt
+++ b/core/src/main/java/org/openedx/core/ui/theme/AppColors.kt
@@ -87,6 +87,8 @@ data class AppColors(
     val inboxTimeMarkerColor: Color,
     val notificationPrimerBadge: Color,
     val notificationPrimerCardBackground: Color,
+
+    val highlightDiscussionResponse: Color,
 ) {
     val primary: Color get() = material.primary
     val primaryVariant: Color get() = material.primaryVariant

--- a/core/src/main/java/org/openedx/core/ui/theme/Theme.kt
+++ b/core/src/main/java/org/openedx/core/ui/theme/Theme.kt
@@ -105,6 +105,8 @@ private val DarkColorPalette = AppColors(
     inboxTimeMarkerColor = dark_inbox_time_marker_color,
     notificationPrimerBadge = dark_notification_primer_badge,
     notificationPrimerCardBackground = dark_notification_primer_card_background,
+
+    highlightDiscussionResponse = dark_highlight_discussion_response,
 )
 
 private val LightColorPalette = AppColors(
@@ -202,6 +204,8 @@ private val LightColorPalette = AppColors(
     inboxTimeMarkerColor = light_inbox_time_marker_color,
     notificationPrimerBadge = light_notification_primer_badge,
     notificationPrimerCardBackground = light_notification_primer_card_background,
+
+    highlightDiscussionResponse = light_highlight_discussion_response,
 )
 
 val MaterialTheme.appColors: AppColors

--- a/core/src/openedx/org/openedx/core/ui/theme/Colors.kt
+++ b/core/src/openedx/org/openedx/core/ui/theme/Colors.kt
@@ -80,6 +80,7 @@ val light_social_auth_divider = light_divider
 val light_inbox_time_marker_color = Color(0xFF707070)
 val light_notification_primer_badge = Color(0xFF132D26)
 val light_notification_primer_card_background = light_primary_card_info_background
+val light_highlight_discussion_response = light_card_view_background
 
 
 val dark_primary = Color(0xFF3F68F8)
@@ -160,3 +161,4 @@ val dark_social_auth_divider = dark_divider
 val dark_inbox_time_marker_color = Color(0xFFADADAD)
 val dark_notification_primer_badge = Color(0xFF5DE3C0)
 val dark_notification_primer_card_background = Color(0xFF132925)
+val dark_highlight_discussion_response = dark_card_view_background

--- a/discussion/src/main/java/org/openedx/discussion/domain/model/DiscussionComment.kt
+++ b/discussion/src/main/java/org/openedx/discussion/domain/model/DiscussionComment.kt
@@ -1,6 +1,7 @@
 package org.openedx.discussion.domain.model
 
 import android.os.Parcelable
+import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 import org.openedx.core.domain.model.ProfileImage
 import org.openedx.core.extension.LinkedImageText
@@ -31,4 +32,7 @@ data class DiscussionComment(
     val profileImage: ProfileImage?,
     val users: Map<String, DiscussionProfile>?,
     var isAuthor: Boolean,
-) : Parcelable
+) : Parcelable {
+    @IgnoredOnParcel
+    var shouldHighlight: Boolean = false
+}

--- a/discussion/src/main/java/org/openedx/discussion/presentation/comments/DiscussionCommentsViewModel.kt
+++ b/discussion/src/main/java/org/openedx/discussion/presentation/comments/DiscussionCommentsViewModel.kt
@@ -119,10 +119,12 @@ class DiscussionCommentsViewModel(
                     val comment = comments.find { it.id == responseId }
                     if (comment == null) {
                         val newComment = interactor.getResponse(responseId)
+                        newComment.shouldHighlight = true
                         comments.add(0, newComment)
                         commentCount.inc()
                     } else {
                         comments.remove(comment)
+                        comment.shouldHighlight = true
                         comments.add(0, comment)
                     }
                 }

--- a/discussion/src/main/java/org/openedx/discussion/presentation/ui/DiscussionUI.kt
+++ b/discussion/src/main/java/org/openedx/discussion/presentation/ui/DiscussionUI.kt
@@ -241,7 +241,7 @@ fun CommentItem(
 
     LaunchedEffect(comment.shouldHighlight) {
         if (comment.shouldHighlight) {
-            repeat(6) { // 3 full blinks (on + off = 2)
+            repeat(3) {
                 backgroundColor.animateTo(highlightColor, animationSpec = tween(250))
                 backgroundColor.animateTo(normalColor, animationSpec = tween(250))
             }

--- a/discussion/src/main/java/org/openedx/discussion/presentation/ui/DiscussionUI.kt
+++ b/discussion/src/main/java/org/openedx/discussion/presentation/ui/DiscussionUI.kt
@@ -230,6 +230,12 @@ fun CommentItem(
         Icons.Outlined.ThumbUp
     }
 
+    val backgroundColor = if (comment.shouldHighlight) {
+        MaterialTheme.appColors.primaryCardInfoBackground
+    } else {
+        MaterialTheme.appColors.cardViewBackground
+    }
+
     val context = LocalContext.current
 
     Card(
@@ -241,7 +247,7 @@ fun CommentItem(
                 shape
             )
         ),
-        backgroundColor = MaterialTheme.appColors.cardViewBackground,
+        backgroundColor = backgroundColor,
         elevation = 0.dp
     ) {
         Column(
@@ -693,7 +699,8 @@ private fun ThreadItemPreview() {
     }
 }
 
-@Preview
+@Preview(uiMode = UI_MODE_NIGHT_NO)
+@Preview(uiMode = UI_MODE_NIGHT_YES)
 @Composable
 private fun CommentItemPreview() {
     OpenEdXTheme {

--- a/discussion/src/main/java/org/openedx/discussion/presentation/ui/DiscussionUI.kt
+++ b/discussion/src/main/java/org/openedx/discussion/presentation/ui/DiscussionUI.kt
@@ -231,7 +231,7 @@ fun CommentItem(
     }
 
     val backgroundColor = if (comment.shouldHighlight) {
-        MaterialTheme.appColors.primaryCardInfoBackground
+        MaterialTheme.appColors.highlightDiscussionResponse
     } else {
         MaterialTheme.appColors.cardViewBackground
     }

--- a/discussion/src/main/java/org/openedx/discussion/presentation/ui/DiscussionUI.kt
+++ b/discussion/src/main/java/org/openedx/discussion/presentation/ui/DiscussionUI.kt
@@ -2,6 +2,8 @@ package org.openedx.discussion.presentation.ui
 
 import android.content.res.Configuration.UI_MODE_NIGHT_NO
 import android.content.res.Configuration.UI_MODE_NIGHT_YES
+import androidx.compose.animation.Animatable
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -31,6 +33,8 @@ import androidx.compose.material.icons.filled.PushPin
 import androidx.compose.material.icons.filled.ThumbUp
 import androidx.compose.material.icons.outlined.ThumbUp
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -230,10 +234,20 @@ fun CommentItem(
         Icons.Outlined.ThumbUp
     }
 
-    val backgroundColor = if (comment.shouldHighlight) {
-        MaterialTheme.appColors.highlightDiscussionResponse
-    } else {
-        MaterialTheme.appColors.cardViewBackground
+    val highlightColor = MaterialTheme.appColors.highlightDiscussionResponse
+    val normalColor = MaterialTheme.appColors.cardViewBackground
+
+    val backgroundColor = remember { Animatable(normalColor) }
+
+    LaunchedEffect(comment.shouldHighlight) {
+        if (comment.shouldHighlight) {
+            repeat(6) { // 3 full blinks (on + off = 2)
+                backgroundColor.animateTo(highlightColor, animationSpec = tween(250))
+                backgroundColor.animateTo(normalColor, animationSpec = tween(250))
+            }
+        } else {
+            backgroundColor.snapTo(normalColor)
+        }
     }
 
     val context = LocalContext.current
@@ -247,7 +261,7 @@ fun CommentItem(
                 shape
             )
         ),
-        backgroundColor = backgroundColor,
+        backgroundColor = backgroundColor.value,
         elevation = 0.dp
     ) {
         Column(


### PR DESCRIPTION
### Description

**Highlight Targeted Response During Notifications Inbox Screen Navigation**

Jira Ticket: [LEARNER-10448](https://2u-internal.atlassian.net/browse/LEARNER-10448), [LEARNER-10506](https://2u-internal.atlassian.net/browse/LEARNER-10506)

- Highlight the response during the notifications inbox screen navigation.

Highlighted Response
| Dark Mode  | Light Mode |
| ------------- | ------------- |
| <video src="https://github.com/user-attachments/assets/2987618a-0acf-493a-9d98-868f3ace9777"/> | <video src="https://github.com/user-attachments/assets/60071bfd-8a8e-4ddc-bbda-7bff0a2d4a5d"/> |