### PR TITLE
build: Upgrade Social Auth Dependencies

### DIFF
--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -56,11 +56,11 @@ android {
 dependencies {
     implementation project(path: ':core')
 
-    implementation "androidx.credentials:credentials:1.2.0"
-    implementation "androidx.credentials:credentials-play-services-auth:1.2.0"
-    implementation "com.facebook.android:facebook-login:16.2.0"
-    implementation "com.google.android.gms:play-services-auth:21.0.0"
-    implementation "com.google.android.libraries.identity.googleid:googleid:1.1.0"
+    implementation "androidx.credentials:credentials:1.3.0"
+    implementation "androidx.credentials:credentials-play-services-auth:1.3.0"
+    implementation "com.facebook.android:facebook-login:18.0.2"
+    implementation "com.google.android.gms:play-services-auth:21.3.0"
+    implementation "com.google.android.libraries.identity.googleid:googleid:1.1.1"
     implementation("com.microsoft.identity.client:msal:4.9.0") {
         //Workaround for the error Failed to resolve: 'io.opentelemetry:opentelemetry-bom' for AS Iguana
         exclude(group: "io.opentelemetry")


### PR DESCRIPTION
### Description

[LEARNER-10461](https://2u-internal.atlassian.net/browse/LEARNER-10461)

The Google Credentials library was causing social login failures, which I resolved by updating the library as per Google's recommendations. Along with that, I updated other social login libraries based on their changelogs, and no breaking changes occurred.

### Issue

Google Auth [FAQ](https://developer.android.com/identity/sign-in/credential-manager-troubleshooting-guide): "Ensure your credentials library is updated to version 1.2.1 or higher." (We were currently using 1.2.0)

### Updates Changelog

- Google Credentials [(1.2.0 -> 1.3.0)](https://developer.android.com/jetpack/androidx/releases/credentials#1.2.2)
- Facebook [(16.2.0 -> 18.0.2)](https://github.com/facebook/facebook-android-sdk/blob/main/CHANGELOG.md)
- Play Services Auth [(21.0.0 -> 21.3.0)](https://developers.google.com/android/guides/releases)
- Google Id [(1.1.0 -> 1.1.1)](https://developers.google.com/identity/android-credential-manager/releases)