### PR TITLE
feat: Add Pinned Icon for Pinned Threads in Discussion

### DIFF
--- a/app/src/main/java/org/openedx/app/AppRouter.kt
+++ b/app/src/main/java/org/openedx/app/AppRouter.kt
@@ -329,14 +329,15 @@ class AppRouter : AuthRouter, DiscoveryRouter, DashboardRouter, CourseRouter, Di
         replaceFragmentWithBackStack(
             fm,
             DiscussionThreadsFragment.newInstance(
-                action,
-                courseId,
-                topicId,
-                threadId,
-                responseId,
-                commentId,
-                title,
-                viewType.name
+                threadType = action,
+                courseId = courseId,
+                topicId = topicId,
+                threadId = threadId,
+                responseId = responseId,
+                commentId = commentId,
+                title = title,
+                viewType = viewType.name,
+                blockId = "",
             )
         )
     }

--- a/course/src/main/java/org/openedx/course/presentation/unit/container/CourseUnitContainerAdapter.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/container/CourseUnitContainerAdapter.kt
@@ -58,14 +58,15 @@ class CourseUnitContainerAdapter(
 
             (block.isDiscussionBlock && block.studentViewData?.topicId.isNullOrEmpty().not()) -> {
                 DiscussionThreadsFragment.newInstance(
-                    DiscussionTopicsViewModel.TOPIC,
-                    viewModel.courseId,
-                    block.studentViewData?.topicId ?: "",
-                    "",
-                    "",
-                    block.displayName,
-                    FragmentViewType.MAIN_CONTENT.name,
-                    block.id
+                    threadType = DiscussionTopicsViewModel.TOPIC,
+                    courseId = viewModel.courseId,
+                    topicId = block.studentViewData?.topicId ?: "",
+                    threadId = "",
+                    responseId = "",
+                    commentId = "",
+                    title = block.displayName,
+                    viewType = FragmentViewType.MAIN_CONTENT.name,
+                    blockId = block.id,
                 )
             }
 

--- a/discussion/src/main/java/org/openedx/discussion/presentation/threads/DiscussionThreadsFragment.kt
+++ b/discussion/src/main/java/org/openedx/discussion/presentation/threads/DiscussionThreadsFragment.kt
@@ -239,7 +239,7 @@ class DiscussionThreadsFragment : Fragment() {
             commentId: String,
             title: String,
             viewType: String,
-            blockId: String = "",
+            blockId: String,
         ): DiscussionThreadsFragment {
             val fragment = DiscussionThreadsFragment()
             fragment.arguments = bundleOf(

--- a/discussion/src/main/java/org/openedx/discussion/presentation/threads/DiscussionThreadsFragment.kt
+++ b/discussion/src/main/java/org/openedx/discussion/presentation/threads/DiscussionThreadsFragment.kt
@@ -96,6 +96,7 @@ import org.openedx.core.ui.theme.appShapes
 import org.openedx.core.ui.theme.appTypography
 import org.openedx.core.ui.windowSizeValue
 import org.openedx.discussion.domain.model.DiscussionType
+import org.openedx.discussion.domain.model.Thread
 import org.openedx.discussion.presentation.DiscussionRouter
 import org.openedx.discussion.presentation.ui.ThreadItem
 import org.openedx.discussion.R as discussionR
@@ -272,7 +273,7 @@ private fun DiscussionThreadsScreen(
     onSwipeRefresh: () -> Unit,
     updatedOrder: (String) -> Unit,
     updatedFilter: (String) -> Unit,
-    onItemClick: (org.openedx.discussion.domain.model.Thread) -> Unit,
+    onItemClick: (Thread) -> Unit,
     onCreatePostClick: () -> Unit,
     paginationCallback: () -> Unit,
     onBackClick: () -> Unit,
@@ -710,7 +711,7 @@ private fun DiscussionThreadsScreenPreview() {
         DiscussionThreadsScreen(
             windowSize = WindowSize(WindowType.Compact, WindowType.Compact),
             "All posts",
-            uiState = DiscussionThreadsUIState.Threads(listOf(mockThread, mockThread, mockThread)),
+            uiState = DiscussionThreadsUIState.Threads(listOf(mockPinnedThread, mockThread)),
             uiMessage = null,
             onItemClick = {},
             onBackClick = {},
@@ -758,7 +759,7 @@ private fun DiscussionThreadsScreenTabletPreview() {
         DiscussionThreadsScreen(
             windowSize = WindowSize(WindowType.Medium, WindowType.Medium),
             "All posts",
-            uiState = DiscussionThreadsUIState.Threads(listOf(mockThread, mockThread, mockThread)),
+            uiState = DiscussionThreadsUIState.Threads(listOf(mockPinnedThread, mockThread)),
             uiMessage = null,
             onItemClick = {},
             onBackClick = {},
@@ -774,7 +775,7 @@ private fun DiscussionThreadsScreenTabletPreview() {
     }
 }
 
-private val mockThread = org.openedx.discussion.domain.model.Thread(
+private val mockThread = Thread(
     id = "",
     author = "",
     authorLabel = "",
@@ -796,7 +797,7 @@ private val mockThread = org.openedx.discussion.domain.model.Thread(
     previewBody = "",
     abuseFlaggedCount = "",
     title = "Discussion title long Discussion title long good item",
-    pinned = true,
+    pinned = false,
     closed = false,
     following = true,
     commentCount = 21,
@@ -809,3 +810,5 @@ private val mockThread = org.openedx.discussion.domain.model.Thread(
     anonymousToPeers = false,
     isAuthor = false,
 )
+
+private val mockPinnedThread = mockThread.copy(pinned = true)

--- a/discussion/src/main/java/org/openedx/discussion/presentation/ui/DiscussionUI.kt
+++ b/discussion/src/main/java/org/openedx/discussion/presentation/ui/DiscussionUI.kt
@@ -27,6 +27,7 @@ import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.HelpOutline
 import androidx.compose.material.icons.filled.ChevronRight
+import androidx.compose.material.icons.filled.PushPin
 import androidx.compose.material.icons.filled.ThumbUp
 import androidx.compose.material.icons.outlined.ThumbUp
 import androidx.compose.runtime.Composable
@@ -60,6 +61,7 @@ import org.openedx.core.utils.TimeUtils
 import org.openedx.discussion.R
 import org.openedx.discussion.domain.model.DiscussionComment
 import org.openedx.discussion.domain.model.DiscussionType
+import org.openedx.discussion.domain.model.Thread
 import org.openedx.discussion.domain.model.Topic
 import org.openedx.discussion.presentation.comments.DiscussionCommentsFragment
 import org.openedx.core.R as CoreR
@@ -67,7 +69,7 @@ import org.openedx.core.R as CoreR
 @Composable
 fun ThreadMainItem(
     modifier: Modifier,
-    thread: org.openedx.discussion.domain.model.Thread,
+    thread: Thread,
     onClick: (String, Boolean) -> Unit,
     onUserPhotoClick: (String) -> Unit
 ) {
@@ -492,8 +494,8 @@ fun CommentMainItem(
 
 @Composable
 fun ThreadItem(
-    thread: org.openedx.discussion.domain.model.Thread,
-    onClick: (org.openedx.discussion.domain.model.Thread) -> Unit,
+    thread: Thread,
+    onClick: (Thread) -> Unit,
 ) {
     val icon = when (thread.type) {
         DiscussionType.DISCUSSION -> painterResource(id = R.drawable.discussion_ic_discussion)
@@ -525,26 +527,28 @@ fun ThreadItem(
                 color = MaterialTheme.appColors.textPrimaryVariant,
                 textStyle = MaterialTheme.appTypography.labelSmall
             )
-            if (thread.unreadCommentCount > 0 && !thread.read) {
-                Row(
-                    modifier = Modifier,
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(4.dp)
-                ) {
+            Row(
+                modifier = Modifier,
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
+                val iconSize = (MaterialTheme.appTypography.labelSmall.fontSize.value + 4).dp
+                if (thread.unreadCommentCount > 0 && !thread.read) {
                     Box {
                         Icon(
-                            modifier = Modifier.size((MaterialTheme.appTypography.labelSmall.fontSize.value + 4).dp),
+                            modifier = Modifier.size(iconSize),
                             painter = painterResource(id = R.drawable.discussion_ic_unread_replies),
                             tint = MaterialTheme.appColors.textPrimaryVariant,
                             contentDescription = null
                         )
                         Image(
-                            modifier = Modifier.size((MaterialTheme.appTypography.labelSmall.fontSize.value + 4).dp),
+                            modifier = Modifier.size(iconSize),
                             painter = painterResource(id = R.drawable.discussion_ic_unread_replies_dot),
                             contentDescription = null
                         )
                     }
                     Text(
+                        modifier = Modifier.align(Alignment.CenterVertically),
                         text = pluralStringResource(
                             id = R.plurals.discussion_missed_posts,
                             thread.unreadCommentCount,
@@ -552,6 +556,15 @@ fun ThreadItem(
                         ),
                         color = MaterialTheme.appColors.textPrimaryVariant,
                         style = MaterialTheme.appTypography.labelSmall
+                    )
+                }
+                if (thread.pinned) {
+                    Spacer(Modifier.width(10.dp))
+                    Icon(
+                        modifier = Modifier.size(iconSize),
+                        imageVector = Icons.Default.PushPin,
+                        contentDescription = null,
+                        tint = MaterialTheme.appColors.textPrimaryVariant,
                     )
                 }
             }
@@ -661,10 +674,10 @@ fun TopicItem(
 @Composable
 private fun TopicItemPreview() {
     OpenEdXTheme {
-        TopicItem(topic = mockTopic,
-            onClick = { _, _ ->
-
-            })
+        TopicItem(
+            topic = mockTopic,
+            onClick = { _, _ -> },
+        )
     }
 }
 
@@ -675,7 +688,8 @@ private fun ThreadItemPreview() {
     OpenEdXTheme {
         ThreadItem(
             thread = mockThread,
-            onClick = {})
+            onClick = {},
+        )
     }
 }
 
@@ -730,7 +744,7 @@ private val mockComment = DiscussionComment(
     isAuthor = false,
 )
 
-private val mockThread = org.openedx.discussion.domain.model.Thread(
+private val mockThread = Thread(
     id = "",
     author = "ABC",
     authorLabel = "",


### PR DESCRIPTION
### Description

[LEARNER-10465](https://2u-internal.atlassian.net/browse/LEARNER-10465)

- Pinned icon on pinned threads in the Discussion Module.
- The icon is consistent with platform design guidelines.
- Icon appears regardless of sorting order to maintain clarity.

### Screenshots
| Before | After |
|--------|--------|
| ![Before](https://github.com/user-attachments/assets/b4f28f99-56e8-451f-87fe-f2f7d35373ea) | ![Pinned](https://github.com/user-attachments/assets/73ccfcd1-49cc-4d0c-a4f7-67ff8e83f983) | 