### PR TITLE
fix: Issues occurring while casting the videos.

### DIFF
--- a/app/src/main/java/org/openedx/app/di/AppModule.kt
+++ b/app/src/main/java/org/openedx/app/di/AppModule.kt
@@ -58,6 +58,7 @@ import org.openedx.core.system.notifier.VideoNotifier
 import org.openedx.core.system.notifier.app.AppNotifier
 import org.openedx.core.utils.FileUtil
 import org.openedx.course.data.storage.CoursePreferences
+import org.openedx.course.module.CastManager
 import org.openedx.course.presentation.CourseAnalytics
 import org.openedx.course.presentation.CourseRouter
 import org.openedx.dashboard.presentation.DashboardAnalytics
@@ -196,6 +197,7 @@ val appModule = module {
     factory { (activity: AppCompatActivity) -> AppReviewManager(activity, get(), get()) }
 
     single { TranscriptManager(get()) }
+    single { CastManager(get()) }
     single { WhatsNewManager(get(), get(), get(), get()) }
     single<WhatsNewGlobalManager> { get<WhatsNewManager>() }
 

--- a/app/src/main/java/org/openedx/app/di/ScreenModule.kt
+++ b/app/src/main/java/org/openedx/app/di/ScreenModule.kt
@@ -382,6 +382,7 @@ val screenModule = module {
             title = title,
             context = get(),
             preferencesManager = get(),
+            castManager = get(),
             courseRepository = get(),
             notifier = get(),
             networkConnection = get(),

--- a/app/src/main/java/org/openedx/app/di/ScreenModule.kt
+++ b/app/src/main/java/org/openedx/app/di/ScreenModule.kt
@@ -375,17 +375,18 @@ val screenModule = module {
             get()
         )
     }
-    viewModel { (courseId: String, blockId: String) ->
+    viewModel { (courseId: String, blockId: String, title: String) ->
         EncodedVideoUnitViewModel(
-            courseId,
-            blockId,
-            get(),
-            get(),
-            get(),
-            get(),
-            get(),
-            get(),
-            get(),
+            courseId = courseId,
+            blockId = blockId,
+            title = title,
+            context = get(),
+            preferencesManager = get(),
+            courseRepository = get(),
+            notifier = get(),
+            networkConnection = get(),
+            transcriptManager = get(),
+            courseAnalytics = get(),
         )
     }
     viewModel { (courseId: String, courseTitle: String, enrollmentMode: String) ->

--- a/course/src/main/java/org/openedx/course/extension/MediaItemExt.kt
+++ b/course/src/main/java/org/openedx/course/extension/MediaItemExt.kt
@@ -1,0 +1,7 @@
+package org.openedx.course.extension
+
+import androidx.media3.common.MediaItem
+
+fun MediaItem.matches(other: MediaItem): Boolean {
+    return this.localConfiguration?.uri == other.localConfiguration?.uri
+}

--- a/course/src/main/java/org/openedx/course/module/CastManager.kt
+++ b/course/src/main/java/org/openedx/course/module/CastManager.kt
@@ -1,0 +1,89 @@
+package org.openedx.course.module
+
+import android.content.Context
+import androidx.media3.cast.CastPlayer
+import androidx.media3.cast.SessionAvailabilityListener
+import androidx.media3.common.MediaItem
+import androidx.media3.common.util.UnstableApi
+import com.google.android.gms.cast.framework.CastContext
+import com.google.android.gms.cast.framework.CastState
+import org.openedx.core.utils.Logger
+import org.openedx.course.extension.matches
+import java.util.concurrent.Executors
+
+@androidx.annotation.OptIn(UnstableApi::class)
+class CastManager(val context: Context) {
+
+    private val logger = Logger(TAG)
+
+    var castPlayer: CastPlayer? = null
+        private set
+
+    private var onAction: ((state: Int) -> Unit)? = null
+
+    init {
+        initializeCastPlayer()
+    }
+
+    private fun initializeCastPlayer() {
+        val executor = Executors.newSingleThreadExecutor()
+        CastContext.getSharedInstance(context, executor).addOnSuccessListener { castContext ->
+            castPlayer = CastPlayer(castContext)
+            setUpCastListener()
+        }.addOnFailureListener {
+            logger.e(it, true)
+        }
+    }
+
+    private fun setUpCastListener() {
+        castPlayer?.setSessionAvailabilityListener(object : SessionAvailabilityListener {
+            override fun onCastSessionAvailable() {
+                onAction?.invoke(CastState.CONNECTED)
+            }
+
+            override fun onCastSessionUnavailable() {
+                onAction?.invoke(CastState.NOT_CONNECTED)
+            }
+        })
+    }
+
+    fun setMediaItem(mediaItem: MediaItem, currentVideoTime: Long) {
+        val currentItem = castPlayer?.currentMediaItem
+
+        if (currentItem != null && mediaItem.matches(currentItem)) {
+            castPlayer?.seekTo(currentVideoTime)
+            castPlayer?.playWhenReady = true
+            return
+        }
+
+        castPlayer?.setMediaItem(mediaItem, currentVideoTime)
+        castPlayer?.playWhenReady = true
+    }
+
+    fun attachCastPlayer(onAction: (state: Int) -> Unit) {
+        this.onAction = onAction
+        if (castPlayer == null) {
+            initializeCastPlayer()
+        } else {
+            castPlayer?.isCastSessionAvailable?.let { isAvailable ->
+                if (isAvailable) {
+                    onAction(CastState.CONNECTED)
+                }
+            }
+        }
+    }
+
+    fun stopPlayer() {
+        castPlayer?.stop()
+    }
+
+    fun detachCastPlayer() {
+        onAction = null
+    }
+
+    fun getCurrentPosition() = castPlayer?.currentPosition ?: 0L
+
+    private companion object {
+        private const val TAG = "CastManager"
+    }
+}

--- a/course/src/main/java/org/openedx/course/presentation/unit/video/EncodedVideoUnitViewModel.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/video/EncodedVideoUnitViewModel.kt
@@ -183,16 +183,15 @@ class EncodedVideoUnitViewModel(
     override fun onResume(owner: LifecycleOwner) {
         super.onResume(owner)
         exoPlayer?.addListener(exoPlayerListener)
+        getActivePlayer()?.playWhenReady = true
     }
 
     override fun onPause(owner: LifecycleOwner) {
         super.onPause(owner)
-        if (state.value.isCastActive) {
-            getActivePlayer()?.release()
-        } else {
+        if (!state.value.isCastActive) {
             exoPlayer?.removeListener(exoPlayerListener)
-            exoPlayer?.pause()
         }
+        getActivePlayer()?.pause()
     }
 
     fun getActivePlayer(): Player? {

--- a/course/src/main/java/org/openedx/course/presentation/unit/video/EncodedVideoUnitViewModel.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/video/EncodedVideoUnitViewModel.kt
@@ -51,6 +51,7 @@ import java.util.concurrent.Executors
 class EncodedVideoUnitViewModel(
     courseId: String,
     blockId: String,
+    val title: String,
     private val context: Context,
     private val preferencesManager: CorePreferences,
     courseRepository: CourseRepository,
@@ -112,6 +113,7 @@ class EncodedVideoUnitViewModel(
 
     private val movieMetadata = MediaMetadata.Builder()
         .setMediaType(MediaMetadata.MEDIA_TYPE_MOVIE)
+        .setTitle(title)
         .build()
 
     private val exoPlayerListener = object : Player.Listener {

--- a/course/src/main/java/org/openedx/course/presentation/unit/video/EncodedVideoUnitViewModel.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/video/EncodedVideoUnitViewModel.kt
@@ -28,15 +28,20 @@ import androidx.media3.exoplayer.trackselection.DefaultTrackSelector
 import androidx.media3.exoplayer.upstream.DefaultBandwidthMeter
 import androidx.media3.extractor.DefaultExtractorsFactory
 import com.google.android.gms.cast.framework.CastState
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
 import org.openedx.core.data.storage.CorePreferences
 import org.openedx.core.domain.model.VideoPlaybackSpeed
 import org.openedx.core.domain.model.VideoQuality
+import org.openedx.core.extension.isTrue
 import org.openedx.core.module.TranscriptManager
 import org.openedx.core.system.connection.NetworkConnection
 import org.openedx.core.system.notifier.CourseNotifier
@@ -77,6 +82,8 @@ class EncodedVideoUnitViewModel(
     private val _state = MutableStateFlow(PlayerState())
     internal val state: StateFlow<PlayerState>
         get() = _state
+
+    private var videoTimeJob: Job? = null
 
     init {
         transcriptObject.asFlow().distinctUntilChanged().mapNotNull {
@@ -198,6 +205,7 @@ class EncodedVideoUnitViewModel(
             exoPlayer?.prepare()
             exoPlayer?.playWhenReady = isPlaying
         }
+        startUpdatingVideoTime()
     }
 
     override fun onPause(owner: LifecycleOwner) {
@@ -207,6 +215,7 @@ class EncodedVideoUnitViewModel(
             exoPlayer?.removeListener(exoPlayerListener)
         }
         exoPlayer?.pause()
+        stopUpdatingVideoTime()
     }
 
     private fun initPlayer() {
@@ -228,12 +237,36 @@ class EncodedVideoUnitViewModel(
         logVideoLoadedEvent(videoUrl)
     }
 
-    fun getActivePlayer(): Player? {
+    private fun getActivePlayer(): Player? {
         return if (state.value.activePlayerType == PlayerType.CHROME_CAST) {
             castManager.castPlayer
         } else {
             exoPlayer
         }
+    }
+
+    private fun startUpdatingVideoTime() {
+        videoTimeJob = viewModelScope.launch {
+            while (isActive) {
+                getActivePlayer()?.let {
+                    if (it.isPlaying && it.currentMediaItem?.matches(getMediaItem()).isTrue()) {
+                        setCurrentVideoTime(it.currentPosition)
+                    } else if (it.playbackState == Player.STATE_IDLE || it.playbackState == Player.STATE_ENDED) {
+                        setCurrentVideoTime(0)
+                    }
+                    val completePercentage = it.currentPosition.toDouble() / it.duration.toDouble()
+                    if (completePercentage >= 0.8f) {
+                        markBlockCompleted(blockId)
+                    }
+                }
+                delay(200L)
+            }
+        }
+    }
+
+    private fun stopUpdatingVideoTime() {
+        videoTimeJob?.cancel()
+        videoTimeJob = null
     }
 
     private fun applyTrackSelector(isSubtitlesDisabled: Boolean): DefaultTrackSelector {
@@ -267,10 +300,10 @@ class EncodedVideoUnitViewModel(
         _state.update { it.copy(activePlayerType = PlayerType.EXO_REGULAR) }
     }
 
-    private fun changeCastState(isActive: Boolean) {
+    private fun changeCastState(isCastActive: Boolean) {
         _state.update {
             it.copy(
-                activePlayerType = if (isActive) PlayerType.CHROME_CAST else PlayerType.EXO_REGULAR
+                activePlayerType = if (isCastActive) PlayerType.CHROME_CAST else PlayerType.EXO_REGULAR
             )
         }
     }

--- a/course/src/main/java/org/openedx/course/presentation/unit/video/EncodedVideoUnitViewModel.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/video/EncodedVideoUnitViewModel.kt
@@ -206,7 +206,7 @@ class EncodedVideoUnitViewModel(
         if (state.value.activePlayerType != PlayerType.CHROME_CAST) {
             exoPlayer?.removeListener(exoPlayerListener)
         }
-        getActivePlayer()?.pause()
+        exoPlayer?.pause()
     }
 
     private fun initPlayer() {

--- a/course/src/main/java/org/openedx/course/presentation/unit/video/EncodedVideoUnitViewModel.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/video/EncodedVideoUnitViewModel.kt
@@ -258,6 +258,7 @@ class EncodedVideoUnitViewModel(
 
     fun getMediaItem() = MediaItem.Builder().setMediaMetadata(movieMetadata)
         .setUri(videoUrl)
+        .setMimeType(if (videoUrl.endsWith(HLS_EXT)) MimeTypes.APPLICATION_M3U8 else VIDEO_MIME_TYPE)
         .build()
 
     @UnstableApi
@@ -298,5 +299,6 @@ class EncodedVideoUnitViewModel(
     private companion object {
         private const val TAG = "EncodedVideoUnitViewModel"
         private const val HLS_EXT = ".m3u8"
+        private const val VIDEO_MIME_TYPE = "video/*"
     }
 }

--- a/course/src/main/java/org/openedx/course/presentation/unit/video/EncodedVideoUnitViewModel.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/video/EncodedVideoUnitViewModel.kt
@@ -27,7 +27,7 @@ import androidx.media3.exoplayer.trackselection.AdaptiveTrackSelection
 import androidx.media3.exoplayer.trackselection.DefaultTrackSelector
 import androidx.media3.exoplayer.upstream.DefaultBandwidthMeter
 import androidx.media3.extractor.DefaultExtractorsFactory
-import com.google.android.gms.cast.framework.CastContext
+import com.google.android.gms.cast.framework.CastState
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -37,23 +37,25 @@ import kotlinx.coroutines.flow.update
 import org.openedx.core.data.storage.CorePreferences
 import org.openedx.core.domain.model.VideoPlaybackSpeed
 import org.openedx.core.domain.model.VideoQuality
-import org.openedx.core.extension.isTrue
 import org.openedx.core.module.TranscriptManager
 import org.openedx.core.system.connection.NetworkConnection
 import org.openedx.core.system.notifier.CourseNotifier
 import org.openedx.core.utils.LocaleUtils
-import org.openedx.core.utils.Logger
 import org.openedx.course.data.repository.CourseRepository
+import org.openedx.course.extension.matches
+import org.openedx.course.module.CastManager
 import org.openedx.course.presentation.CourseAnalytics
-import java.util.concurrent.Executors
+import org.openedx.course.presentation.CourseAnalyticsEvent
 
 @SuppressLint("StaticFieldLeak")
+@androidx.annotation.OptIn(UnstableApi::class)
 class EncodedVideoUnitViewModel(
     courseId: String,
     blockId: String,
     val title: String,
     private val context: Context,
     private val preferencesManager: CorePreferences,
+    private val castManager: CastManager,
     courseRepository: CourseRepository,
     notifier: CourseNotifier,
     networkConnection: NetworkConnection,
@@ -68,17 +70,13 @@ class EncodedVideoUnitViewModel(
     transcriptManager,
     courseAnalytics
 ) {
-    private val logger = Logger(TAG)
 
     var exoPlayer: ExoPlayer? = null
         private set
 
-    @SuppressLint("UnsafeOptInUsageError")
-    var castPlayer: CastPlayer? = null
-        private set
-
     private val _state = MutableStateFlow(PlayerState())
-    internal val state: StateFlow<PlayerState> = _state
+    internal val state: StateFlow<PlayerState>
+        get() = _state
 
     init {
         transcriptObject.asFlow().distinctUntilChanged().mapNotNull {
@@ -86,9 +84,8 @@ class EncodedVideoUnitViewModel(
                 exoPlayer?.currentMediaItem?.buildUpon()
                     ?.setSubtitleConfigurations(subtitleConfigurations)?.build()
                     ?.let { mediaItem ->
-                        exoPlayer?.clearMediaItems()
-                        exoPlayer?.addMediaItem(mediaItem)
-                        exoPlayer?.seekTo(getCurrentVideoTime())
+                        exoPlayer?.setMediaItem(mediaItem, getCurrentVideoTime())
+                        exoPlayer?.playWhenReady = true
                         _state.update { it.copy(isSubtitlesReady = true) }
                     }
             }
@@ -128,6 +125,7 @@ class EncodedVideoUnitViewModel(
 
         override fun onIsPlayingChanged(isPlaying: Boolean) {
             super.onIsPlayingChanged(isPlaying)
+            this@EncodedVideoUnitViewModel.isPlaying = isPlaying
             logPlayPauseEvent(
                 videoUrl,
                 isPlaying,
@@ -163,60 +161,61 @@ class EncodedVideoUnitViewModel(
         }
     }
 
-    @UnstableApi
     override fun onCreate(owner: LifecycleOwner) {
         super.onCreate(owner)
         if (exoPlayer != null) {
             return
         }
         initPlayer()
-
-        val executor = Executors.newSingleThreadExecutor()
-        CastContext.getSharedInstance(context, executor).addOnSuccessListener { castContext ->
-            castPlayer = CastPlayer(castContext)
-            _isUpdated.value = true
-        }.addOnFailureListener {
-            logger.e(it, true)
-        }
     }
 
     override fun onResume(owner: LifecycleOwner) {
         super.onResume(owner)
+        castManager.attachCastPlayer { state ->
+            when (state) {
+                CastState.CONNECTED -> {
+                    logCastConnection(CourseAnalyticsEvent.CAST_CONNECTED)
+                    exoPlayer?.pause()
+                    castManager.setMediaItem(
+                        getMediaItem(),
+                        getCurrentVideoTime()
+                    )
+                    changeCastState(true)
+                }
+
+                CastState.NOT_CONNECTED -> {
+                    logCastConnection(CourseAnalyticsEvent.CAST_DISCONNECTED)
+                    exoPlayer?.seekTo(castManager.getCurrentPosition())
+                    castManager.stopPlayer()
+                    exoPlayer?.play()
+                    changeCastState(false)
+                }
+            }
+        }
         exoPlayer?.addListener(exoPlayerListener)
-        getActivePlayer()?.playWhenReady = true
+        if (_state.value.activePlayerType == PlayerType.EXO_REGULAR || _state.value.activePlayerType == PlayerType.EXO_FULL_SCREEN) {
+            setPlayerMedia(getMediaItem())
+            exoPlayer?.prepare()
+            exoPlayer?.playWhenReady = isPlaying
+        }
     }
 
     override fun onPause(owner: LifecycleOwner) {
         super.onPause(owner)
-        if (!state.value.isCastActive) {
+        castManager.detachCastPlayer()
+        if (state.value.activePlayerType != PlayerType.CHROME_CAST) {
             exoPlayer?.removeListener(exoPlayerListener)
         }
         getActivePlayer()?.pause()
     }
 
-    fun getActivePlayer(): Player? {
-        return if (state.value.isCastActive) {
-            castPlayer
-        } else {
-            exoPlayer
-        }
-    }
-
-    @UnstableApi
-    fun releasePlayers() {
-        _state.update { it.copy(isPlayerSetUp = false) }
-        exoPlayer?.release()
-        castPlayer?.release()
-        exoPlayer = null
-        castPlayer = null
-    }
-
-    @UnstableApi
-    fun initPlayer() {
+    private fun initPlayer() {
         val selector = applyTrackSelector(isSubtitlesDisabled = true)
+        val renderersFactory = DefaultRenderersFactory(context)
+            .setEnableDecoderFallback(true) // Use software if hardware fails
         exoPlayer = ExoPlayer.Builder(
             context,
-            DefaultRenderersFactory(context),
+            renderersFactory,
             DefaultMediaSourceFactory(context, DefaultExtractorsFactory()),
             selector,
             DefaultLoadControl(),
@@ -225,10 +224,18 @@ class EncodedVideoUnitViewModel(
         ).build().apply {
             setPlaybackSpeed(preferencesManager.videoSettings.videoPlaybackSpeed.speedValue)
         }
+        _state.update { it.copy(activePlayerType = PlayerType.EXO_REGULAR) }
         logVideoLoadedEvent(videoUrl)
     }
 
-    @UnstableApi
+    fun getActivePlayer(): Player? {
+        return if (state.value.activePlayerType == PlayerType.CHROME_CAST) {
+            castManager.castPlayer
+        } else {
+            exoPlayer
+        }
+    }
+
     private fun applyTrackSelector(isSubtitlesDisabled: Boolean): DefaultTrackSelector {
         val videoQuality = getVideoQuality()
         val params = DefaultTrackSelector.Parameters.Builder(context)
@@ -248,57 +255,64 @@ class EncodedVideoUnitViewModel(
         return selector
     }
 
-    @UnstableApi
-    fun applyPlayerMedia() {
-        if (!state.value.isPlayerSetUp) {
-            setPlayerMedia(getMediaItem())
-            getActivePlayer()?.prepare()
-            _state.update { it.copy(isPlayerSetUp = true) }
-        }
-    }
-
-    fun getMediaItem() = MediaItem.Builder().setMediaMetadata(movieMetadata)
-        .setUri(videoUrl)
-        .setMimeType(if (videoUrl.endsWith(HLS_EXT)) MimeTypes.APPLICATION_M3U8 else VIDEO_MIME_TYPE)
-        .build()
-
-    @UnstableApi
     fun enterFullscreen(): Boolean {
-        if (state.value.isCastActive) return false
-        isPlaying = getActivePlayer()?.isPlaying.isTrue()
+        if (state.value.activePlayerType == PlayerType.CHROME_CAST) return false
         applyTrackSelector(isSubtitlesDisabled = false)
+        _state.update { it.copy(activePlayerType = PlayerType.EXO_FULL_SCREEN) }
         return true
     }
 
-    @UnstableApi
     fun leaveFullscreen() {
         applyTrackSelector(isSubtitlesDisabled = true)
-        _isUpdated.value = true
+        _state.update { it.copy(activePlayerType = PlayerType.EXO_REGULAR) }
     }
 
-    fun changeCastState(isActive: Boolean) {
-        _state.update { it.copy(isCastActive = isActive) }
+    private fun changeCastState(isActive: Boolean) {
+        _state.update {
+            it.copy(
+                activePlayerType = if (isActive) PlayerType.CHROME_CAST else PlayerType.EXO_REGULAR
+            )
+        }
     }
 
-    @UnstableApi
     private fun setPlayerMedia(mediaItem: MediaItem) {
+        val currentItem = exoPlayer?.currentMediaItem
+
+        if (currentItem != null && mediaItem.matches(currentItem)) {
+            exoPlayer?.seekTo(getCurrentVideoTime())
+            exoPlayer?.playWhenReady = true
+            return
+        }
         if (videoUrl.endsWith(HLS_EXT)) {
             val factory = DefaultDataSource.Factory(context)
             val mediaSource: HlsMediaSource =
                 HlsMediaSource.Factory(factory).createMediaSource(mediaItem)
             exoPlayer?.setMediaSource(mediaSource, getCurrentVideoTime())
         } else {
-            getActivePlayer()?.setMediaItem(
+            exoPlayer?.setMediaItem(
                 mediaItem,
                 getCurrentVideoTime()
             )
         }
     }
 
+    fun releasePlayers() {
+        _state.update { it.copy(activePlayerType = PlayerType.NONE) }
+        exoPlayer?.release()
+        exoPlayer = null
+        castManager.stopPlayer()
+    }
+
+    private fun getMediaItem() = MediaItem.Builder().setMediaMetadata(movieMetadata)
+        .setUri(videoUrl)
+        .setMimeType(if (videoUrl.endsWith(HLS_EXT)) MimeTypes.APPLICATION_M3U8 else VIDEO_MIME_TYPE)
+        .build()
+
+    fun getCastPlayer(): CastPlayer? = castManager.castPlayer
+
     private fun getVideoQuality() = preferencesManager.videoSettings.videoStreamingQuality
 
     private companion object {
-        private const val TAG = "EncodedVideoUnitViewModel"
         private const val HLS_EXT = ".m3u8"
         private const val VIDEO_MIME_TYPE = "video/*"
     }

--- a/course/src/main/java/org/openedx/course/presentation/unit/video/PlayerState.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/video/PlayerState.kt
@@ -2,8 +2,14 @@ package org.openedx.course.presentation.unit.video
 
 internal data class PlayerState(
     val selectedLanguage: String = "",
-    val isPlayerSetUp: Boolean = false,
-    val isCastActive: Boolean = false,
+    var activePlayerType: PlayerType = PlayerType.NONE,
     val isVideoEnded: Boolean = false,
     val isSubtitlesReady: Boolean = false,
 )
+
+enum class PlayerType {
+    EXO_REGULAR,
+    EXO_FULL_SCREEN,
+    CHROME_CAST,
+    NONE
+}

--- a/course/src/main/java/org/openedx/course/presentation/unit/video/VideoFullScreenFragment.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/video/VideoFullScreenFragment.kt
@@ -12,12 +12,15 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.view.WindowCompat
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.ui.PlayerView
@@ -80,7 +83,16 @@ class VideoFullScreenFragment : DialogFragment() {
     @Composable
     private fun PlayerComposeView() {
         val currentView = LocalView.current
+        val lifecycleOwner = LocalLifecycleOwner.current
+
         DisposableEffect(Unit) {
+            val observer = LifecycleEventObserver { _, event ->
+                if (event == Lifecycle.Event.ON_RESUME) {
+                    viewModel.enterFullscreen()
+                }
+            }
+
+            lifecycleOwner.lifecycle.addObserver(observer)
             onDispose {
                 currentView.keepScreenOn = false
                 viewModel.leaveFullscreen()
@@ -108,9 +120,6 @@ class VideoFullScreenFragment : DialogFragment() {
     override fun onPause() {
         requireActivity().window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
         viewModel.exoPlayer?.removeListener(exoPlayerListener)
-        if (!requireActivity().isChangingConfigurations) {
-            viewModel.exoPlayer?.pause()
-        }
         super.onPause()
     }
 

--- a/course/src/main/java/org/openedx/course/presentation/unit/video/VideoUnitFragment.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/video/VideoUnitFragment.kt
@@ -7,6 +7,7 @@ import android.os.Looper
 import android.view.View
 import android.view.WindowManager
 import android.widget.FrameLayout
+import androidx.annotation.OptIn
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -15,7 +16,7 @@ import androidx.core.os.bundleOf
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
-import androidx.media3.cast.SessionAvailabilityListener
+import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import androidx.window.layout.WindowMetricsCalculator
 import kotlinx.coroutines.flow.launchIn
@@ -36,7 +37,6 @@ import org.openedx.core.ui.theme.OpenEdXTheme
 import org.openedx.core.utils.LocaleUtils
 import org.openedx.course.R
 import org.openedx.course.databinding.FragmentVideoUnitBinding
-import org.openedx.course.presentation.CourseAnalyticsEvent
 import org.openedx.course.presentation.ui.VideoSubtitles
 import org.openedx.course.presentation.ui.VideoTitle
 import kotlin.math.roundToInt
@@ -86,6 +86,7 @@ class VideoUnitFragment : Fragment(R.layout.fragment_video_unit) {
         viewModel.downloadSubtitles()
     }
 
+    @OptIn(UnstableApi::class)
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         binding.cvVideoTitle?.setContent {
@@ -157,59 +158,36 @@ class VideoUnitFragment : Fragment(R.layout.fragment_video_unit) {
 
         binding.playerView.layoutParams = layoutParams
 
-        viewModel.isUpdated.observe(viewLifecycleOwner) { isUpdated ->
-            if (isUpdated) {
-                initPlayer()
-            }
-        }
-
         viewModel.state.onEach {
-            if (it.isVideoEnded && !appReviewManager.isDialogShowed) {
-                appReviewManager.tryToOpenRateDialog()
+            when {
+                it.activePlayerType == PlayerType.EXO_REGULAR -> {
+                    updatePlayerType(viewModel.exoPlayer)
+                    showVideoControllerIndefinitely(false)
+                }
+
+                it.activePlayerType == PlayerType.CHROME_CAST -> {
+                    updatePlayerType(viewModel.getCastPlayer())
+                    showVideoControllerIndefinitely(true)
+                }
+
+                it.isVideoEnded && !appReviewManager.isDialogShowed -> {
+                    appReviewManager.tryToOpenRateDialog()
+                }
             }
         }.launchIn(lifecycleScope)
     }
 
-    @androidx.annotation.OptIn(UnstableApi::class)
-    private fun initPlayer() {
-        with(binding) {
-            playerView.player = null
-            playerView.player = viewModel.getActivePlayer()
-            playerView.setShowNextButton(false)
-            playerView.setShowPreviousButton(false)
-            showVideoControllerIndefinitely(false)
-            viewModel.applyPlayerMedia()
-            viewModel.exoPlayer?.playWhenReady = viewModel.isPlaying
-            viewModel.castPlayer?.setSessionAvailabilityListener(
-                object : SessionAvailabilityListener {
-                    override fun onCastSessionAvailable() {
-                        viewModel.logCastConnection(CourseAnalyticsEvent.CAST_CONNECTED)
-                        viewModel.changeCastState(true)
-                        viewModel.exoPlayer?.pause()
-                        playerView.player = viewModel.castPlayer
-                        viewModel.castPlayer?.setMediaItem(
-                            viewModel.getMediaItem(),
-                            viewModel.getCurrentVideoTime()
-                        )
-                        viewModel.castPlayer?.playWhenReady = true
-                        showVideoControllerIndefinitely(true)
-                    }
-
-                    override fun onCastSessionUnavailable() {
-                        viewModel.logCastConnection(CourseAnalyticsEvent.CAST_DISCONNECTED)
-                        viewModel.changeCastState(false)
-                        playerView.player = viewModel.exoPlayer
-                        viewModel.exoPlayer?.seekTo(viewModel.castPlayer?.currentPosition ?: 0L)
-                        viewModel.castPlayer?.stop()
-                        viewModel.exoPlayer?.play()
-                        showVideoControllerIndefinitely(false)
-                    }
-                }
-            )
-
-            playerView.setFullscreenButtonClickListener {
+    @OptIn(UnstableApi::class)
+    private fun updatePlayerType(player: Player?) {
+        with(binding.playerView) {
+            this.player = null
+            this.player = player
+            this.setShowNextButton(false)
+            this.setShowPreviousButton(false)
+            this.setFullscreenButtonClickListener {
                 if (viewModel.enterFullscreen()) {
-                    VideoFullScreenFragment.newInstance().show(childFragmentManager, VideoFullScreenFragment.TAG)
+                    VideoFullScreenFragment.newInstance()
+                        .show(childFragmentManager, VideoFullScreenFragment.TAG)
                 }
             }
         }
@@ -239,11 +217,11 @@ class VideoUnitFragment : Fragment(R.layout.fragment_video_unit) {
         if (show) {
             binding.playerView.controllerAutoShow = false
             binding.playerView.controllerShowTimeoutMs = 0
-            binding.playerView.showController()
         } else {
             binding.playerView.controllerAutoShow = true
             binding.playerView.controllerShowTimeoutMs = 2000
         }
+        binding.playerView.showController()
     }
 
     companion object {

--- a/course/src/main/java/org/openedx/course/presentation/unit/video/VideoUnitFragment.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/video/VideoUnitFragment.kt
@@ -116,13 +116,13 @@ class VideoUnitFragment : Fragment(R.layout.fragment_video_unit) {
                     showSubtitleLanguage = viewModel.transcripts.size > 1,
                     currentIndex = currentIndex,
                     onTranscriptClick = {
-                        viewModel.getActivePlayer()?.apply {
+                        binding.playerView.player?.apply {
                             seekTo(it.start.mseconds.toLong())
                             play()
                         }
                     },
                     onSettingsClick = {
-                        viewModel.getActivePlayer()?.pause()
+                        binding.playerView.player?.pause()
                         val dialog = SelectBottomDialogFragment.newInstance(
                             LocaleUtils.getLanguages(viewModel.transcripts.keys.toList())
                         )

--- a/course/src/main/java/org/openedx/course/presentation/unit/video/VideoUnitFragment.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/video/VideoUnitFragment.kt
@@ -2,8 +2,6 @@ package org.openedx.course.presentation.unit.video
 
 import android.content.res.Configuration
 import android.os.Bundle
-import android.os.Handler
-import android.os.Looper
 import android.view.View
 import android.view.WindowManager
 import android.widget.FrameLayout
@@ -55,27 +53,10 @@ class VideoUnitFragment : Fragment(R.layout.fragment_video_unit) {
 
     private var windowSize: WindowSize? = null
 
-    private val handler = Handler(Looper.getMainLooper())
-    private var videoTimeRunnable: Runnable = object : Runnable {
-        override fun run() {
-            viewModel.getActivePlayer()?.let {
-                if (it.isPlaying) {
-                    viewModel.setCurrentVideoTime(it.currentPosition)
-                }
-                val completePercentage = it.currentPosition.toDouble() / it.duration.toDouble()
-                if (completePercentage >= 0.8f) {
-                    viewModel.markBlockCompleted(viewModel.blockId)
-                }
-            }
-            handler.postDelayed(this, 200)
-        }
-    }
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         windowSize = computeWindowSizeClasses()
         lifecycle.addObserver(viewModel)
-        handler.post(videoTimeRunnable)
         requireArguments().apply {
             viewModel.videoUrl = getString(ARG_VIDEO_URL, "")
             viewModel.transcripts = stringToObject<Map<String, String>>(
@@ -208,7 +189,6 @@ class VideoUnitFragment : Fragment(R.layout.fragment_video_unit) {
         if (!requireActivity().isChangingConfigurations) {
             viewModel.releasePlayers()
         }
-        handler.removeCallbacks(videoTimeRunnable)
         super.onDestroy()
     }
 

--- a/course/src/main/java/org/openedx/course/presentation/unit/video/VideoUnitFragment.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/video/VideoUnitFragment.kt
@@ -48,6 +48,7 @@ class VideoUnitFragment : Fragment(R.layout.fragment_video_unit) {
         parametersOf(
             requireArguments().getString(ARG_COURSE_ID, ""),
             requireArguments().getString(ARG_BLOCK_ID, ""),
+            requireArguments().getString(ARG_TITLE, ""),
         )
     }
     private val appReviewManager by inject<AppReviewManager> { parametersOf(requireActivity()) }
@@ -89,7 +90,7 @@ class VideoUnitFragment : Fragment(R.layout.fragment_video_unit) {
         super.onViewCreated(view, savedInstanceState)
         binding.cvVideoTitle?.setContent {
             OpenEdXTheme {
-                VideoTitle(text = requireArguments().getString(ARG_TITLE) ?: "")
+                VideoTitle(text = viewModel.title)
             }
         }
 

--- a/course/src/main/java/org/openedx/course/presentation/unit/video/VideoUnitViewModel.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/video/VideoUnitViewModel.kt
@@ -42,10 +42,6 @@ open class VideoUnitViewModel(
     val currentVideoTime: LiveData<Long>
         get() = _currentVideoTime
 
-    protected val _isUpdated = MutableLiveData(true)
-    val isUpdated: LiveData<Boolean>
-        get() = _isUpdated
-
     private val _currentIndex = MutableStateFlow(0)
     val currentIndex = _currentIndex.asStateFlow()
 
@@ -65,10 +61,8 @@ open class VideoUnitViewModel(
         viewModelScope.launch {
             notifier.notifier.collect {
                 if (it is CourseVideoPositionChanged && videoUrl == it.videoUrl) {
-                    _isUpdated.value = false
                     _currentVideoTime.value = it.videoTime
                     videoDuration = it.videoDuration
-                    _isUpdated.value = true
                     isPlaying = it.isPlaying
                 } else if (it is CourseSubtitleLanguageChanged) {
                     transcriptLanguage = it.value

--- a/course/src/test/java/org/openedx/course/presentation/unit/video/VideoUnitViewModelTest.kt
+++ b/course/src/test/java/org/openedx/course/presentation/unit/video/VideoUnitViewModelTest.kt
@@ -164,7 +164,5 @@ class VideoUnitViewModelTest {
         advanceUntilIdle()
 
         assert(viewModel.currentVideoTime.value == 10L)
-        assert(viewModel.isUpdated.value == true)
     }
-
 }


### PR DESCRIPTION
## Description

Jira Tickets: [LEARNER-10379](https://2u-internal.atlassian.net/browse/LEARNER-10379), [LEARNER-10501](https://2u-internal.atlassian.net/browse/LEARNER-10501)

- Revamp the cast player.
- Fix the crash while casting the video.
- Fix the issue where the ‘Stop casting' button doesn’t show the information of the playing video.
- Fix the issue where casting is disconnected while changing the orientation to landscape.
- When the device is locked while casting, the video should continue playing without interruption. 
- Tapping the Next/Previous button while casting should start and cast the next/previous video without any issues.


**Reasons for switching to a singleton CastManager**
- Consistent playback across screens and orientation changes.
- Safe, single entry-point to CastPlayer throughout content navigation.
- Central place for session listeners and logging.
- Compatible with MVVM (via injection or exposure to ViewModels).