### PR TITLE
fix: UI Issue in Landscape Mode – Video Controls Cut Off.

### DIFF
--- a/course/src/main/res/layout-land/fragment_video_unit.xml
+++ b/course/src/main/res/layout-land/fragment_video_unit.xml
@@ -8,11 +8,10 @@
     <androidx.cardview.widget.CardView
         android:id="@+id/cardView"
         android:layout_width="0dp"
-        android:layout_height="0dp"
+        android:layout_height="match_parent"
         app:cardCornerRadius="20dp"
         app:cardElevation="0dp"
-        app:layout_constraintDimensionRatio="H,16:9"
-        app:layout_constraintEnd_toStartOf="@id/subtitles"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintWidth_percent="0.6">

--- a/course/src/main/res/layout-land/fragment_youtube_video_unit.xml
+++ b/course/src/main/res/layout-land/fragment_youtube_video_unit.xml
@@ -8,11 +8,10 @@
     <androidx.cardview.widget.CardView
         android:id="@+id/cardView"
         android:layout_width="0dp"
-        android:layout_height="0dp"
+        android:layout_height="match_parent"
         app:cardCornerRadius="20dp"
         app:cardElevation="0dp"
-        app:layout_constraintDimensionRatio="W,9:16"
-        app:layout_constraintEnd_toStartOf="@id/subtitles"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintWidth_percent="0.6">


### PR DESCRIPTION
### Description

Jira: [LEARNER-10500](https://2u-internal.atlassian.net/browse/LEARNER-10500)

- Fix UI issue in Landscape Mode for both native and the YouTube video player controls, which are cut off.

**Screenshots** 
| Before  | After |
| ------------- | ------------- |
| ![youtube-before](https://github.com/user-attachments/assets/38748404-8b79-4773-8add-62e5170ddf8c) | ![Youtube-after](https://github.com/user-attachments/assets/b0b9187a-0c99-4732-bcb8-f0625419041d) |
| ![exo-before](https://github.com/user-attachments/assets/d3132b9e-6fc0-435b-afe3-c76cbd142ed3)  | ![Exo-after](https://github.com/user-attachments/assets/922ca8fd-3b27-4ff3-96b1-41293556bb97)  |

