### PR TITLE
fix: Persist registration field data on recomposition

### DIFF
--- a/auth/src/main/java/org/openedx/auth/presentation/signup/SignUpFragment.kt
+++ b/auth/src/main/java/org/openedx/auth/presentation/signup/SignUpFragment.kt
@@ -31,11 +31,6 @@ class SignUpFragment : Fragment() {
     }
     private val router by inject<AuthRouter>()
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        viewModel.getRegistrationFields()
-    }
-
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,

--- a/auth/src/main/java/org/openedx/auth/presentation/signup/SignUpViewModel.kt
+++ b/auth/src/main/java/org/openedx/auth/presentation/signup/SignUpViewModel.kt
@@ -78,6 +78,7 @@ class SignUpViewModel(
     init {
         collectAppUpgradeEvent()
         logRegisterScreenEvent()
+        getRegistrationFields()
     }
 
     fun getRegistrationFields() {

--- a/auth/src/test/java/org/openedx/auth/presentation/signup/SignUpViewModelTest.kt
+++ b/auth/src/test/java/org/openedx/auth/presentation/signup/SignUpViewModelTest.kt
@@ -332,7 +332,7 @@ class SignUpViewModelTest {
         coEvery { interactor.getRegistrationFields() } throws UnknownHostException()
         viewModel.getRegistrationFields()
         advanceUntilIdle()
-        coVerify(exactly = 1) { interactor.getRegistrationFields() }
+        coVerify(exactly = 2) { interactor.getRegistrationFields() }
         verify(exactly = 1) { appNotifier.notifier }
 
         assertFalse(viewModel.uiState.value.isLoading)
@@ -359,7 +359,7 @@ class SignUpViewModelTest {
         coEvery { interactor.getRegistrationFields() } throws Exception()
         viewModel.getRegistrationFields()
         advanceUntilIdle()
-        coVerify(exactly = 1) { interactor.getRegistrationFields() }
+        coVerify(exactly = 2) { interactor.getRegistrationFields() }
         verify(exactly = 1) { appNotifier.notifier }
 
         assertFalse(viewModel.uiState.value.isLoading)
@@ -384,7 +384,7 @@ class SignUpViewModelTest {
         coEvery { interactor.getRegistrationFields() } returns listOfFields
         viewModel.getRegistrationFields()
         advanceUntilIdle()
-        coVerify(exactly = 1) { interactor.getRegistrationFields() }
+        coVerify(exactly = 2) { interactor.getRegistrationFields() }
         verify(exactly = 1) { appNotifier.notifier }
 
         //val fields = viewModel.uiState.value as? SignUpUIState.Fields


### PR DESCRIPTION
### Description:

- Moved the getRegistration API call from the onCreate method of the class to the init block of the ViewModel.

Ticket: [LEARNER-10487](https://2u-internal.atlassian.net/browse/LEARNER-10487)