### PR TITLE
fix: Fallback to DummyPushManager when Push feature is disabled

### DIFF
--- a/app/src/main/java/org/openedx/app/di/AppModule.kt
+++ b/app/src/main/java/org/openedx/app/di/AppModule.kt
@@ -46,6 +46,7 @@ import org.openedx.core.presentation.global.WhatsNewGlobalManager
 import org.openedx.core.presentation.global.app_upgrade.AppUpgradeRouter
 import org.openedx.core.system.AppCookieManager
 import org.openedx.core.system.CalendarManager
+import org.openedx.core.system.DummyPushManager
 import org.openedx.core.system.PushGlobalManager
 import org.openedx.core.system.ResourceManager
 import org.openedx.core.system.connection.NetworkConnection
@@ -217,8 +218,11 @@ val appModule = module {
     single<IAPAnalytics> { get<AnalyticsManager>() }
     single<NotificationsAnalytics> { get<AnalyticsManager>() }
 
-    single { PushManager(get(), get(), get()) }
-    single<PushGlobalManager> { get<PushManager>() }
+    single { DummyPushManager() }
+    single<PushGlobalManager> {
+        if (get<Config>().isPushNotificationsEnabled()) get<PushManager>()
+        else get<DummyPushManager>()
+    }
 
     factory { AgreementProvider(get(), get()) }
     factory { FacebookAuthHelper() }

--- a/app/src/main/java/org/openedx/app/system/push/OpenEdXFirebaseMessagingService.kt
+++ b/app/src/main/java/org/openedx/app/system/push/OpenEdXFirebaseMessagingService.kt
@@ -18,13 +18,13 @@ import org.openedx.app.R
 import org.openedx.core.config.Config
 import org.openedx.core.data.storage.CorePreferences
 import org.openedx.core.extension.isNotNullOrEmpty
-import org.openedx.notifications.PushManager
+import org.openedx.core.system.PushGlobalManager
 
 class OpenEdXFirebaseMessagingService : FirebaseMessagingService() {
 
     private val preferences: CorePreferences by inject()
     private val config: Config by inject()
-    private val pushManager: PushManager by inject()
+    private val pushManager: PushGlobalManager by inject()
 
     override fun onMessageReceived(message: RemoteMessage) {
         super.onMessageReceived(message)

--- a/core/src/main/java/org/openedx/core/system/PushGlobalManager.kt
+++ b/core/src/main/java/org/openedx/core/system/PushGlobalManager.kt
@@ -18,3 +18,13 @@ interface PushGlobalManager {
 
     fun logNotificationTappedEvent(data: Map<String, String>)
 }
+
+class DummyPushManager : PushGlobalManager {
+    override suspend fun getUnreadNotificationsCount() = 0
+    override suspend fun markNotificationAsRead(notificationId: Int) {}
+    override fun showNotificationsPrimer(context: Context, fragmentManager: FragmentManager) {}
+    override fun logNotificationPermissionStatusEvent(context: Context) {}
+    override fun logNotificationBellClickedEvent(hasUnreadNotifications: Boolean) {}
+    override fun logNotificationReceivedEvent(data: Map<String, String>) {}
+    override fun logNotificationTappedEvent(data: Map<String, String>) {}
+}

--- a/core/src/main/java/org/openedx/core/ui/IAPUI.kt
+++ b/core/src/main/java/org/openedx/core/ui/IAPUI.kt
@@ -157,7 +157,7 @@ fun OptionCard(
     val configuration = LocalConfiguration.current
     val width =
         if (configuration.orientation == Configuration.ORIENTATION_PORTRAIT) configuration.screenWidthDp
-        else (configuration.screenWidthDp / 0.33).toInt()
+        else (configuration.screenWidthDp * 0.5).toInt()
 
     Card(
         modifier = Modifier

--- a/notifications/src/main/java/org/openedx/notifications/di/NotificationsModuleProvider.kt
+++ b/notifications/src/main/java/org/openedx/notifications/di/NotificationsModuleProvider.kt
@@ -4,6 +4,7 @@ import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.core.module.Module
 import org.koin.dsl.module
 import org.openedx.core.di.KoinModuleProvider
+import org.openedx.notifications.PushManager
 import org.openedx.notifications.data.repository.NotificationsRepository
 import org.openedx.notifications.domain.interactor.NotificationsInteractor
 import org.openedx.notifications.presentation.inbox.NotificationsInboxViewModel
@@ -13,6 +14,8 @@ import org.openedx.notifications.presentation.settings.NotificationsSettingsView
 class NotificationsModuleProvider : KoinModuleProvider {
 
     private val notificationsModule = module {
+        single { PushManager(get(), get(), get()) }
+
         single { NotificationsRepository(get(), get()) }
         factory { NotificationsInteractor(get()) }
 


### PR DESCRIPTION
## **Description**

[LEARNER-10565](https://2u-internal.atlassian.net/browse/LEARNER-10565)

**What’s Changed:**

* Introduce `DummyPushManager` as a no-op fallback when push notifications are disabled
* Update Koin binding so `PushGlobalManager` always resolves, preventing injection failures

**Why:**

Disabling the push feature flag previously removed the `PushGlobalManager` binding, causing ViewModel initialization to crash. This change guarantees a harmless stub is available, preserving app stability regardless of the flag state.
