### PR TITLE
feat: App Appearance Settings Screen

### DIFF
--- a/app/src/main/java/org/openedx/app/AppRouter.kt
+++ b/app/src/main/java/org/openedx/app/AppRouter.kt
@@ -47,6 +47,7 @@ import org.openedx.notifications.presentation.settings.NotificationsSettingsFrag
 import org.openedx.profile.domain.model.Account
 import org.openedx.profile.presentation.ProfileRouter
 import org.openedx.profile.presentation.anothersaccount.AnothersProfileFragment
+import org.openedx.profile.presentation.appearance.AppearanceSettingsFragment
 import org.openedx.profile.presentation.calendar.CalendarFragment
 import org.openedx.profile.presentation.delete.DeleteProfileFragment
 import org.openedx.profile.presentation.edit.EditProfileFragment
@@ -439,6 +440,10 @@ class AppRouter : AuthRouter, DiscoveryRouter, DashboardRouter, CourseRouter, Di
 
     override fun navigateToVideoSettings(fm: FragmentManager) {
         replaceFragmentWithBackStack(fm, VideoSettingsFragment())
+    }
+
+    override fun navigateToAppearanceSettings(fm: FragmentManager) {
+        replaceFragmentWithBackStack(fm, AppearanceSettingsFragment())
     }
 
     override fun navigateToPushNotificationsSettings(fm: FragmentManager) {

--- a/app/src/main/java/org/openedx/app/AppViewModel.kt
+++ b/app/src/main/java/org/openedx/app/AppViewModel.kt
@@ -24,6 +24,7 @@ import org.openedx.core.system.PushGlobalManager
 import org.openedx.core.system.notifier.app.AppNotifier
 import org.openedx.core.system.notifier.app.LogoutEvent
 import org.openedx.core.system.notifier.app.SignInEvent
+import org.openedx.core.ui.theme.ThemeManager
 import org.openedx.core.utils.FileUtil
 import org.openedx.core.utils.Logger
 
@@ -57,6 +58,7 @@ class AppViewModel(
     init {
         logAppLaunchEvent()
         setUserId(preferencesManager.user)
+        setAppThemeFromPreference()
     }
 
     override fun onCreate(owner: LifecycleOwner) {
@@ -104,6 +106,10 @@ class AppViewModel(
         user?.let {
             analytics.setUserIdForSession(it.id)
         }
+    }
+
+    private fun setAppThemeFromPreference() {
+        ThemeManager.applyThemeMode(context, preferencesManager.appThemeMode)
     }
 
     private suspend fun handleLogoutEvent(event: LogoutEvent) {

--- a/app/src/main/java/org/openedx/app/data/storage/PreferencesManager.kt
+++ b/app/src/main/java/org/openedx/app/data/storage/PreferencesManager.kt
@@ -8,6 +8,7 @@ import org.openedx.core.data.model.User
 import org.openedx.core.data.storage.CorePreferences
 import org.openedx.core.data.storage.InAppReviewPreferences
 import org.openedx.core.domain.model.AppConfig
+import org.openedx.core.domain.model.AppThemeMode
 import org.openedx.core.domain.model.VideoPlaybackSpeed
 import org.openedx.core.domain.model.VideoQuality
 import org.openedx.core.domain.model.VideoSettings
@@ -136,6 +137,15 @@ class PreferencesManager(context: Context) : CorePreferences, ProfilePreferences
             )
         }
 
+    override var appThemeMode: AppThemeMode
+        set(value) {
+            saveString(APP_THEME_MODE, value.name)
+        }
+        get() {
+            val mode = getString(APP_THEME_MODE, defValue = AppThemeMode.MATCH_DEVICE.name)
+            return AppThemeMode.valueOf(mode)
+        }
+
     override var appConfig: AppConfig
         set(value) {
             val appConfigJson = Gson().toJson(value)
@@ -248,5 +258,6 @@ class PreferencesManager(context: Context) : CorePreferences, ProfilePreferences
         private const val NOTIFICATIONS_CONFIGURATION = "notifications_configuration"
         private const val NOTIFICATIONS_PRIMER_CONFIGURATION = "notifications_primer_configuration"
         private const val PLS_BANNER_SHOWN = "pls_banner_shown"
+        private const val APP_THEME_MODE = "app_theme_mode"
     }
 }

--- a/app/src/main/java/org/openedx/app/di/ScreenModule.kt
+++ b/app/src/main/java/org/openedx/app/di/ScreenModule.kt
@@ -62,6 +62,7 @@ import org.openedx.profile.data.repository.ProfileRepository
 import org.openedx.profile.domain.interactor.ProfileInteractor
 import org.openedx.profile.domain.model.Account
 import org.openedx.profile.presentation.anothersaccount.AnothersProfileViewModel
+import org.openedx.profile.presentation.appearance.AppearanceSettingsViewModel
 import org.openedx.profile.presentation.calendar.CalendarViewModel
 import org.openedx.profile.presentation.delete.DeleteProfileViewModel
 import org.openedx.profile.presentation.edit.EditProfileViewModel
@@ -208,6 +209,7 @@ val screenModule = module {
         )
     }
     viewModel { (account: Account) -> EditProfileViewModel(get(), get(), get(), get(), account) }
+    viewModel { AppearanceSettingsViewModel(get(), get()) }
     viewModel { VideoSettingsViewModel(get(), get(), get(), get()) }
     viewModel { (qualityType: String) -> VideoQualityViewModel(qualityType, get(), get(), get()) }
     viewModel { DeleteProfileViewModel(get(), get(), get(), get(), get()) }

--- a/app/src/test/java/org/openedx/AppViewModelTest.kt
+++ b/app/src/test/java/org/openedx/AppViewModelTest.kt
@@ -29,6 +29,7 @@ import org.openedx.app.room.AppDatabase
 import org.openedx.core.config.Config
 import org.openedx.core.config.FirebaseConfig
 import org.openedx.core.data.model.User
+import org.openedx.core.domain.model.AppThemeMode
 import org.openedx.core.system.PushGlobalManager
 import org.openedx.core.system.notifier.app.AppNotifier
 import org.openedx.core.system.notifier.app.LogoutEvent
@@ -53,12 +54,14 @@ class AppViewModelTest {
     private val pushManager = mockk<PushGlobalManager>()
 
     private val user = User(0, "", "", "")
+    private val appThemeMode = AppThemeMode.MATCH_DEVICE
 
     @Before
     fun before() {
         Dispatchers.setMain(dispatcher)
         every { analytics.logEvent(any(), any()) } returns Unit
         every { preferencesManager.user } returns user
+        every { preferencesManager.appThemeMode } returns appThemeMode
     }
 
     @After

--- a/core/src/main/java/org/openedx/core/data/storage/CorePreferences.kt
+++ b/core/src/main/java/org/openedx/core/data/storage/CorePreferences.kt
@@ -2,6 +2,7 @@ package org.openedx.core.data.storage
 
 import org.openedx.core.data.model.User
 import org.openedx.core.domain.model.AppConfig
+import org.openedx.core.domain.model.AppThemeMode
 import org.openedx.core.domain.model.VideoSettings
 
 interface CorePreferences {
@@ -11,6 +12,7 @@ interface CorePreferences {
     var accessTokenExpiresAt: Long
     var user: User?
     var videoSettings: VideoSettings
+    var appThemeMode: AppThemeMode
     var appConfig: AppConfig
     var canResetAppDirectory: Boolean
     var lastSignInType: String

--- a/core/src/main/java/org/openedx/core/domain/model/AppThemeMode.kt
+++ b/core/src/main/java/org/openedx/core/domain/model/AppThemeMode.kt
@@ -1,0 +1,26 @@
+package org.openedx.core.domain.model
+
+import androidx.annotation.StringRes
+import org.openedx.core.R
+
+enum class AppThemeMode(
+    val value: String,
+    @StringRes val titleResId: Int,
+    @StringRes val descriptionResId: Int = 0,
+) {
+    LIGHT(
+        value = "light",
+        titleResId = R.string.core_light_mode,
+    ),
+
+    DARK(
+        value = "dark",
+        titleResId = R.string.core_dark_mode,
+    ),
+
+    MATCH_DEVICE(
+        value = "auto",
+        titleResId = R.string.core_match_device,
+        descriptionResId = R.string.core_match_device_description,
+    )
+}

--- a/core/src/main/java/org/openedx/core/ui/theme/ThemeManager.kt
+++ b/core/src/main/java/org/openedx/core/ui/theme/ThemeManager.kt
@@ -1,4 +1,4 @@
-package org.openedx.profile.presentation.appearance
+package org.openedx.core.ui.theme
 
 import android.app.UiModeManager
 import android.content.Context

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -240,4 +240,10 @@
     <string name="iap_continue_to_payment">Continue to payment (%s)</string>
     <string name="iap_continue_with_free_track">Continue with free track</string>
 
+    <!-- App Appearance Settings -->
+    <string name="core_light_mode">Light mode</string>
+    <string name="core_dark_mode">Dark mode</string>
+    <string name="core_match_device">Match device</string>
+    <string name="core_match_device_description">Matches your device settings automatically.</string>
+
 </resources>

--- a/profile/src/main/java/org/openedx/profile/presentation/ProfileAnalytics.kt
+++ b/profile/src/main/java/org/openedx/profile/presentation/ProfileAnalytics.kt
@@ -26,6 +26,10 @@ enum class ProfileAnalyticsEvent(val eventName: String, val biValue: String) {
         "Profile:Video Setting Clicked",
         "edx.bi.app.profile.video_setting.clicked"
     ),
+    APPEARANCE_SETTING_CLICKED(
+        "Profile:Appearance Setting Clicked",
+        "edx.bi.app.profile.appearance_setting.clicked"
+    ),
     PUSH_NOTIFICATIONS_CLICKED(
         "Profile:Push Notifications Setting Clicked",
         "edx.bi.app.profile.push_notifications_setting.clicked"
@@ -82,6 +86,10 @@ enum class ProfileAnalyticsEvent(val eventName: String, val biValue: String) {
         "Profile:Logged Out",
         "edx.bi.app.user.logout"
     ),
+    APP_THEME_CHANGED(
+        "Profile:App Theme Changed",
+        "edx.bi.app.profile.app_theme.changed"
+    ),
 }
 
 enum class ProfileAnalyticsKey(val key: String) {
@@ -94,4 +102,6 @@ enum class ProfileAnalyticsKey(val key: String) {
     SUCCESS("success"),
     FORCE("force"),
     FALSE("false"),
+    NEW_MODE("new_mode"),
+    PREVIOUS_MODE("previous_mode")
 }

--- a/profile/src/main/java/org/openedx/profile/presentation/ProfileRouter.kt
+++ b/profile/src/main/java/org/openedx/profile/presentation/ProfileRouter.kt
@@ -16,6 +16,8 @@ interface ProfileRouter {
 
     fun navigateToVideoSettings(fm: FragmentManager)
 
+    fun navigateToAppearanceSettings(fm: FragmentManager)
+
     fun navigateToPushNotificationsSettings(fm: FragmentManager)
 
     fun navigateToVideoQuality(fm: FragmentManager, videoQualityType: VideoQualityType)

--- a/profile/src/main/java/org/openedx/profile/presentation/appearance/AppearanceSettingsFragment.kt
+++ b/profile/src/main/java/org/openedx/profile/presentation/appearance/AppearanceSettingsFragment.kt
@@ -1,0 +1,252 @@
+package org.openedx.profile.presentation.appearance
+
+import android.content.res.Configuration
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Divider
+import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Done
+import androidx.compose.material.rememberScaffoldState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTagsAsResourceId
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.fragment.app.Fragment
+import org.koin.androidx.viewmodel.ext.android.viewModel
+import org.openedx.core.domain.model.AppThemeMode
+import org.openedx.core.extension.nonZero
+import org.openedx.core.extension.tagId
+import org.openedx.core.ui.Toolbar
+import org.openedx.core.ui.WindowSize
+import org.openedx.core.ui.WindowType
+import org.openedx.core.ui.displayCutoutForLandscape
+import org.openedx.core.ui.rememberWindowSize
+import org.openedx.core.ui.settingsHeaderBackground
+import org.openedx.core.ui.statusBarsInset
+import org.openedx.core.ui.theme.OpenEdXTheme
+import org.openedx.core.ui.theme.appColors
+import org.openedx.core.ui.theme.appShapes
+import org.openedx.core.ui.theme.appTypography
+import org.openedx.core.ui.windowSizeValue
+import org.openedx.profile.R
+
+class AppearanceSettingsFragment : Fragment() {
+
+    private val viewModel by viewModel<AppearanceSettingsViewModel>()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ) = ComposeView(requireContext()).apply {
+        setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+        setContent {
+            OpenEdXTheme {
+                val context = LocalContext.current
+                val windowSize = rememberWindowSize()
+                val themeMode by viewModel.appThemeMode.collectAsState()
+
+                AppearanceSettingsScreen(
+                    windowSize = windowSize,
+                    selectedTheme = themeMode,
+                    onThemeChanged = {
+                        viewModel.setAppThemeMode(context, it)
+                    },
+                    onBackClick = {
+                        requireActivity().supportFragmentManager.popBackStack()
+                    }
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalComposeUiApi::class)
+@Composable
+private fun AppearanceSettingsScreen(
+    windowSize: WindowSize,
+    selectedTheme: AppThemeMode,
+    onThemeChanged: (AppThemeMode) -> Unit,
+    onBackClick: () -> Unit,
+) {
+    val scaffoldState = rememberScaffoldState()
+    Scaffold(
+        modifier = Modifier
+            .fillMaxSize()
+            .semantics { testTagsAsResourceId = true },
+        scaffoldState = scaffoldState,
+        backgroundColor = MaterialTheme.appColors.background
+    ) { paddingValues ->
+
+        val topBarWidth by remember(key1 = windowSize) {
+            mutableStateOf(
+                windowSize.windowSizeValue(
+                    expanded = Modifier.widthIn(Dp.Unspecified, 560.dp),
+                    compact = Modifier.fillMaxWidth()
+                )
+            )
+        }
+
+        val contentWidth by remember(key1 = windowSize) {
+            mutableStateOf(
+                windowSize.windowSizeValue(
+                    expanded = Modifier.widthIn(Dp.Unspecified, 420.dp),
+                    compact = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 24.dp, vertical = 16.dp)
+                )
+            )
+        }
+
+        Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.TopCenter
+        ) {
+            Column(
+                modifier = Modifier
+                    .padding(paddingValues)
+                    .settingsHeaderBackground()
+                    .statusBarsInset(),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Toolbar(
+                    modifier = topBarWidth.displayCutoutForLandscape(),
+                    label = stringResource(id = R.string.profile_appearance),
+                    canShowBackBtn = true,
+                    labelTint = MaterialTheme.appColors.settingsTitleContent,
+                    iconTint = MaterialTheme.appColors.settingsTitleContent,
+                    onBackClick = onBackClick
+                )
+
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .clip(MaterialTheme.appShapes.screenBackgroundShape)
+                        .background(MaterialTheme.appColors.background)
+                        .displayCutoutForLandscape(),
+                    contentAlignment = Alignment.TopCenter
+                ) {
+
+                    Column(
+                        modifier = Modifier
+                            .then(contentWidth)
+                            .verticalScroll(rememberScrollState()),
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        AppThemeMode.entries.forEach { theme ->
+                            ThemeModeOption(
+                                title = stringResource(id = theme.titleResId),
+                                description = theme.descriptionResId.nonZero()
+                                    ?.let { stringResource(id = theme.descriptionResId) } ?: "",
+                                selected = selectedTheme == theme,
+                                onClick = {
+                                    onThemeChanged(theme)
+                                }
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ThemeModeOption(
+    title: String,
+    description: String,
+    selected: Boolean,
+    onClick: () -> Unit,
+) {
+    Row(
+        Modifier
+            .testTag("btn_theme_mode_${title.tagId()}")
+            .fillMaxWidth()
+            .height(70.dp)
+            .clickable {
+                onClick()
+            },
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Column(
+            Modifier
+                .weight(1f)
+                .padding(vertical = 16.dp),
+            verticalArrangement = Arrangement.Center
+        ) {
+            Text(
+                modifier = Modifier.testTag("txt_theme_mode_title_${title.tagId()}"),
+                text = title,
+                color = MaterialTheme.appColors.textPrimary,
+                style = MaterialTheme.appTypography.titleMedium
+            )
+            if (description.isNotEmpty()) {
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    modifier = Modifier.testTag("txt_theme_mode_description_${title.tagId()}"),
+                    text = description,
+                    color = MaterialTheme.appColors.textSecondary,
+                    style = MaterialTheme.appTypography.labelMedium
+                )
+            }
+        }
+        if (selected) {
+            Icon(
+                modifier = Modifier.testTag("ic_theme_selected_${title.tagId()}"),
+                imageVector = Icons.Filled.Done,
+                tint = MaterialTheme.appColors.primary,
+                contentDescription = null
+            )
+        }
+    }
+    Divider()
+}
+
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_NO)
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun AppearanceScreenPreview() {
+    OpenEdXTheme {
+        AppearanceSettingsScreen(
+            windowSize = WindowSize(WindowType.Compact, WindowType.Compact),
+            selectedTheme = AppThemeMode.DARK,
+            onThemeChanged = {},
+            onBackClick = {},
+        )
+    }
+}

--- a/profile/src/main/java/org/openedx/profile/presentation/appearance/AppearanceSettingsViewModel.kt
+++ b/profile/src/main/java/org/openedx/profile/presentation/appearance/AppearanceSettingsViewModel.kt
@@ -1,0 +1,53 @@
+package org.openedx.profile.presentation.appearance
+
+import android.content.Context
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import org.openedx.core.BaseViewModel
+import org.openedx.core.data.storage.CorePreferences
+import org.openedx.core.domain.model.AppThemeMode
+import org.openedx.profile.presentation.ProfileAnalytics
+import org.openedx.profile.presentation.ProfileAnalyticsEvent
+import org.openedx.profile.presentation.ProfileAnalyticsKey
+
+class AppearanceSettingsViewModel(
+    private val preferences: CorePreferences,
+    private val analytics: ProfileAnalytics,
+) : BaseViewModel() {
+
+    private val _appThemeMode = MutableStateFlow(AppThemeMode.MATCH_DEVICE)
+    val appThemeMode: StateFlow<AppThemeMode>
+        get() = _appThemeMode
+
+    init {
+        _appThemeMode.value = preferences.appThemeMode
+    }
+
+    fun setAppThemeMode(context: Context, newMode: AppThemeMode) {
+        val previousMode = _appThemeMode.value
+        if (previousMode == newMode) return
+
+        ThemeManager.applyThemeMode(context, newMode)
+
+        preferences.appThemeMode = newMode
+        _appThemeMode.value = newMode
+
+        logAppThemeModeChangedEvent(previousMode, newMode)
+    }
+
+    private fun logAppThemeModeChangedEvent(
+        previousMode: AppThemeMode,
+        currentMode: AppThemeMode,
+    ) {
+        val event = ProfileAnalyticsEvent.APP_THEME_CHANGED
+        analytics.logEvent(
+            event.eventName,
+            mapOf(
+                ProfileAnalyticsKey.NAME.key to event.biValue,
+                ProfileAnalyticsKey.CATEGORY.key to ProfileAnalyticsKey.PROFILE.key,
+                ProfileAnalyticsKey.PREVIOUS_MODE.key to previousMode.value,
+                ProfileAnalyticsKey.NEW_MODE.key to currentMode.value,
+            )
+        )
+    }
+}

--- a/profile/src/main/java/org/openedx/profile/presentation/appearance/AppearanceSettingsViewModel.kt
+++ b/profile/src/main/java/org/openedx/profile/presentation/appearance/AppearanceSettingsViewModel.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.flow.StateFlow
 import org.openedx.core.BaseViewModel
 import org.openedx.core.data.storage.CorePreferences
 import org.openedx.core.domain.model.AppThemeMode
+import org.openedx.core.ui.theme.ThemeManager
 import org.openedx.profile.presentation.ProfileAnalytics
 import org.openedx.profile.presentation.ProfileAnalyticsEvent
 import org.openedx.profile.presentation.ProfileAnalyticsKey

--- a/profile/src/main/java/org/openedx/profile/presentation/appearance/ThemeManager.kt
+++ b/profile/src/main/java/org/openedx/profile/presentation/appearance/ThemeManager.kt
@@ -1,0 +1,38 @@
+package org.openedx.profile.presentation.appearance
+
+import android.app.UiModeManager
+import android.content.Context
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.appcompat.app.AppCompatDelegate
+import org.openedx.core.domain.model.AppThemeMode
+
+object ThemeManager {
+    fun applyThemeMode(context: Context, mode: AppThemeMode) {
+        when {
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
+                val uiMode = mode.toUiModeManagerConstant()
+                val ui = context.getSystemService(UiModeManager::class.java)
+                ui?.setApplicationNightMode(uiMode)
+            }
+
+            else -> {
+                val delegateMode = mode.toAppCompatNightConstant()
+                AppCompatDelegate.setDefaultNightMode(delegateMode)
+            }
+        }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.S)
+    private fun AppThemeMode.toUiModeManagerConstant(): Int = when (this) {
+        AppThemeMode.LIGHT -> UiModeManager.MODE_NIGHT_NO
+        AppThemeMode.DARK -> UiModeManager.MODE_NIGHT_YES
+        AppThemeMode.MATCH_DEVICE -> UiModeManager.MODE_NIGHT_CUSTOM
+    }
+
+    private fun AppThemeMode.toAppCompatNightConstant(): Int = when (this) {
+        AppThemeMode.LIGHT -> AppCompatDelegate.MODE_NIGHT_NO
+        AppThemeMode.DARK -> AppCompatDelegate.MODE_NIGHT_YES
+        AppThemeMode.MATCH_DEVICE -> AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
+    }
+}

--- a/profile/src/main/java/org/openedx/profile/presentation/settings/SettingsFragment.kt
+++ b/profile/src/main/java/org/openedx/profile/presentation/settings/SettingsFragment.kt
@@ -89,6 +89,12 @@ class SettingsFragment : Fragment() {
                                 )
                             }
 
+                            SettingsScreenAction.AppearanceSettingsClick -> {
+                                viewModel.appearanceSettingsClicked(
+                                    requireActivity().supportFragmentManager
+                                )
+                            }
+
                             SettingsScreenAction.PushNotificationsSettingsClick -> {
                                 viewModel.pushNotificationsSettingsClicked(
                                     requireActivity().supportFragmentManager
@@ -169,6 +175,7 @@ internal interface SettingsScreenAction {
     object TermsClick : SettingsScreenAction
     object SupportClick : SettingsScreenAction
     object VideoSettingsClick : SettingsScreenAction
+    object AppearanceSettingsClick : SettingsScreenAction
     object ManageAccountClick : SettingsScreenAction
     object CalendarSettingsClick : SettingsScreenAction
     object PushNotificationsSettingsClick : SettingsScreenAction

--- a/profile/src/main/java/org/openedx/profile/presentation/settings/SettingsScreenUI.kt
+++ b/profile/src/main/java/org/openedx/profile/presentation/settings/SettingsScreenUI.kt
@@ -190,6 +190,9 @@ internal fun SettingsScreen(
                                         onVideoSettingsClick = {
                                             onAction(SettingsScreenAction.VideoSettingsClick)
                                         },
+                                        onAppearanceSettingsClick = {
+                                            onAction(SettingsScreenAction.AppearanceSettingsClick)
+                                        },
                                         onCalendarSettingsClick = {
                                             onAction(SettingsScreenAction.CalendarSettingsClick)
                                         },
@@ -273,6 +276,7 @@ internal fun SettingsScreen(
 private fun SettingsSection(
     uiState: SettingsUIState.Data,
     onVideoSettingsClick: () -> Unit,
+    onAppearanceSettingsClick: () -> Unit,
     onCalendarSettingsClick: () -> Unit,
     onPushNotificationsSettingsClick: () -> Unit,
 ) {
@@ -294,6 +298,12 @@ private fun SettingsSection(
                 SettingsItem(
                     text = stringResource(id = profileR.string.profile_video),
                     onClick = onVideoSettingsClick
+                )
+
+                SettingsDivider()
+                SettingsItem(
+                    text = stringResource(id = profileR.string.profile_appearance),
+                    onClick = onAppearanceSettingsClick
                 )
 
 //                SettingsDivider()

--- a/profile/src/main/java/org/openedx/profile/presentation/settings/SettingsViewModel.kt
+++ b/profile/src/main/java/org/openedx/profile/presentation/settings/SettingsViewModel.kt
@@ -168,6 +168,11 @@ class SettingsViewModel(
         logProfileEvent(ProfileAnalyticsEvent.VIDEO_SETTING_CLICKED)
     }
 
+    fun appearanceSettingsClicked(fragmentManager: FragmentManager) {
+        router.navigateToAppearanceSettings(fragmentManager)
+        logProfileEvent(ProfileAnalyticsEvent.APPEARANCE_SETTING_CLICKED)
+    }
+
     fun pushNotificationsSettingsClicked(fragmentManager: FragmentManager) {
         router.navigateToPushNotificationsSettings(fragmentManager)
         logProfileEvent((ProfileAnalyticsEvent.PUSH_NOTIFICATIONS_CLICKED))

--- a/profile/src/main/res/values/strings.xml
+++ b/profile/src/main/res/values/strings.xml
@@ -64,4 +64,5 @@
     <string name="profile_purchases">Purchases</string>
     <string name="profile_restore_purchaes">Restore Purchases</string>
     <string name="profile_push_notifications">Push Notifications</string>
+    <string name="profile_appearance">Appearance</string>
 </resources>


### PR DESCRIPTION
## Description

[LEARNER-10562](https://2u-internal.atlassian.net/browse/LEARNER-10562)

This setting will allow users to select from three options manually:

- Light mode
- Dark mode
- Match device

This update will enhance the user experience, allowing them to maintain a consistent theme regardless of system settings.

## Analytics

```
Profile:Appearance Setting Clicked
edx.bi.app.profile.appearance_setting.clicked
```

```
Profile:App Theme Changed
edx.bi.app.profile.app_theme.changed

Attributes: new_mode / previous_mode | auto, light & dark
```

## Screenshots

| Light | Dark |
|--------|--------|
| <img src="https://github.com/user-attachments/assets/95424f36-1271-4bc1-b137-78334a87766b" /> | <img src="https://github.com/user-attachments/assets/47d773ab-b971-4a95-8786-faec115dd0b0" /> | 

## Reference
- https://developer.android.com/develop/ui/views/theming/darktheme#change-themes
