### PR TITLE
Revert "feat: Integrate FirebasePerformance plugin for performance monitoring"

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,6 @@ apply plugin: 'kotlin-kapt'
 if (firebaseEnabled) {
     apply plugin: 'com.google.gms.google-services'
     apply plugin: 'com.google.firebase.crashlytics'
-    apply plugin: 'com.google.firebase.firebase-perf'
 
     tasks.register('generateGoogleServicesJson') {
         configHelper.generateGoogleServicesJson(appId)
@@ -153,7 +152,6 @@ dependencies {
 
     api platform("com.google.firebase:firebase-bom:$firebase_version")
     api "com.google.firebase:firebase-messaging"
-    api "com.google.firebase:firebase-perf:21.0.4"
 
     // Segment Library
     implementation "com.segment.analytics.kotlin:android:1.16.3"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -114,11 +114,6 @@
                 <action android:name="com.google.firebase.MESSAGING_EVENT" />
             </intent-filter>
         </service>
-
-        <!-- Enable debug logging for Firebase Performance Monitoring -->
-        <meta-data
-            android:name="firebase_performance_logcat_enabled"
-            android:value="true" />
     </application>
 
 </manifest>

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,6 @@ plugins {
     id 'org.jetbrains.kotlin.android' version "$kotlin_version" apply false
     id 'com.google.gms.google-services' version '4.4.1' apply false
     id "com.google.firebase.crashlytics" version "3.0.1" apply false
-    id "com.google.firebase.firebase-perf" version "1.4.2" apply false
 }
 
 tasks.register('clean', Delete) {


### PR DESCRIPTION
### Description

This PR reverts the recent addition of the Firebase Performance Monitoring library. After validating on multiple device models, we observed that the library’s internal instrumentation was causing ANRs in production. To mitigate these issues, we attempted the following workarounds, but none proved effective:

- **Delayed Initialization:** Postponed `FirebaseApp.initializeApp()` until after app launch.
- **Alternate Coroutine Scope:** Moved Performance SDK startup onto a dedicated background scope.
- **Conditional Startup Flags:** Tried enabling/disabling instrumentation flags at runtime.

Despite these efforts, ANRs continued to occur on certain Android versions. To stabilize the branch, we’re reverting the Performance library integration and will revisit once a fix or updated SDK is available.

