### PR TITLE
feat: Open First Incomplete Subsection by Default in Home and Videos Tabs

### DIFF
--- a/app/src/main/java/org/openedx/app/di/ScreenModule.kt
+++ b/app/src/main/java/org/openedx/app/di/ScreenModule.kt
@@ -342,7 +342,6 @@ val screenModule = module {
             get(),
             get(),
             get(),
-            get(),
             get()
         )
     }

--- a/course/src/main/java/org/openedx/course/presentation/outline/CourseOutlineViewModel.kt
+++ b/course/src/main/java/org/openedx/course/presentation/outline/CourseOutlineViewModel.kt
@@ -230,16 +230,13 @@ class CourseOutlineViewModel(
                 courseStructure = courseStructure.copy(blockData = sortBlocks(blocks))
                 initDownloadModelsStatus()
 
-                val courseSectionsState =
-                    (_uiState.value as? CourseOutlineUIState.CourseData)?.courseSectionsState.orEmpty()
-
                 _uiState.value = CourseOutlineUIState.CourseData(
                     courseStructure = courseStructure,
                     downloadedState = getDownloadModelsStatus(),
                     resumeComponent = getResumeBlock(blocks, courseStatus.lastVisitedBlockId),
                     resumeUnitTitle = resumeVerticalBlock?.displayName ?: "",
                     courseSubSections = courseSubSections,
-                    courseSectionsState = courseSectionsState,
+                    courseSectionsState = getCourseSectionExpandedState(courseStructure.blockData),
                     subSectionsDownloadsCount = subSectionsDownloadsCount,
                     datesBannerInfo = datesBannerInfo
                 )
@@ -343,6 +340,22 @@ class CourseOutlineViewModel(
                 }
             }
         }
+    }
+
+    private fun getCourseSectionExpandedState(blockData: List<Block>): Map<String, Boolean> {
+        val expandedState = mutableMapOf<String, Boolean>()
+
+        // Open only the first incomplete section (if any)
+        blockData.firstOrNull { !it.isCompleted() }?.id
+            ?.let { expandedState[it] = true }
+
+        // Merge in any existing overrides (existing takes precedence)
+        val existingState = (_uiState.value as? CourseOutlineUIState.CourseData)
+            ?.courseSectionsState
+            .orEmpty()
+        expandedState.putAll(existingState)
+
+        return expandedState
     }
 
     fun viewCertificateTappedEvent() {

--- a/course/src/main/java/org/openedx/course/presentation/videos/CourseVideoViewModel.kt
+++ b/course/src/main/java/org/openedx/course/presentation/videos/CourseVideoViewModel.kt
@@ -12,7 +12,6 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import org.openedx.core.BlockType
 import org.openedx.core.UIMessage
-import org.openedx.core.config.Config
 import org.openedx.core.data.storage.CorePreferences
 import org.openedx.core.domain.model.Block
 import org.openedx.core.domain.model.VideoSettings
@@ -37,7 +36,6 @@ import org.openedx.course.presentation.CourseRouter
 class CourseVideoViewModel(
     val courseId: String,
     val courseTitle: String,
-    private val config: Config,
     private val interactor: CourseInteractor,
     private val resourceManager: ResourceManager,
     private val networkConnection: NetworkConnection,
@@ -58,7 +56,6 @@ class CourseVideoViewModel(
 ) {
 
     private val logger = Logger(TAG)
-    val isCourseNestedListEnabled get() = config.getCourseUIConfig().isCourseDropdownNavigationEnabled
 
     private val _uiState = MutableStateFlow<CourseVideosUIState>(CourseVideosUIState.Loading)
     val uiState: StateFlow<CourseVideosUIState>
@@ -159,13 +156,14 @@ class CourseVideoViewModel(
                     courseStructure = courseStructure.copy(blockData = sortBlocks(blocks))
                     initDownloadModelsStatus()
 
-                    val courseSectionsState =
-                        (_uiState.value as? CourseVideosUIState.CourseData)?.courseSectionsState.orEmpty()
-
                     _uiState.value =
                         CourseVideosUIState.CourseData(
-                            courseStructure, getDownloadModelsStatus(), courseSubSections,
-                            courseSectionsState, subSectionsDownloadsCount, getDownloadModelsSize()
+                            courseStructure = courseStructure,
+                            downloadedState = getDownloadModelsStatus(),
+                            courseSubSections = courseSubSections,
+                            courseSectionsState = getCourseSectionExpandedState(courseStructure.blockData),
+                            subSectionsDownloadsCount = subSectionsDownloadsCount,
+                            downloadModelsSize = getDownloadModelsSize(),
                         )
                 }
                 courseNotifier.send(CourseLoading(false))
@@ -237,6 +235,22 @@ class CourseVideoViewModel(
                 )
             }
         }
+    }
+
+    private fun getCourseSectionExpandedState(blockData: List<Block>): Map<String, Boolean> {
+        val expandedState = mutableMapOf<String, Boolean>()
+
+        // Open only the first incomplete section (if any)
+        blockData.firstOrNull { !it.isCompleted() }?.id
+            ?.let { expandedState[it] = true }
+
+        // Merge in any existing overrides (existing takes precedence)
+        val existingState = (_uiState.value as? CourseVideosUIState.CourseData)
+            ?.courseSectionsState
+            .orEmpty()
+        expandedState.putAll(existingState)
+
+        return expandedState
     }
 
     companion object {

--- a/course/src/test/java/org/openedx/course/presentation/videos/CourseVideoViewModelTest.kt
+++ b/course/src/test/java/org/openedx/course/presentation/videos/CourseVideoViewModelTest.kt
@@ -218,7 +218,6 @@ class CourseVideoViewModelTest {
         val viewModel = CourseVideoViewModel(
             "",
             "",
-            config,
             interactor,
             resourceManager,
             networkConnection,
@@ -250,7 +249,6 @@ class CourseVideoViewModelTest {
         val viewModel = CourseVideoViewModel(
             "",
             "",
-            config,
             interactor,
             resourceManager,
             networkConnection,
@@ -290,7 +288,6 @@ class CourseVideoViewModelTest {
         val viewModel = CourseVideoViewModel(
             "",
             "",
-            config,
             interactor,
             resourceManager,
             networkConnection,
@@ -332,7 +329,6 @@ class CourseVideoViewModelTest {
         val viewModel = CourseVideoViewModel(
             "",
             "",
-            config,
             interactor,
             resourceManager,
             networkConnection,
@@ -370,7 +366,6 @@ class CourseVideoViewModelTest {
             val viewModel = CourseVideoViewModel(
                 "",
                 "",
-                config,
                 interactor,
                 resourceManager,
                 networkConnection,
@@ -412,7 +407,6 @@ class CourseVideoViewModelTest {
             val viewModel = CourseVideoViewModel(
                 "",
                 "",
-                config,
                 interactor,
                 resourceManager,
                 networkConnection,


### PR DESCRIPTION
### Description

[LEARNER-10619](https://2u-internal.atlassian.net/browse/LEARNER-10619)

This change updates the logic in both the Home and Videos tabs to automatically expand the first incomplete course subsection by default. This enhances user experience by guiding learners directly to their next actionable content without requiring manual exploration.

### Highlights:

- Identifies the first incomplete subsection from the course structure.
- Automatically expands it when the user opens the Home or Videos tab.
- Preserves the user’s previous expanded state if available.

### Default Course Home State:

| Then | Now |
|--------|--------|
| <img src="https://github.com/user-attachments/assets/5b5cbab5-a48f-4c81-8d11-cc52d0e2ae0a" /> | <img src="https://github.com/user-attachments/assets/a33b3c06-7dcc-44c9-af20-1db56ce817db" /> | 
