### PR TITLE
fix: Crash `IllegalStateException` in `VideoUnitFragment`

### DIFF
--- a/course/src/main/java/org/openedx/course/presentation/unit/video/VideoUnitFragment.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/video/VideoUnitFragment.kt
@@ -155,7 +155,7 @@ class VideoUnitFragment : Fragment(R.layout.fragment_video_unit) {
                     appReviewManager.tryToOpenRateDialog()
                 }
             }
-        }.launchIn(lifecycleScope)
+        }.launchIn(viewLifecycleOwner.lifecycleScope)
     }
 
     @OptIn(UnstableApi::class)


### PR DESCRIPTION
### Description

Jira Ticket: [LEARNER-10596](https://2u-internal.atlassian.net/browse/LEARNER-10596)

- Use `viewLifecycleOwner.lifecycleScope` with `viewModel.state.onEach`.
- viewLifecycleOwner.lifecycleScope only becomes active after onCreateView(), and is canceled in onDestroyView().
- It’s tied to the view's lifecycle — safe to use with binding, playerView, or other view-related operations.

#### Steps to reproduce the crash.
- Open the video components from any course.
- Rapidly navigate using the **Next** and **Previous** buttons.
- Eventually, the app crashes 💥 after repeated navigation.
