### PR TITLE
fix: Network failed error handling on CourseDashboard

### DIFF
--- a/course/src/main/java/org/openedx/course/presentation/container/CourseContainerFragment.kt
+++ b/course/src/main/java/org/openedx/course/presentation/container/CourseContainerFragment.kt
@@ -72,7 +72,7 @@ import org.koin.core.parameter.parametersOf
 import org.openedx.core.domain.model.CourseAccessError
 import org.openedx.core.domain.model.iap.IAPFlow
 import org.openedx.core.domain.model.iap.IAPFlowSource
-import org.openedx.core.extension.isNull
+import org.openedx.core.extension.isNotNull
 import org.openedx.core.extension.isTrue
 import org.openedx.core.extension.takeIfNotEmpty
 import org.openedx.core.presentation.dialog.IAPDialogFragment
@@ -393,7 +393,6 @@ fun CourseDashboard(
                 }
             }
             HandleUIMessage(uiMessage = uiMessage, scaffoldState = scaffoldState)
-            if (dataReady.value.isNull()) return@Scaffold
 
             if (dataReady.value.isTrue() && canShowTrackSelection) {
                 val courseExpiresDate =
@@ -416,7 +415,7 @@ fun CourseDashboard(
                     IAPDialogFragment.TAG
                 )
                 viewModel.disableTrackSelection()
-            } else {
+            } else if (dataReady.isNotNull()) {
                 LaunchedEffect(pagerState.currentPage) {
                     tabState.animateScrollToItem(pagerState.currentPage)
                     viewModel.courseContainerTabClickedEvent(pagerState.currentPage)


### PR DESCRIPTION
### Description:


- show a proper message in case internet isn't available and app doesn't have a cached data

fix: [LEARNER-10628](https://2u-internal.atlassian.net/browse/LEARNER-10628)