### PR TITLE
build: Upgrade Google Play Billing Library to v8.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ local.properties
 .venv/
 i18n/
 **/values-*/strings.xml
+/.kotlin/

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,6 +10,7 @@ def fullstoryEnabled = fullstoryConfig?.getOrDefault('ENABLED', false)
 
 apply plugin: 'com.android.application'
 apply plugin: 'org.jetbrains.kotlin.android'
+apply plugin: 'org.jetbrains.kotlin.plugin.compose'
 apply plugin: 'kotlin-parcelize'
 apply plugin: 'kotlin-kapt'
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -123,9 +123,6 @@ android {
         compose true
         buildConfig true
     }
-    composeOptions {
-        kotlinCompilerExtensionVersion = "$compose_compiler_version"
-    }
     bundle {
         language {
             enableSplit = false

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,7 +12,7 @@ apply plugin: 'com.android.application'
 apply plugin: 'org.jetbrains.kotlin.android'
 apply plugin: 'org.jetbrains.kotlin.plugin.compose'
 apply plugin: 'kotlin-parcelize'
-apply plugin: 'kotlin-kapt'
+apply plugin: 'com.google.devtools.ksp'
 
 if (firebaseEnabled) {
     apply plugin: 'com.google.gms.google-services'
@@ -154,7 +154,7 @@ dependencies {
     implementation project(path: ':notifications')
     implementation project(path: ':featuremanagement')
 
-    kapt "androidx.room:room-compiler:$room_version"
+    ksp "androidx.room:room-compiler:$room_version"
 
     implementation 'androidx.core:core-splashscreen:1.0.1'
 
@@ -214,8 +214,6 @@ private def setupFirebaseConfigFields(buildType) {
     buildType.manifestPlaceholders = [fcmEnabled: firebaseEnabled && cloudMessagingEnabled]
 }
 
-kapt {
-    arguments {
-        arg("room.schemaLocation", "$projectDir/schemas")
-    }
+ksp {
+    arg("room.schemaLocation", "$projectDir/schemas")
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 def config = configHelper.fetchConfig()
 def appId = config.getOrDefault("APPLICATION_ID", "org.openedx.app")
 def themeDirectory = config.getOrDefault("THEME_DIRECTORY", "openedx")
@@ -106,9 +108,14 @@ android {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
     }
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17
-        freeCompilerArgs = List.of("-Xstring-concat=inline")
+    kotlin {
+        compilerOptions {
+            jvmTarget = JvmTarget.fromTarget("17")
+            freeCompilerArgs.addAll(List.of(
+                    "-Xstring-concat=inline",
+                    "-XXLanguage:+PropertyParamAnnotationDefaultTargetMode",
+            ))
+        }
     }
     buildFeatures {
         viewBinding true

--- a/app/src/main/java/org/openedx/app/di/AppModule.kt
+++ b/app/src/main/java/org/openedx/app/di/AppModule.kt
@@ -81,8 +81,8 @@ import org.openedx.whatsnew.WhatsNewManager
 import org.openedx.whatsnew.WhatsNewRouter
 import org.openedx.whatsnew.data.storage.WhatsNewPreferences
 import org.openedx.whatsnew.presentation.WhatsNewAnalytics
-import org.openedx.core.R as CoreR
 import org.openedx.core.DatabaseManager as IDatabaseManager
+import org.openedx.core.R as CoreR
 
 val appModule = module {
 
@@ -153,8 +153,8 @@ val appModule = module {
             androidApplication(),
             AppDatabase::class.java,
             DATABASE_NAME
-        ).fallbackToDestructiveMigration()
-            .fallbackToDestructiveMigrationOnDowngrade()
+        ).fallbackToDestructiveMigration(true)
+            .fallbackToDestructiveMigrationOnDowngrade(true)
             .build()
     }
 

--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -56,9 +56,6 @@ android {
         viewBinding true
         compose true
     }
-    composeOptions {
-        kotlinCompilerExtensionVersion = "$compose_compiler_version"
-    }
 }
 
 dependencies {

--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     id 'com.android.library'
     id 'org.jetbrains.kotlin.android'
@@ -40,9 +42,14 @@ android {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
     }
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17
-        freeCompilerArgs = List.of("-Xstring-concat=inline")
+    kotlin {
+        compilerOptions {
+            jvmTarget = JvmTarget.fromTarget("17")
+            freeCompilerArgs.addAll(List.of(
+                    "-Xstring-concat=inline",
+                    "-XXLanguage:+PropertyParamAnnotationDefaultTargetMode",
+            ))
+        }
     }
     buildFeatures {
         viewBinding true

--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 plugins {
     id 'com.android.library'
     id 'org.jetbrains.kotlin.android'
+    id 'org.jetbrains.kotlin.plugin.compose'
     id 'kotlin-parcelize'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ ext {
 
     jsoup_version = '1.13.1'
 
-    room_version = '2.6.1'
+    room_version = '2.7.2'
 
     work_version = '2.9.0'
 

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,6 @@ buildscript {
         kotlin_version = '2.2.0'
         coroutines_version = '1.7.1'
         compose_version = '1.6.2'
-        compose_compiler_version = '1.5.10'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ import java.util.regex.Pattern
 
 buildscript {
     ext {
-        kotlin_version = '1.9.22'
+        kotlin_version = '2.2.0'
         coroutines_version = '1.7.1'
         compose_version = '1.6.2'
         compose_compiler_version = '1.5.10'
@@ -16,6 +16,7 @@ plugins {
     id 'com.android.application' version '8.4.0' apply false
     id 'com.android.library' version '8.4.0' apply false
     id 'org.jetbrains.kotlin.android' version "$kotlin_version" apply false
+    id 'org.jetbrains.kotlin.plugin.compose' version "$kotlin_version" apply false
     id 'com.google.gms.google-services' version '4.4.1' apply false
     id "com.google.firebase.crashlytics" version "3.0.1" apply false
 }

--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ ext {
 
     webkit_version = "1.11.0"
 
-    billing_version = "6.2.1"
+    billing_version = "8.0.0"
 
     configHelper = new ConfigHelper(projectDir, getCurrentFlavor())
 

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ plugins {
     id 'org.jetbrains.kotlin.plugin.compose' version "$kotlin_version" apply false
     id 'com.google.gms.google-services' version '4.4.1' apply false
     id "com.google.firebase.crashlytics" version "3.0.1" apply false
+    id "com.google.devtools.ksp" version "2.2.0-2.0.2" apply false
 }
 
 tasks.register('clean', Delete) {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -15,7 +15,7 @@ plugins {
     id 'org.jetbrains.kotlin.android'
     id 'org.jetbrains.kotlin.plugin.compose'
     id 'kotlin-parcelize'
-    id 'kotlin-kapt'
+    id 'com.google.devtools.ksp'
 }
 
 def currentFlavour = getCurrentFlavor()
@@ -131,7 +131,7 @@ dependencies {
     // Room
     api "androidx.room:room-runtime:$room_version"
     api "androidx.room:room-ktx:$room_version"
-    kapt "androidx.room:room-compiler:$room_version"
+    ksp "androidx.room:room-compiler:$room_version"
 
     //Compose
     api "androidx.compose.runtime:runtime:$compose_version"

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -13,6 +13,7 @@ buildscript {
 plugins {
     id 'com.android.library'
     id 'org.jetbrains.kotlin.android'
+    id 'org.jetbrains.kotlin.plugin.compose'
     id 'kotlin-parcelize'
     id 'kotlin-kapt'
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -130,7 +130,6 @@ dependencies {
 
     // Room
     api "androidx.room:room-runtime:$room_version"
-    api "androidx.room:room-ktx:$room_version"
     ksp "androidx.room:room-compiler:$room_version"
 
     //Compose

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -96,9 +96,6 @@ android {
         compose true
         buildConfig true
     }
-    composeOptions {
-        kotlinCompilerExtensionVersion = "$compose_compiler_version"
-    }
 }
 
 dependencies {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 buildscript {
     repositories {
         mavenCentral()
@@ -78,9 +80,14 @@ android {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
     }
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17
-        freeCompilerArgs = List.of("-Xstring-concat=inline")
+    kotlin {
+        compilerOptions {
+            jvmTarget = JvmTarget.fromTarget("17")
+            freeCompilerArgs.addAll(List.of(
+                    "-Xstring-concat=inline",
+                    "-XXLanguage:+PropertyParamAnnotationDefaultTargetMode",
+            ))
+        }
     }
 
     buildFeatures {

--- a/core/src/main/java/org/openedx/core/data/model/CourseDateBlock.kt
+++ b/core/src/main/java/org/openedx/core/data/model/CourseDateBlock.kt
@@ -32,8 +32,8 @@ data class CourseDateBlock(
     val blockId: String = "",
 ) : Parcelable {
     fun mapToDomain(): CourseDateBlock? {
-        TimeUtils.iso8601ToDate(date)?.let {
-            return CourseDateBlock(
+        return TimeUtils.iso8601ToDate(date)?.let {
+            CourseDateBlock(
                 complete = complete,
                 date = it,
                 assignmentType = assignmentType,
@@ -44,11 +44,11 @@ data class CourseDateBlock(
                 title = title,
                 blockId = blockId
             )
-        } ?: return null
+        }
     }
 
     fun mapToRoomEntity(): CourseDateBlockDb? {
-        TimeUtils.iso8601ToDate(date)?.let {
+        return TimeUtils.iso8601ToDate(date)?.let {
             return CourseDateBlockDb(
                 complete = complete,
                 date = it,
@@ -60,6 +60,6 @@ data class CourseDateBlock(
                 title = title,
                 blockId = blockId
             )
-        } ?: return null
+        }
     }
 }

--- a/core/src/main/java/org/openedx/core/module/billing/BillingProcessor.kt
+++ b/core/src/main/java/org/openedx/core/module/billing/BillingProcessor.kt
@@ -8,6 +8,7 @@ import com.android.billingclient.api.BillingClientStateListener
 import com.android.billingclient.api.BillingFlowParams
 import com.android.billingclient.api.BillingResult
 import com.android.billingclient.api.ConsumeParams
+import com.android.billingclient.api.PendingPurchasesParams
 import com.android.billingclient.api.ProductDetails
 import com.android.billingclient.api.ProductDetailsResult
 import com.android.billingclient.api.Purchase
@@ -41,7 +42,8 @@ class BillingProcessor(
 
     private var billingClient = BillingClient.newBuilder(context)
         .setListener(this)
-        .enablePendingPurchases()
+        .enablePendingPurchases(PendingPurchasesParams.newBuilder().enableOneTimeProducts().build())
+        .enableAutoServiceReconnection()
         .build()
 
     override fun onPurchasesUpdated(

--- a/core/src/main/java/org/openedx/core/utils/TimeUtils.kt
+++ b/core/src/main/java/org/openedx/core/utils/TimeUtils.kt
@@ -17,13 +17,10 @@ import kotlin.math.ceil
 
 object TimeUtils {
 
-    private const val TAG = "TimeUtils"
     private const val FORMAT_ISO_8601 = "yyyy-MM-dd'T'HH:mm:ss'Z'"
     private const val FORMAT_ISO_8601_WITH_TIME_ZONE = "yyyy-MM-dd'T'HH:mm:ssXXX"
 
     private const val SEVEN_DAYS_IN_MILLIS = 604800000L
-
-    private val logger = Logger(TAG)
 
     fun getCurrentTime(): Long {
         return Calendar.getInstance().timeInMillis
@@ -33,8 +30,7 @@ object TimeUtils {
         return try {
             val parsePosition = ParsePosition(0)
             return ISO8601Utils.parse(text, parsePosition)
-        } catch (e: ParseException) {
-            logger.e(throwable = e, metadata = mapOf("time" to text))
+        } catch (_: ParseException) {
             null
         }
     }
@@ -43,8 +39,7 @@ object TimeUtils {
         return try {
             val sdf = SimpleDateFormat(FORMAT_ISO_8601_WITH_TIME_ZONE, Locale.getDefault())
             sdf.parse(text)
-        } catch (e: ParseException) {
-            logger.e(throwable = e, metadata = mapOf("time" to text))
+        } catch (_: ParseException) {
             null
         }
     }
@@ -56,8 +51,7 @@ object TimeUtils {
                 context.getString(R.string.core_full_date_with_time), Locale.getDefault()
             )
             applicationDateFormat.format(courseDateFormat.parse(text)!!)
-        } catch (e: Exception) {
-            logger.e(throwable = e, metadata = mapOf("time" to text))
+        } catch (_: Exception) {
             ""
         }
     }

--- a/course/build.gradle
+++ b/course/build.gradle
@@ -44,9 +44,6 @@ android {
         viewBinding true
         compose true
     }
-    composeOptions {
-        kotlinCompilerExtensionVersion = "$compose_compiler_version"
-    }
 
     flavorDimensions += "env"
     productFlavors {

--- a/course/build.gradle
+++ b/course/build.gradle
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 plugins {
     id 'com.android.library'
     id 'org.jetbrains.kotlin.android'
+    id 'org.jetbrains.kotlin.plugin.compose'
     id 'kotlin-parcelize'
 }
 

--- a/course/build.gradle
+++ b/course/build.gradle
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     id 'com.android.library'
     id 'org.jetbrains.kotlin.android'
@@ -27,9 +29,14 @@ android {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
     }
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17
-        freeCompilerArgs = List.of("-Xstring-concat=inline")
+    kotlin {
+        compilerOptions {
+            jvmTarget = JvmTarget.fromTarget("17")
+            freeCompilerArgs.addAll(List.of(
+                    "-Xstring-concat=inline",
+                    "-XXLanguage:+PropertyParamAnnotationDefaultTargetMode",
+            ))
+        }
     }
 
     buildFeatures {

--- a/dashboard/build.gradle
+++ b/dashboard/build.gradle
@@ -44,9 +44,6 @@ android {
         viewBinding true
         compose true
     }
-    composeOptions {
-        kotlinCompilerExtensionVersion = "$compose_compiler_version"
-    }
 
     flavorDimensions += "env"
     productFlavors {

--- a/dashboard/build.gradle
+++ b/dashboard/build.gradle
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 plugins {
     id 'com.android.library'
     id 'org.jetbrains.kotlin.android'
+    id 'org.jetbrains.kotlin.plugin.compose'
 }
 
 android {

--- a/dashboard/build.gradle
+++ b/dashboard/build.gradle
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     id 'com.android.library'
     id 'org.jetbrains.kotlin.android'
@@ -27,9 +29,14 @@ android {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
     }
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17
-        freeCompilerArgs = List.of("-Xstring-concat=inline")
+    kotlin {
+        compilerOptions {
+            jvmTarget = JvmTarget.fromTarget("17")
+            freeCompilerArgs.addAll(List.of(
+                    "-Xstring-concat=inline",
+                    "-XXLanguage:+PropertyParamAnnotationDefaultTargetMode",
+            ))
+        }
     }
 
     buildFeatures {

--- a/discovery/build.gradle
+++ b/discovery/build.gradle
@@ -5,7 +5,7 @@ plugins {
     id 'org.jetbrains.kotlin.android'
     id 'org.jetbrains.kotlin.plugin.compose'
     id 'kotlin-parcelize'
-    id 'kotlin-kapt'
+    id 'com.google.devtools.ksp'
 }
 
 android {
@@ -67,7 +67,7 @@ android {
 dependencies {
     implementation project(path: ':core')
 
-    kapt "androidx.room:room-compiler:$room_version"
+    ksp "androidx.room:room-compiler:$room_version"
     implementation 'androidx.activity:activity-compose:1.8.1'
 
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'

--- a/discovery/build.gradle
+++ b/discovery/build.gradle
@@ -46,9 +46,6 @@ android {
         viewBinding true
         compose true
     }
-    composeOptions {
-        kotlinCompilerExtensionVersion = "$compose_compiler_version"
-    }
 
     flavorDimensions += "env"
     productFlavors {

--- a/discovery/build.gradle
+++ b/discovery/build.gradle
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 plugins {
     id 'com.android.library'
     id 'org.jetbrains.kotlin.android'
+    id 'org.jetbrains.kotlin.plugin.compose'
     id 'kotlin-parcelize'
     id 'kotlin-kapt'
 }

--- a/discovery/build.gradle
+++ b/discovery/build.gradle
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     id 'com.android.library'
     id 'org.jetbrains.kotlin.android'
@@ -29,9 +31,14 @@ android {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
     }
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17
-        freeCompilerArgs = List.of("-Xstring-concat=inline")
+    kotlin {
+        compilerOptions {
+            jvmTarget = JvmTarget.fromTarget("17")
+            freeCompilerArgs.addAll(List.of(
+                    "-Xstring-concat=inline",
+                    "-XXLanguage:+PropertyParamAnnotationDefaultTargetMode",
+            ))
+        }
     }
 
     buildFeatures {

--- a/discussion/build.gradle
+++ b/discussion/build.gradle
@@ -43,9 +43,6 @@ android {
         viewBinding true
         compose true
     }
-    composeOptions {
-        kotlinCompilerExtensionVersion = "$compose_compiler_version"
-    }
 
     flavorDimensions += "env"
     productFlavors {

--- a/discussion/build.gradle
+++ b/discussion/build.gradle
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     id 'com.android.library'
     id 'org.jetbrains.kotlin.android'
@@ -26,9 +28,14 @@ android {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
     }
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17
-        freeCompilerArgs = List.of("-Xstring-concat=inline")
+    kotlin {
+        compilerOptions {
+            jvmTarget = JvmTarget.fromTarget("17")
+            freeCompilerArgs.addAll(List.of(
+                    "-Xstring-concat=inline",
+                    "-XXLanguage:+PropertyParamAnnotationDefaultTargetMode",
+            ))
+        }
     }
 
     buildFeatures {

--- a/discussion/build.gradle
+++ b/discussion/build.gradle
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 plugins {
     id 'com.android.library'
     id 'org.jetbrains.kotlin.android'
+    id 'org.jetbrains.kotlin.plugin.compose'
     id 'kotlin-parcelize'
 }
 

--- a/featuremanagement/build.gradle.kts
+++ b/featuremanagement/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     id("com.android.library")
     id("org.jetbrains.kotlin.android")
@@ -29,9 +31,14 @@ android {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
-    kotlinOptions {
-        jvmTarget = "17"
-        freeCompilerArgs += listOf("-Xstring-concat=inline")
+    kotlin {
+        compilerOptions {
+            jvmTarget = JvmTarget.fromTarget("17")
+            freeCompilerArgs.addAll(listOf(
+                    "-Xstring-concat=inline",
+                    "-XXLanguage:+PropertyParamAnnotationDefaultTargetMode",
+            ))
+        }
     }
 
     flavorDimensions.add("env") // Define the flavor dimension

--- a/featuremanagement/build.gradle.kts
+++ b/featuremanagement/build.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 plugins {
     id("com.android.library")
     id("org.jetbrains.kotlin.android")
+    id("org.jetbrains.kotlin.plugin.compose")
     id("kotlin-parcelize")
 }
 

--- a/featuremanagement/build.gradle.kts
+++ b/featuremanagement/build.gradle.kts
@@ -35,10 +35,12 @@ android {
     kotlin {
         compilerOptions {
             jvmTarget = JvmTarget.fromTarget("17")
-            freeCompilerArgs.addAll(listOf(
+            freeCompilerArgs.addAll(
+                listOf(
                     "-Xstring-concat=inline",
                     "-XXLanguage:+PropertyParamAnnotationDefaultTargetMode",
-            ))
+                )
+            )
         }
     }
 

--- a/notifications/build.gradle.kts
+++ b/notifications/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     id("com.android.library")
     id("org.jetbrains.kotlin.android")
@@ -29,9 +31,14 @@ android {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
-    kotlinOptions {
-        jvmTarget = "17"
-        freeCompilerArgs += listOf("-Xstring-concat=inline")
+    kotlin {
+        compilerOptions {
+            jvmTarget = JvmTarget.fromTarget("17")
+            freeCompilerArgs.addAll(listOf(
+                    "-Xstring-concat=inline",
+                    "-XXLanguage:+PropertyParamAnnotationDefaultTargetMode",
+            ))
+        }
     }
 
     buildFeatures {

--- a/notifications/build.gradle.kts
+++ b/notifications/build.gradle.kts
@@ -47,10 +47,6 @@ android {
         compose = true
     }
 
-    composeOptions {
-        kotlinCompilerExtensionVersion = rootProject.extra["compose_compiler_version"].toString()
-    }
-
     flavorDimensions.add("env") // Define the flavor dimension
     productFlavors {
         create("prod") {

--- a/notifications/build.gradle.kts
+++ b/notifications/build.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 plugins {
     id("com.android.library")
     id("org.jetbrains.kotlin.android")
+    id("org.jetbrains.kotlin.plugin.compose")
     id("kotlin-parcelize")
 }
 

--- a/notifications/build.gradle.kts
+++ b/notifications/build.gradle.kts
@@ -35,10 +35,12 @@ android {
     kotlin {
         compilerOptions {
             jvmTarget = JvmTarget.fromTarget("17")
-            freeCompilerArgs.addAll(listOf(
+            freeCompilerArgs.addAll(
+                listOf(
                     "-Xstring-concat=inline",
                     "-XXLanguage:+PropertyParamAnnotationDefaultTargetMode",
-            ))
+                )
+            )
         }
     }
 

--- a/profile/build.gradle
+++ b/profile/build.gradle
@@ -44,9 +44,6 @@ android {
         viewBinding true
         compose true
     }
-    composeOptions {
-        kotlinCompilerExtensionVersion = "$compose_compiler_version"
-    }
 
     flavorDimensions += "env"
     productFlavors {

--- a/profile/build.gradle
+++ b/profile/build.gradle
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 plugins {
     id 'com.android.library'
     id 'org.jetbrains.kotlin.android'
+    id 'org.jetbrains.kotlin.plugin.compose'
     id 'kotlin-parcelize'
 }
 

--- a/profile/build.gradle
+++ b/profile/build.gradle
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     id 'com.android.library'
     id 'org.jetbrains.kotlin.android'
@@ -27,9 +29,14 @@ android {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
     }
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17
-        freeCompilerArgs = List.of("-Xstring-concat=inline")
+    kotlin {
+        compilerOptions {
+            jvmTarget = JvmTarget.fromTarget("17")
+            freeCompilerArgs.addAll(List.of(
+                    "-Xstring-concat=inline",
+                    "-XXLanguage:+PropertyParamAnnotationDefaultTargetMode",
+            ))
+        }
     }
 
     buildFeatures {

--- a/whatsnew/build.gradle
+++ b/whatsnew/build.gradle
@@ -46,10 +46,6 @@ android {
         compose true
     }
 
-    composeOptions {
-        kotlinCompilerExtensionVersion = "$compose_compiler_version"
-    }
-
     flavorDimensions += "env"
     productFlavors {
         prod {

--- a/whatsnew/build.gradle
+++ b/whatsnew/build.gradle
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     id 'com.android.library'
     id 'org.jetbrains.kotlin.android'
@@ -28,9 +30,14 @@ android {
         targetCompatibility JavaVersion.VERSION_17
     }
 
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17
-        freeCompilerArgs = List.of("-Xstring-concat=inline")
+    kotlin {
+        compilerOptions {
+            jvmTarget = JvmTarget.fromTarget("17")
+            freeCompilerArgs.addAll(List.of(
+                    "-Xstring-concat=inline",
+                    "-XXLanguage:+PropertyParamAnnotationDefaultTargetMode",
+            ))
+        }
     }
 
     buildFeatures {

--- a/whatsnew/build.gradle
+++ b/whatsnew/build.gradle
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 plugins {
     id 'com.android.library'
     id 'org.jetbrains.kotlin.android'
+    id 'org.jetbrains.kotlin.plugin.compose'
     id 'kotlin-parcelize'
 }
 


### PR DESCRIPTION
### Description

[LEARNER-10643](https://2u-internal.atlassian.net/browse/LEARNER-10643)

To support **Google Play Billing Library 8.0.0**, the following changes were required:

---

### 🔧 Technical Changes

1. **Upgrade Kotlin**

   * From `1.9.22` → `2.2.20`
   * Required for compatibility with new version

2. **Switch from KAPT to KSP**

   * `Compose Compiler Gradle Plugin` (required with Kotlin 2.2.20) does **not support KAPT**
   * Migrated annotation processors from KAPT to KSP

3. **Upgrade Room**

   * From `2.6.1` → `2.7.2`
   * Ensures full compatibility with KSP

---

### 🔗 References

* [Kotlin Compiler Options Migration](https://kotlinlang.org/docs/gradle-compiler-options.html#migrate-from-kotlinoptions-to-compileroptions)
* [Compose Compiler Gradle Plugin](https://developer.android.com/develop/ui/compose/compiler)
* [Remove ComposeOptions](https://android-developers.googleblog.com/2024/04/jetpack-compose-compiler-moving-to-kotlin-repository.html)
* [Billing Library Release Notes](https://developer.android.com/google/play/billing/release-notes?authuser=2)
* [Migrate to KSP](https://developer.android.com/build/migrate-to-ksp#kts)
* [Room KSP Support](https://developer.android.com/jetpack/androidx/releases/room?authuser=2#declaring_dependencies)
* [Room KSP Options](https://developer.android.com/jetpack/androidx/releases/room?authuser=2#annotation-processor-options)
