### PR TITLE
fix: Blacklist disallowed video hosts to prevent HTTP Forbidden error

### DIFF
--- a/core/src/main/java/org/openedx/core/config/Config.kt
+++ b/core/src/main/java/org/openedx/core/config/Config.kt
@@ -127,6 +127,9 @@ class Config(context: Context) {
         return getObjectOrNewInstance(OPTIMIZELY, OptimizelyConfig::class.java)
     }
 
+    fun getVideoPlayerConfig(): VideoPlayerConfig {
+        return getObjectOrNewInstance(VIDEO_PLAYER, VideoPlayerConfig::class.java)
+    }
     private fun getString(key: String, defaultValue: String = ""): String {
         val element = getObject(key)
         return if (element != null) {
@@ -189,6 +192,7 @@ class Config(context: Context) {
         private const val UI_COMPONENTS = "UI_COMPONENTS"
         private const val PLATFORM_NAME = "PLATFORM_NAME"
         private const val OPTIMIZELY = "OPTIMIZELY"
+        private const val VIDEO_PLAYER = "VIDEO_PLAYER"
     }
 
     enum class ViewType {

--- a/core/src/main/java/org/openedx/core/config/Config.kt
+++ b/core/src/main/java/org/openedx/core/config/Config.kt
@@ -130,6 +130,7 @@ class Config(context: Context) {
     fun getVideoPlayerConfig(): VideoPlayerConfig {
         return getObjectOrNewInstance(VIDEO_PLAYER, VideoPlayerConfig::class.java)
     }
+
     private fun getString(key: String, defaultValue: String = ""): String {
         val element = getObject(key)
         return if (element != null) {

--- a/core/src/main/java/org/openedx/core/config/VideoPlayerConfig.kt
+++ b/core/src/main/java/org/openedx/core/config/VideoPlayerConfig.kt
@@ -1,0 +1,11 @@
+package org.openedx.core.config
+
+import com.google.gson.annotations.SerializedName
+
+data class VideoPlayerConfig(
+    @SerializedName("VIDEO_TRANSCRIPT_ENABLED")
+    val isVideoTranscriptEnabled: Boolean = false,
+
+    @SerializedName("BLACKLIST_URLS")
+    val blacklistUrls: List<String> = emptyList(),
+)

--- a/core/src/main/java/org/openedx/core/data/model/Block.kt
+++ b/core/src/main/java/org/openedx/core/data/model/Block.kt
@@ -138,20 +138,10 @@ data class VideoInfo(
     var streamPriority: Int?,
 ) {
     fun mapToDomain(): DomainVideoInfo {
-        val filteredUrl = url
-            ?.takeIf { u -> blacklistPrefixes.none { prefix -> u.startsWith(prefix) } }
-            .orEmpty()
-
         return DomainVideoInfo(
-            url = filteredUrl,
+            url = url ?: "",
             fileSize = fileSize ?: 0,
             streamPriority = streamPriority ?: 0,
-        )
-    }
-
-    companion object {
-        var blacklistPrefixes: List<String> = listOf(
-            "https://cdn.idlxmedia.net/",
         )
     }
 }

--- a/core/src/main/java/org/openedx/core/data/model/Block.kt
+++ b/core/src/main/java/org/openedx/core/data/model/Block.kt
@@ -138,10 +138,20 @@ data class VideoInfo(
     var streamPriority: Int?,
 ) {
     fun mapToDomain(): DomainVideoInfo {
+        val filteredUrl = url
+            ?.takeIf { u -> blacklistPrefixes.none { prefix -> u.startsWith(prefix) } }
+            .orEmpty()
+
         return DomainVideoInfo(
-            url = url ?: "",
+            url = filteredUrl,
             fileSize = fileSize ?: 0,
             streamPriority = streamPriority ?: 0,
+        )
+    }
+
+    companion object {
+        var blacklistPrefixes: List<String> = listOf(
+            "https://cdn.idlxmedia.net/",
         )
     }
 }

--- a/core/src/main/java/org/openedx/core/domain/model/Block.kt
+++ b/core/src/main/java/org/openedx/core/domain/model/Block.kt
@@ -119,16 +119,12 @@ data class EncodedVideos(
                 || hls?.url != null
                 || fallback?.url != null
 
-    private val videoUrl: String
-        get() = fallback?.url
-            ?: hls?.url
-            ?: desktopMp4?.url
-            ?: mobileHigh?.url
-            ?: mobileLow?.url
-            ?: ""
-
     val hasVideoUrl: Boolean
-        get() = videoUrl.isNotEmpty()
+        get() = isPreferredVideoInfo(mobileHigh) ||
+                isPreferredVideoInfo(mobileLow) ||
+                isPreferredVideoInfo(desktopMp4) ||
+                isPreferredVideoInfo(hls) ||
+                isPreferredVideoInfo(fallback)
 
     val hasYoutubeUrl: Boolean
         get() = youtube?.url?.isNotEmpty() == true

--- a/core/src/main/java/org/openedx/core/utils/VideoUtil.kt
+++ b/core/src/main/java/org/openedx/core/utils/VideoUtil.kt
@@ -1,9 +1,14 @@
 package org.openedx.core.utils
 
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
 import org.openedx.core.AppDataConstants.VIDEO_FORMAT_M3U8
 import org.openedx.core.AppDataConstants.VIDEO_FORMAT_MP4
+import org.openedx.core.config.Config
 
-object VideoUtil {
+object VideoUtil : KoinComponent {
+
+    private val config by inject<Config>()
 
     val SUPPORTED_VIDEO_FORMATS = arrayOf(
         VIDEO_FORMAT_MP4,
@@ -17,7 +22,15 @@ object VideoUtil {
      * @return `true` if video url is valid, `false` otherwise.
      */
     fun isValidVideoUrl(videoUrl: String): Boolean {
-        return videoHasFormat(videoUrl, *SUPPORTED_VIDEO_FORMATS)
+        return videoHasFormat(videoUrl, *SUPPORTED_VIDEO_FORMATS) && isVideoWhiteListed(videoUrl)
+    }
+
+    private fun isVideoWhiteListed(videoUrl: String): Boolean {
+        val blacklistPrefixes = config.getVideoPlayerConfig().blacklistUrls
+        return videoUrl
+            .takeIf { u -> blacklistPrefixes.none { prefix -> u.startsWith(prefix) } }
+            .orEmpty()
+            .isNotEmpty()
     }
 
     /**

--- a/core/src/main/java/org/openedx/core/utils/VideoUtil.kt
+++ b/core/src/main/java/org/openedx/core/utils/VideoUtil.kt
@@ -22,15 +22,24 @@ object VideoUtil : KoinComponent {
      * @return `true` if video url is valid, `false` otherwise.
      */
     fun isValidVideoUrl(videoUrl: String): Boolean {
-        return videoHasFormat(videoUrl, *SUPPORTED_VIDEO_FORMATS) && isVideoWhiteListed(videoUrl)
+        val hasValidFormat = videoHasFormat(videoUrl, *SUPPORTED_VIDEO_FORMATS)
+        val isBlackListed = isVideoURLBlackListed(videoUrl)
+
+        return hasValidFormat && isBlackListed.not()
     }
 
-    private fun isVideoWhiteListed(videoUrl: String): Boolean {
+    /**
+     * Determines whether the given video URL is blacklisted.
+     *
+     * Retrieves the list of blacklist URL prefixes from the video player configuration
+     * and checks if the provided URL starts with any of those prefixes.
+     *
+     * @param videoUrl the URL of the video to check against the blacklist
+     * @return `true` if the video URL starts with any configured blacklist prefix, `false` otherwise
+     */
+    private fun isVideoURLBlackListed(videoUrl: String): Boolean {
         val blacklistPrefixes = config.getVideoPlayerConfig().blacklistUrls
-        return videoUrl
-            .takeIf { u -> blacklistPrefixes.none { prefix -> u.startsWith(prefix) } }
-            .orEmpty()
-            .isNotEmpty()
+        return blacklistPrefixes.any { videoUrl.startsWith(it) }
     }
 
     /**


### PR DESCRIPTION
### Description

[LEARNER-10626](https://2u-internal.atlassian.net/browse/LEARNER-10626)

ExoPlayer requests to “https://cdn.idlxmedia.net/” resulted in an HTTP Forbidden error on mobile. As a temporary workaround, we’ve disabled this host on mobile by filtering out its URLs.

----

### Screenshots

| Before | After |
|--------|--------|
| <img height=500 src="https://github.com/user-attachments/assets/c77714c3-485f-46eb-891e-26f50753cba6"/> | <img height=500 src="https://github.com/user-attachments/assets/f255f7e3-6ad3-4aee-937a-826bd204c357" /> | 

