### PR TITLE
feat: Push Preferences and Notification Inbox Improvements

### DIFF
--- a/notifications/src/main/java/org/openedx/notifications/data/api/APIConstants.kt
+++ b/notifications/src/main/java/org/openedx/notifications/data/api/APIConstants.kt
@@ -5,10 +5,7 @@ object APIConstants {
     const val NOTIFICATIONS_INBOX = "/api/notifications/"
     const val NOTIFICATIONS_SEEN = "/api/notifications/mark-seen/{app_name}/"
     const val NOTIFICATION_READ = "/api/notifications/read/"
-
-    const val NOTIFICATIONS_CONFIGURATION = "/api/notifications/configurations/"
-    const val NOTIFICATION_UPDATE_CONFIGURATION = "/api/notifications/preferences/update-all/"
-
+    const val NOTIFICATIONS_CONFIGURATION = "/api/notifications/v2/configurations/"
     const val APP_NAME_DISCUSSION = "discussion"
     const val NOTIFICATION_TYPE = "core"
     const val NOTIFICATION_CHANNEL = "push"

--- a/notifications/src/main/java/org/openedx/notifications/data/api/NotificationsApi.kt
+++ b/notifications/src/main/java/org/openedx/notifications/data/api/NotificationsApi.kt
@@ -10,7 +10,6 @@ import org.openedx.notifications.data.model.NotificationsUpdateResponse
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.PATCH
-import retrofit2.http.POST
 import retrofit2.http.PUT
 import retrofit2.http.Path
 import retrofit2.http.Query
@@ -38,7 +37,7 @@ interface NotificationsApi {
     @GET(APIConstants.NOTIFICATIONS_CONFIGURATION)
     suspend fun fetchNotificationsConfiguration(): NotificationsConfiguration
 
-    @POST(APIConstants.NOTIFICATION_UPDATE_CONFIGURATION)
+    @PUT(APIConstants.NOTIFICATIONS_CONFIGURATION)
     suspend fun updateNotificationsConfiguration(
         @Body notificationsUpdateBody: NotificationsUpdateBody,
     ): NotificationsUpdateResponse

--- a/notifications/src/main/java/org/openedx/notifications/data/model/NotificationsUpdateBody.kt
+++ b/notifications/src/main/java/org/openedx/notifications/data/model/NotificationsUpdateBody.kt
@@ -1,7 +1,7 @@
 package org.openedx.notifications.data.model
 
 import com.google.gson.annotations.SerializedName
-import org.openedx.notifications.domain.model.NotificationsUpdateResponse
+import org.openedx.notifications.domain.model.NotificationsConfiguration
 
 data class NotificationsUpdateBody(
     @SerializedName("notification_app") val notificationApp: String,
@@ -14,13 +14,9 @@ data class NotificationsUpdateResponse(
     @SerializedName("status") val status: String,
     @SerializedName("data") val data: NotificationUpdateData,
 ) {
-    fun mapToDomain(): NotificationsUpdateResponse {
-        return NotificationsUpdateResponse(
-            status = status,
-            updatedValue = data.updatedValue,
-            notificationType = data.notificationType,
-            channel = data.channel,
-            app = data.app
+    fun mapToDomain(): NotificationsConfiguration {
+        return NotificationsConfiguration(
+            discussionsPushEnabled = data.updatedValue,
         )
     }
 }

--- a/notifications/src/main/java/org/openedx/notifications/data/repository/NotificationsRepository.kt
+++ b/notifications/src/main/java/org/openedx/notifications/data/repository/NotificationsRepository.kt
@@ -9,7 +9,6 @@ import org.openedx.notifications.data.storage.NotificationsPreferences
 import org.openedx.notifications.domain.model.InboxNotifications
 import org.openedx.notifications.domain.model.NotificationsConfiguration
 import org.openedx.notifications.domain.model.NotificationsCount
-import org.openedx.notifications.domain.model.NotificationsUpdateResponse
 
 class NotificationsRepository(
     private val api: NotificationsApi,
@@ -49,7 +48,7 @@ class NotificationsRepository(
 
     suspend fun updateNotificationsConfiguration(
         isDiscussionPushEnabled: Boolean,
-    ): NotificationsUpdateResponse {
+    ): NotificationsConfiguration {
         val response = api.updateNotificationsConfiguration(
             NotificationsUpdateBody(
                 notificationApp = APIConstants.APP_NAME_DISCUSSION,
@@ -58,7 +57,7 @@ class NotificationsRepository(
                 value = isDiscussionPushEnabled,
             )
         ).mapToDomain()
-        updateNotificationsPreference(response.updatedValue)
+        updateNotificationsPreference(response.discussionsPushEnabled)
         return response
     }
 

--- a/notifications/src/main/java/org/openedx/notifications/domain/interactor/NotificationsInteractor.kt
+++ b/notifications/src/main/java/org/openedx/notifications/domain/interactor/NotificationsInteractor.kt
@@ -4,7 +4,6 @@ import org.openedx.notifications.data.repository.NotificationsRepository
 import org.openedx.notifications.domain.model.InboxNotifications
 import org.openedx.notifications.domain.model.NotificationsConfiguration
 import org.openedx.notifications.domain.model.NotificationsCount
-import org.openedx.notifications.domain.model.NotificationsUpdateResponse
 
 class NotificationsInteractor(
     private val repository: NotificationsRepository,
@@ -31,7 +30,7 @@ class NotificationsInteractor(
 
     suspend fun updateNotificationsConfiguration(
         isDiscussionPushEnabled: Boolean,
-    ): NotificationsUpdateResponse {
+    ): NotificationsConfiguration {
         return repository.updateNotificationsConfiguration(
             isDiscussionPushEnabled = isDiscussionPushEnabled,
         )

--- a/notifications/src/main/java/org/openedx/notifications/domain/model/NotificationsUpdateResponse.kt
+++ b/notifications/src/main/java/org/openedx/notifications/domain/model/NotificationsUpdateResponse.kt
@@ -1,9 +1,0 @@
-package org.openedx.notifications.domain.model
-
-data class NotificationsUpdateResponse(
-    val status: String,
-    val updatedValue: Boolean,
-    val notificationType: String,
-    val channel: String,
-    val app: String,
-)

--- a/notifications/src/main/java/org/openedx/notifications/presentation/inbox/NotificationsInboxFragment.kt
+++ b/notifications/src/main/java/org/openedx/notifications/presentation/inbox/NotificationsInboxFragment.kt
@@ -38,7 +38,9 @@ import androidx.compose.material.pullrefresh.pullRefresh
 import androidx.compose.material.pullrefresh.rememberPullRefreshState
 import androidx.compose.material.rememberScaffoldState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -196,6 +198,21 @@ private fun InboxView(
         mutableIntStateOf(scrollState.firstVisibleItemIndex)
     }
     val loadMoreTriggerThreshold = 4
+    val shouldLoadMore by remember {
+        derivedStateOf {
+            scrollState.shouldLoadMore(
+                rememberedFirstIndex = firstVisibleIndex,
+                rememberedLastIndex = lastVisibleIndex,
+                threshold = loadMoreTriggerThreshold
+            )
+        }
+    }
+
+    LaunchedEffect(shouldLoadMore) {
+        if (shouldLoadMore && canLoadMore) {
+            paginationCallBack()
+        }
+    }
 
     Scaffold(
         scaffoldState = scaffoldState,
@@ -245,7 +262,7 @@ private fun InboxView(
                                             )
                                         }
 
-                                        items(items) { item ->
+                                        items(items = items, key = { it.id }) { item ->
                                             NotificationItemView(
                                                 modifier = Modifier.clickable {
                                                     markNotificationAsRead(item, section)
@@ -271,15 +288,6 @@ private fun InboxView(
                                             CircularProgressIndicator(color = MaterialTheme.appColors.primary)
                                         }
                                     }
-                                }
-
-                                if (scrollState.shouldLoadMore(
-                                        rememberedFirstIndex = firstVisibleIndex,
-                                        rememberedLastIndex = lastVisibleIndex,
-                                        threshold = loadMoreTriggerThreshold
-                                    )
-                                ) {
-                                    paginationCallBack()
                                 }
                             }
                         }

--- a/notifications/src/main/java/org/openedx/notifications/presentation/inbox/NotificationsInboxViewModel.kt
+++ b/notifications/src/main/java/org/openedx/notifications/presentation/inbox/NotificationsInboxViewModel.kt
@@ -102,7 +102,7 @@ class NotificationsInboxViewModel(
 
                 // Update the UI state based on whether any notifications exist
                 _uiState.value = if (notifications.values.any { it.isNotEmpty() }) {
-                    InboxUIState.Data(notifications = notifications.toMap())
+                    InboxUIState.Data(notifications = notifications.mapValues { it.value.toList() })
                 } else {
                     InboxUIState.Fallback(state = InboxFullScreenState.Empty)
                 }

--- a/notifications/src/main/java/org/openedx/notifications/presentation/settings/NotificationsSettingsViewModel.kt
+++ b/notifications/src/main/java/org/openedx/notifications/presentation/settings/NotificationsSettingsViewModel.kt
@@ -58,7 +58,7 @@ class NotificationsSettingsViewModel(
             viewModelScope.launch {
                 try {
                     val response = interactor.updateNotificationsConfiguration(value)
-                    enablePushNotifications(enabled = response.updatedValue)
+                    enablePushNotifications(enabled = response.discussionsPushEnabled)
                 } catch (e: Exception) {
                     logger.e(throwable = e, metadata = mapOf("preference" to value))
                     showErrorMessage()

--- a/notifications/src/test/java/org/openedx/notifications/presentation/primer/NotificationsPrimerViewModelTest.kt
+++ b/notifications/src/test/java/org/openedx/notifications/presentation/primer/NotificationsPrimerViewModelTest.kt
@@ -19,7 +19,7 @@ import org.junit.Test
 import org.junit.rules.TestRule
 import org.openedx.notifications.data.storage.NotificationsPreferences
 import org.openedx.notifications.domain.interactor.NotificationsInteractor
-import org.openedx.notifications.domain.model.NotificationsUpdateResponse
+import org.openedx.notifications.domain.model.NotificationsConfiguration
 import org.openedx.notifications.presentation.NotificationsAnalytics
 
 
@@ -36,19 +36,15 @@ class NotificationsPrimerViewModelTest {
     private val analytics: NotificationsAnalytics = mockk(relaxed = true)
     private val preferences: NotificationsPreferences = mockk(relaxed = true)
 
-    private val mockNotificationsUpdateResponse = NotificationsUpdateResponse(
-        status = "",
-        updatedValue = true,
-        notificationType = "",
-        channel = "",
-        app = "",
+    private val mockNotificationsConfiguration = NotificationsConfiguration(
+        discussionsPushEnabled = true,
     )
 
     @Before
     fun setUp() {
         Dispatchers.setMain(dispatcher)
 
-        coEvery { interactor.updateNotificationsConfiguration(any()) } returns mockNotificationsUpdateResponse
+        coEvery { interactor.updateNotificationsConfiguration(any()) } returns mockNotificationsConfiguration
     }
 
     @Test

--- a/notifications/src/test/java/org/openedx/notifications/presentation/settings/NotificationsSettingsViewModelTest.kt
+++ b/notifications/src/test/java/org/openedx/notifications/presentation/settings/NotificationsSettingsViewModelTest.kt
@@ -32,7 +32,6 @@ import org.openedx.core.utils.Logger
 import org.openedx.notifications.data.storage.NotificationsPreferences
 import org.openedx.notifications.domain.interactor.NotificationsInteractor
 import org.openedx.notifications.domain.model.NotificationsConfiguration
-import org.openedx.notifications.domain.model.NotificationsUpdateResponse
 import org.openedx.notifications.presentation.NotificationsAnalytics
 import java.net.UnknownHostException
 
@@ -55,13 +54,6 @@ class NotificationsSettingsViewModelTest {
     private val somethingWrong = "Service is unavailable. Please try again later."
 
     private val mockNotificationsConfiguration = NotificationsConfiguration(true)
-    private val mockNotificationsUpdateResponse = NotificationsUpdateResponse(
-        status = "",
-        updatedValue = true,
-        notificationType = "",
-        channel = "",
-        app = "",
-    )
 
     @Before
     fun setUp() {
@@ -150,8 +142,8 @@ class NotificationsSettingsViewModelTest {
         every { notificationManager.areNotificationsEnabled() } returns true
         every { preferences.notifications.discussionsPushEnabled } returns true
         coEvery { interactor.fetchNotificationsConfiguration() } returns mockNotificationsConfiguration
-        coEvery { interactor.updateNotificationsConfiguration(any()) } returns mockNotificationsUpdateResponse.copy(
-            updatedValue = false
+        coEvery { interactor.updateNotificationsConfiguration(any()) } returns mockNotificationsConfiguration.copy(
+            discussionsPushEnabled = false
         )
 
         viewModel = NotificationsSettingsViewModel(context, interactor, analytics, preferences)
@@ -220,7 +212,7 @@ class NotificationsSettingsViewModelTest {
 
         // Permission Enabled
         every { notificationManager.areNotificationsEnabled() } returns true
-        coEvery { interactor.updateNotificationsConfiguration(any()) } returns mockNotificationsUpdateResponse
+        coEvery { interactor.updateNotificationsConfiguration(any()) } returns mockNotificationsConfiguration
 
         viewModel.setDiscussionNotificationPreference(true)
         advanceUntilIdle()


### PR DESCRIPTION
### Description

[LEARNER-10655](https://2u-internal.atlassian.net/browse/LEARNER-10655)

### Push Preferences
- Update the push notifications preferences API

### Notifications Inbox
- Refactor load-more logic in to prevent infinite recomposition by moving the threshold check into a `derivedStateOf` and triggering pagination inside a `LaunchedEffect`, ensuring `fetchMore()` fires only once each time the scroll threshold is crossed.
- Snapshot each section’s notifications with `toList()` and provide stable `key = { it.id }` in `LazyColumn` so Compose detects updated list instances and immediately renders newly fetched items.