### PR TITLE
feat: Default Follow New Posts And Localize Timestamps In Discussion

### DIFF
--- a/core/src/main/java/org/openedx/core/utils/TimeUtils.kt
+++ b/core/src/main/java/org/openedx/core/utils/TimeUtils.kt
@@ -12,10 +12,14 @@ import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Date
 import java.util.Locale
+import java.util.TimeZone
 import java.util.concurrent.TimeUnit
 import kotlin.math.ceil
 
 object TimeUtils {
+
+    private val POSIX_LOCALE = Locale("en", "US", "POSIX")
+    private val UTC_TIME_ZONE = TimeZone.getTimeZone("UTC")
 
     private const val FORMAT_ISO_8601 = "yyyy-MM-dd'T'HH:mm:ss'Z'"
     private const val FORMAT_ISO_8601_WITH_TIME_ZONE = "yyyy-MM-dd'T'HH:mm:ssXXX"
@@ -46,7 +50,9 @@ object TimeUtils {
 
     fun iso8601ToDateWithTime(context: Context, text: String): String {
         return try {
-            val courseDateFormat = SimpleDateFormat(FORMAT_ISO_8601, Locale.getDefault())
+            val courseDateFormat = SimpleDateFormat(FORMAT_ISO_8601, POSIX_LOCALE).apply {
+                timeZone = UTC_TIME_ZONE
+            }
             val applicationDateFormat = SimpleDateFormat(
                 context.getString(R.string.core_full_date_with_time), Locale.getDefault()
             )

--- a/discussion/src/main/java/org/openedx/discussion/presentation/threads/DiscussionAddThreadFragment.kt
+++ b/discussion/src/main/java/org/openedx/discussion/presentation/threads/DiscussionAddThreadFragment.kt
@@ -196,7 +196,7 @@ private fun DiscussionAddThreadScreen(
         mutableStateOf(topicData)
     }
     var followPost by rememberSaveable {
-        mutableStateOf(false)
+        mutableStateOf(true)
     }
     val expandedList by rememberSaveable {
         mutableStateOf(topics)


### PR DESCRIPTION
### Description

[LEARNER-10656](https://2u-internal.atlassian.net/browse/LEARNER-10656)


- Check `Follow this post` by default for all new discussion posts and questions
- Parse server-provided `ISO-8601 UTC` timestamps with `SimpleDateFormat` using an explicit UTC timezone and `POSIX` locale to avoid default-timezone ambiguity
- Display all timestamps in the discussion module in the user’s local timezone
