### PR TITLE
feat: Payments and upgrade execution from locked content

### DIFF
--- a/app/src/main/java/org/openedx/app/di/ScreenModule.kt
+++ b/app/src/main/java/org/openedx/app/di/ScreenModule.kt
@@ -329,7 +329,6 @@ val screenModule = module {
             get(),
             get(),
             get(),
-            get(),
         )
     }
     viewModel { (courseId: String, courseTitle: String) ->

--- a/app/src/main/java/org/openedx/app/di/ScreenModule.kt
+++ b/app/src/main/java/org/openedx/app/di/ScreenModule.kt
@@ -28,6 +28,7 @@ import org.openedx.course.presentation.outline.CourseOutlineViewModel
 import org.openedx.course.presentation.section.CourseSectionViewModel
 import org.openedx.course.presentation.unit.container.CourseUnitContainerViewModel
 import org.openedx.course.presentation.unit.html.HtmlUnitViewModel
+import org.openedx.course.presentation.unit.unlockcontent.UnlockContentViewModel
 import org.openedx.course.presentation.unit.video.BaseVideoViewModel
 import org.openedx.course.presentation.unit.video.EncodedVideoUnitViewModel
 import org.openedx.course.presentation.unit.video.VideoUnitViewModel
@@ -327,6 +328,8 @@ val screenModule = module {
             get(),
             get(),
             get(),
+            get(),
+            get(),
         )
     }
     viewModel { (courseId: String, courseTitle: String) ->
@@ -525,6 +528,10 @@ val screenModule = module {
         )
     }
     viewModel { HtmlUnitViewModel(get(), get(), get(), get(), get()) }
+
+    viewModel { (blockId: String, courseId: String) ->
+        UnlockContentViewModel(blockId, courseId, get(), get(), get(), get())
+    }
 
     viewModel { ProgramViewModel(get(), get(), get(), get(), get(), get(), get(), get()) }
 

--- a/core/src/main/java/org/openedx/core/ApiConstants.kt
+++ b/core/src/main/java/org/openedx/core/ApiConstants.kt
@@ -29,7 +29,7 @@ object ApiConstants {
     const val AUTH_TYPE_MICROSOFT = "azuread-oauth2"
 
     const val COURSE_KEY = "course_key"
-    const val BLOCKS_API_VERSION = "v3"
+    const val BLOCKS_API_VERSION = "v4"
     const val HEADER_STALE_IF_ERROR = "stale-if-error=0"
 
     object RegistrationFields {

--- a/core/src/main/java/org/openedx/core/data/model/Block.kt
+++ b/core/src/main/java/org/openedx/core/data/model/Block.kt
@@ -2,6 +2,7 @@ package org.openedx.core.data.model
 
 import com.google.gson.annotations.SerializedName
 import org.openedx.core.BlockType
+import org.openedx.core.domain.model.AuthorizationDenialReason
 import org.openedx.core.utils.TimeUtils
 import org.openedx.core.domain.model.Block as DomainBlock
 import org.openedx.core.domain.model.BlockCounts as DomainBlockCounts
@@ -38,6 +39,10 @@ data class Block(
     val completion: Double?,
     @SerializedName("contains_gated_content")
     val containsGatedContent: Boolean?,
+    @SerializedName("authorization_denial_reason")
+    val authorizationDenialReason: String?,
+    @SerializedName("authorization_denial_message")
+    val authorizationDenialMessage: String?,
     @SerializedName("assignment_progress")
     val assignmentProgress: AssignmentProgress?,
     @SerializedName("due")
@@ -71,6 +76,7 @@ data class Block(
             blockCounts = blockCounts?.mapToDomain()!!,
             completion = completion ?: 0.0,
             containsGatedContent = containsGatedContent ?: false,
+            authorizationDenialReason = AuthorizationDenialReason.from(authorizationDenialReason),
             assignmentProgress = assignmentProgress?.mapToDomain(),
             due = TimeUtils.iso8601ToDate(due ?: ""),
         )

--- a/core/src/main/java/org/openedx/core/data/model/room/BlockDb.kt
+++ b/core/src/main/java/org/openedx/core/data/model/room/BlockDb.kt
@@ -8,6 +8,7 @@ import org.openedx.core.data.model.BlockCounts
 import org.openedx.core.data.model.EncodedVideos
 import org.openedx.core.data.model.StudentViewData
 import org.openedx.core.data.model.VideoInfo
+import org.openedx.core.domain.model.AuthorizationDenialReason
 import org.openedx.core.utils.TimeUtils
 import org.openedx.core.domain.model.AssignmentProgress as DomainAssignmentProgress
 import org.openedx.core.domain.model.Block as DomainBlock
@@ -45,6 +46,8 @@ data class BlockDb(
     val completion: Double,
     @ColumnInfo("contains_gated_content")
     val containsGatedContent: Boolean,
+    @ColumnInfo("authorization_denial_reason")
+    val authorizationDenialReason: String,
     @Embedded
     val assignmentProgress: AssignmentProgressDb?,
     @ColumnInfo("due")
@@ -78,6 +81,7 @@ data class BlockDb(
             descendantsType = descendantsType,
             completion = completion,
             containsGatedContent = containsGatedContent,
+            authorizationDenialReason = AuthorizationDenialReason.from(authorizationDenialReason),
             assignmentProgress = assignmentProgress?.mapToDomain(),
             due = TimeUtils.iso8601ToDate(due ?: ""),
         )
@@ -104,6 +108,7 @@ data class BlockDb(
                     blockCounts = BlockCountsDb.createFrom(blockCounts),
                     completion = completion ?: 0.0,
                     containsGatedContent = containsGatedContent ?: false,
+                    authorizationDenialReason = authorizationDenialReason ?: "",
                     assignmentProgress = assignmentProgress?.mapToRoomEntity(),
                     due = due
                 )

--- a/core/src/main/java/org/openedx/core/domain/model/Block.kt
+++ b/core/src/main/java/org/openedx/core/domain/model/Block.kt
@@ -78,6 +78,9 @@ data class Block(
         return count
     }
 
+    fun isPaidContent(): Boolean =
+        authorizationDenialReason == AuthorizationDenialReason.FEATURE_BASED_ENROLLMENTS
+
     val isVideoBlock get() = type == BlockType.VIDEO
     val isDiscussionBlock get() = type == BlockType.DISCUSSION
     val isHTMLBlock get() = type == BlockType.HTML

--- a/core/src/main/java/org/openedx/core/domain/model/Block.kt
+++ b/core/src/main/java/org/openedx/core/domain/model/Block.kt
@@ -9,7 +9,6 @@ import org.openedx.core.module.db.FileType
 import org.openedx.core.utils.VideoUtil
 import java.util.Date
 
-
 data class Block(
     val id: String,
     val blockId: String,
@@ -26,6 +25,7 @@ data class Block(
     val descendantsType: BlockType,
     val completion: Double,
     val containsGatedContent: Boolean = false,
+    val authorizationDenialReason: AuthorizationDenialReason,
     val downloadModel: DownloadModel? = null,
     val assignmentProgress: AssignmentProgress?,
     val due: Date?
@@ -237,3 +237,14 @@ data class VideoInfo(
 data class BlockCounts(
     val video: Int,
 )
+
+enum class AuthorizationDenialReason(val rawValue: String) {
+    FEATURE_BASED_ENROLLMENTS("Feature-based Enrollments"),
+    UNKNOWN("Unknown");
+
+    companion object {
+        fun from(value: String?): AuthorizationDenialReason {
+            return entries.find { it.rawValue == value } ?: UNKNOWN
+        }
+    }
+}

--- a/core/src/main/java/org/openedx/core/domain/model/iap/PurchaseFlowData.kt
+++ b/core/src/main/java/org/openedx/core/domain/model/iap/PurchaseFlowData.kt
@@ -24,7 +24,7 @@ data class PurchaseFlowData(
     var courseModeTransitionRetryCount: Long = 0
     var isConsumed: Boolean = false
 
-    fun reset() {
+    fun resetAll() {
         iapFlow = null
         screenName = null
         courseId = null
@@ -32,6 +32,10 @@ data class PurchaseFlowData(
         isSelfPaced = null
         componentId = null
         productInfo = null
+        resetSessionData()
+    }
+
+    fun resetSessionData() {
         currencyCode = ""
         price = 0.0
         formattedPrice = null

--- a/core/src/main/java/org/openedx/core/domain/model/iap/PurchaseFlowData.kt
+++ b/core/src/main/java/org/openedx/core/domain/model/iap/PurchaseFlowData.kt
@@ -25,13 +25,6 @@ data class PurchaseFlowData(
     var isConsumed: Boolean = false
 
     fun reset() {
-        iapFlow = null
-        screenName = null
-        courseId = null
-        courseName = null
-        isSelfPaced = null
-        componentId = null
-        productInfo = null
         currencyCode = ""
         price = 0.0
         formattedPrice = null
@@ -71,6 +64,7 @@ enum class IAPFlow(val value: String) {
 enum class IAPFlowSource(val screen: String) {
     COURSE_ENROLLMENT("course_enrollment"),
     COURSE_DASHBOARD("course_dashboard"),
+    COURSE_COMPONENT("course_component"),
     PROFILE("profile"),
     TRACK_SELECTION("track_selection"),
 }

--- a/core/src/main/java/org/openedx/core/domain/model/iap/PurchaseFlowData.kt
+++ b/core/src/main/java/org/openedx/core/domain/model/iap/PurchaseFlowData.kt
@@ -25,6 +25,13 @@ data class PurchaseFlowData(
     var isConsumed: Boolean = false
 
     fun reset() {
+        iapFlow = null
+        screenName = null
+        courseId = null
+        courseName = null
+        isSelfPaced = null
+        componentId = null
+        productInfo = null
         currencyCode = ""
         price = 0.0
         formattedPrice = null

--- a/core/src/main/java/org/openedx/core/presentation/dialog/IAPDialogFragment.kt
+++ b/core/src/main/java/org/openedx/core/presentation/dialog/IAPDialogFragment.kt
@@ -305,13 +305,9 @@ class IAPDialogFragment : DialogFragment() {
             return newInstance(purchaseFlowData)
         }
 
-        fun newInstance(
-            purchaseFlowData: PurchaseFlowData
-        ): IAPDialogFragment {
+        fun newInstance(purchaseFlowData: PurchaseFlowData): IAPDialogFragment {
             val fragment = IAPDialogFragment()
-            fragment.arguments = bundleOf(
-                ARG_PURCHASE_FLOW_DATA to purchaseFlowData
-            )
+            fragment.arguments = bundleOf(ARG_PURCHASE_FLOW_DATA to purchaseFlowData)
             return fragment
         }
     }

--- a/core/src/main/java/org/openedx/core/presentation/iap/IAPEventLogger.kt
+++ b/core/src/main/java/org/openedx/core/presentation/iap/IAPEventLogger.kt
@@ -124,9 +124,6 @@ class IAPEventLogger(
                 IAPAnalyticsEvent.IAP_VALUE_PROP_VIEWED
         val params = buildMap {
             put(IAPAnalyticsKeys.NAME.key, event.biValue)
-            purchaseFlowData?.screenName?.takeIfNotEmpty()?.let { screenName ->
-                put(IAPAnalyticsKeys.SCREEN_NAME.key, screenName)
-            }
             putAll(getIAPEventParams())
         }
         analytics.logScreenEvent(screenName = event.eventName, params = params)

--- a/core/src/main/java/org/openedx/core/presentation/iap/IAPViewModel.kt
+++ b/core/src/main/java/org/openedx/core/presentation/iap/IAPViewModel.kt
@@ -70,8 +70,7 @@ class IAPViewModel(
     private val purchaseListeners = object : BillingProcessor.PurchaseListeners {
         override fun onPurchaseComplete(purchase: Purchase) {
             if (purchase.getCourseId() == purchaseFlowData.courseId) {
-                _uiState.value =
-                    IAPUIState.Loading(loaderType = IAPLoaderType.FULL_SCREEN)
+                _uiState.value = IAPUIState.Loading(loaderType = IAPLoaderType.FULL_SCREEN)
                 purchaseFlowData.purchaseToken = purchase.purchaseToken
                 createOrder(purchaseFlowData)
             }
@@ -95,7 +94,7 @@ class IAPViewModel(
                     is CourseDataUpdated.CourseEnrollmentDataUpdated -> {
                         if (purchaseFlowData.screenName in listOf(
                                 IAPFlowSource.COURSE_ENROLLMENT.screen,
-                                IAPFlowSource.PROFILE.screen
+                                IAPFlowSource.PROFILE.screen,
                             )
                         ) {
                             val isVerifiedMode =
@@ -107,7 +106,8 @@ class IAPViewModel(
                     is CourseDataUpdated.CourseDashboardDataUpdate -> {
                         if (purchaseFlowData.screenName in listOf(
                                 IAPFlowSource.COURSE_DASHBOARD.screen,
-                                IAPFlowSource.TRACK_SELECTION.screen
+                                IAPFlowSource.TRACK_SELECTION.screen,
+                                IAPFlowSource.COURSE_COMPONENT.screen,
                             )
                         ) {
                             val isVerifiedMode =
@@ -122,11 +122,16 @@ class IAPViewModel(
         if (iapInteractor.isUpgradeEnabled) {
             when (purchaseFlowData.iapFlow) {
                 IAPFlow.USER_INITIATED -> {
-                    eventLogger.loadIAPScreenEvent()
-                    loadPrice()
+                    if (purchaseFlowData.screenName == IAPFlowSource.COURSE_COMPONENT.screen) {
+                        _uiState.value = IAPUIState.Loading(loaderType = IAPLoaderType.FULL_SCREEN)
+                        createOrder(purchaseFlowData)
+                    } else {
+                        eventLogger.loadIAPScreenEvent()
+                        loadPrice()
+                    }
                 }
 
-                IAPFlow.SILENT, IAPFlow.RESTORE -> {
+                in listOf(IAPFlow.SILENT, IAPFlow.RESTORE) -> {
                     _uiState.value = IAPUIState.Loading(IAPLoaderType.FULL_SCREEN)
                     purchaseFlowData.flowStartTime = TimeUtils.getCurrentTime()
                     updateCourseData()
@@ -240,7 +245,13 @@ class IAPViewModel(
                         eventLogger.upgradeSuccessEvent()
                     }
                     purchaseFlowData.isConsumed = true
-                    _uiState.value = IAPUIState.CourseDataUpdated
+                    // The IAP dialog will be dismissed by `CourseUnitContainerFragment` after
+                    // refreshing the course components
+                    if (eventLogger.purchaseFlowData?.screenName != IAPFlowSource.COURSE_COMPONENT.screen) {
+                        _uiState.value = IAPUIState.CourseDataUpdated
+                    } else {
+                        iapNotifier.send(CourseDataUpdated.CourseUnitDataUpdate)
+                    }
                     _uiMessage.emit(UIMessage.ToastMessage(resourceManager.getString(R.string.iap_success_message)))
                 }.onFailure {
                     logger.e(throwable = it)

--- a/core/src/main/java/org/openedx/core/presentation/iap/IAPViewModel.kt
+++ b/core/src/main/java/org/openedx/core/presentation/iap/IAPViewModel.kt
@@ -365,7 +365,7 @@ class IAPViewModel(
 
     fun clearIAPFLow() {
         _uiState.value = IAPUIState.Clear
-        purchaseFlowData.reset()
+        purchaseFlowData.resetAll()
     }
 
     companion object {

--- a/core/src/main/java/org/openedx/core/system/notifier/CourseDataUpdated.kt
+++ b/core/src/main/java/org/openedx/core/system/notifier/CourseDataUpdated.kt
@@ -6,4 +6,6 @@ sealed class CourseDataUpdated : IAPEvent {
 
     data class CourseDashboardDataUpdate(val courseId: String, val isVerifiedMode: Boolean) :
         CourseDataUpdated()
+
+    data object CourseUnitDataUpdate : CourseDataUpdated()
 }

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -244,4 +244,7 @@
     <string name="core_match_device">Match device</string>
     <string name="core_match_device_description">Matches your device settings automatically.</string>
 
+    <!--  Locked Content  -->
+    <string name="iap_locked_content_title">Graded assignment are locked</string>
+    <string name="iap_locked_content_description">Upgrade to gain access to locked features like this one and get the most out of your course.</string>
 </resources>

--- a/course/src/main/java/org/openedx/course/presentation/container/CourseContainerViewModel.kt
+++ b/course/src/main/java/org/openedx/course/presentation/container/CourseContainerViewModel.kt
@@ -302,7 +302,13 @@ class CourseContainerViewModel(
                 isFromValueProp = isFromValueProp,
                 isExpiredCoursePurchase = isExpiredCoursePurchase
             )
-            if (waitForCourseModeTransition) return
+            if (waitForCourseModeTransition) {
+                return
+            } else {
+                // Refresh the course structure data once the IAP flow is completed
+                // to ensure the latest access state and content are reflected.
+                updateData()
+            }
         } else if (isExpiredCoursePurchase) {
             // No need to process cached data if came from expired course purchase
             return

--- a/course/src/main/java/org/openedx/course/presentation/container/CourseContainerViewModel.kt
+++ b/course/src/main/java/org/openedx/course/presentation/container/CourseContainerViewModel.kt
@@ -304,7 +304,7 @@ class CourseContainerViewModel(
             )
             if (waitForCourseModeTransition) {
                 return
-            } else {
+            } else if (isFromValueProp || isExpiredCoursePurchase) {
                 // Refresh the course structure data once the IAP flow is completed
                 // to ensure the latest access state and content are reflected.
                 updateData()

--- a/course/src/main/java/org/openedx/course/presentation/outline/CourseOutlineScreen.kt
+++ b/course/src/main/java/org/openedx/course/presentation/outline/CourseOutlineScreen.kt
@@ -48,6 +48,7 @@ import org.openedx.core.BlockType
 import org.openedx.core.NoContentScreenType
 import org.openedx.core.UIMessage
 import org.openedx.core.domain.model.AssignmentProgress
+import org.openedx.core.domain.model.AuthorizationDenialReason
 import org.openedx.core.domain.model.Block
 import org.openedx.core.domain.model.BlockCounts
 import org.openedx.core.domain.model.CourseAccessDetails
@@ -309,7 +310,6 @@ private fun CourseOutlineUI(
                                                     ResumeCourseTablet(
                                                         modifier = Modifier.padding(vertical = 16.dp),
                                                         block = uiState.resumeComponent,
-                                                        displayName = uiState.resumeUnitTitle,
                                                         onResumeClick = onResumeClick
                                                     )
                                                 } else {
@@ -439,7 +439,6 @@ private fun ResumeCourse(
 private fun ResumeCourseTablet(
     modifier: Modifier = Modifier,
     block: Block,
-    displayName: String,
     onResumeClick: (String) -> Unit,
 ) {
     Row(
@@ -638,6 +637,7 @@ private val mockChapterBlock = Block(
     descendantsType = BlockType.CHAPTER,
     completion = 0.0,
     containsGatedContent = false,
+    authorizationDenialReason = AuthorizationDenialReason.UNKNOWN,
     assignmentProgress = mockAssignmentProgress,
     due = Date()
 )
@@ -657,6 +657,7 @@ private val mockSequentialBlock = Block(
     descendantsType = BlockType.CHAPTER,
     completion = 0.0,
     containsGatedContent = false,
+    authorizationDenialReason = AuthorizationDenialReason.UNKNOWN,
     assignmentProgress = mockAssignmentProgress,
     due = Date()
 )

--- a/course/src/main/java/org/openedx/course/presentation/section/CourseSectionFragment.kt
+++ b/course/src/main/java/org/openedx/course/presentation/section/CourseSectionFragment.kt
@@ -62,6 +62,7 @@ import org.koin.core.parameter.parametersOf
 import org.openedx.core.BlockType
 import org.openedx.core.UIMessage
 import org.openedx.core.domain.model.AssignmentProgress
+import org.openedx.core.domain.model.AuthorizationDenialReason
 import org.openedx.core.domain.model.Block
 import org.openedx.core.domain.model.BlockCounts
 import org.openedx.core.extension.serializable
@@ -79,12 +80,10 @@ import org.openedx.core.ui.theme.appColors
 import org.openedx.core.ui.theme.appShapes
 import org.openedx.core.ui.theme.appTypography
 import org.openedx.core.ui.windowSizeValue
-import org.openedx.core.ui.windowSizeValue
 import org.openedx.core.utils.FileUtil
 import org.openedx.course.R
 import org.openedx.course.presentation.CourseRouter
 import org.openedx.course.presentation.ui.CardArrow
-import java.io.File
 import java.util.Date
 import org.openedx.core.R as CoreR
 
@@ -481,6 +480,7 @@ private val mockBlock = Block(
     descendantsType = BlockType.HTML,
     completion = 0.0,
     containsGatedContent = false,
+    authorizationDenialReason = AuthorizationDenialReason.UNKNOWN,
     assignmentProgress = AssignmentProgress("", 1f, 2f),
     due = Date()
 )

--- a/course/src/main/java/org/openedx/course/presentation/ui/CourseUI.kt
+++ b/course/src/main/java/org/openedx/course/presentation/ui/CourseUI.kt
@@ -80,6 +80,7 @@ import androidx.compose.ui.zIndex
 import org.jsoup.Jsoup
 import org.openedx.core.BlockType
 import org.openedx.core.domain.model.AssignmentProgress
+import org.openedx.core.domain.model.AuthorizationDenialReason
 import org.openedx.core.domain.model.Block
 import org.openedx.core.domain.model.BlockCounts
 import org.openedx.core.domain.model.CourseBannerType
@@ -1463,6 +1464,7 @@ private val mockChapterBlock = Block(
     descendantsType = BlockType.CHAPTER,
     completion = 1.0,
     containsGatedContent = false,
+    authorizationDenialReason = AuthorizationDenialReason.UNKNOWN,
     assignmentProgress = AssignmentProgress("", 1f, 2f),
     due = Date()
 )

--- a/course/src/main/java/org/openedx/course/presentation/ui/CourseVideosUI.kt
+++ b/course/src/main/java/org/openedx/course/presentation/ui/CourseVideosUI.kt
@@ -66,6 +66,7 @@ import org.openedx.core.BlockType
 import org.openedx.core.NoContentScreenType
 import org.openedx.core.UIMessage
 import org.openedx.core.domain.model.AssignmentProgress
+import org.openedx.core.domain.model.AuthorizationDenialReason
 import org.openedx.core.domain.model.Block
 import org.openedx.core.domain.model.BlockCounts
 import org.openedx.core.domain.model.CourseAccessDetails
@@ -742,6 +743,7 @@ private val mockChapterBlock = Block(
     descendantsType = BlockType.CHAPTER,
     completion = 0.0,
     containsGatedContent = false,
+    authorizationDenialReason = AuthorizationDenialReason.UNKNOWN,
     assignmentProgress = mockAssignmentProgress,
     due = Date()
 )
@@ -762,6 +764,7 @@ private val mockSequentialBlock = Block(
     descendantsType = BlockType.SEQUENTIAL,
     completion = 0.0,
     containsGatedContent = false,
+    authorizationDenialReason = AuthorizationDenialReason.UNKNOWN,
     assignmentProgress = mockAssignmentProgress,
     due = Date()
 )

--- a/course/src/main/java/org/openedx/course/presentation/unit/container/CourseUnitContainerAdapter.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/container/CourseUnitContainerAdapter.kt
@@ -26,7 +26,7 @@ class CourseUnitContainerAdapter(
     private fun unitBlockFragment(block: Block): Fragment {
         return when {
             (block.authorizationDenialReason == AuthorizationDenialReason.FEATURE_BASED_ENROLLMENTS) -> {
-                if (viewModel.isUpgradeEnabled) {
+                if (viewModel.isIAPEnabled) {
                     UnlockContentFragment.newInstance(viewModel.courseId, block.id)
                 } else {
                     NotSupportedUnitFragment.newInstance(

--- a/course/src/main/java/org/openedx/course/presentation/unit/container/CourseUnitContainerAdapter.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/container/CourseUnitContainerAdapter.kt
@@ -3,9 +3,11 @@ package org.openedx.course.presentation.unit.container
 import androidx.fragment.app.Fragment
 import androidx.viewpager2.adapter.FragmentStateAdapter
 import org.openedx.core.FragmentViewType
+import org.openedx.core.domain.model.AuthorizationDenialReason
 import org.openedx.core.domain.model.Block
 import org.openedx.course.presentation.unit.NotSupportedUnitFragment
 import org.openedx.course.presentation.unit.html.HtmlUnitFragment
+import org.openedx.course.presentation.unit.unlockcontent.UnlockContentFragment
 import org.openedx.course.presentation.unit.video.VideoUnitFragment
 import org.openedx.course.presentation.unit.video.YoutubeVideoUnitFragment
 import org.openedx.discussion.presentation.threads.DiscussionThreadsFragment
@@ -23,6 +25,17 @@ class CourseUnitContainerAdapter(
 
     private fun unitBlockFragment(block: Block): Fragment {
         return when {
+            (block.authorizationDenialReason == AuthorizationDenialReason.FEATURE_BASED_ENROLLMENTS) -> {
+                if (viewModel.isUpgradeEnabled) {
+                    UnlockContentFragment.newInstance(viewModel.courseId, block.id)
+                } else {
+                    NotSupportedUnitFragment.newInstance(
+                        block.id,
+                        block.lmsWebUrl
+                    )
+                }
+            }
+
             (block.isVideoBlock &&
                     (block.studentViewData?.encodedVideos?.hasVideoUrl == true ||
                             block.studentViewData?.encodedVideos?.hasYoutubeUrl == true)) -> {
@@ -31,7 +44,9 @@ class CourseUnitContainerAdapter(
                     val downloadModel = viewModel.getDownloadModelById(block.id)
                     val isDownloaded = downloadModel != null
 
-                    val videoUrl = downloadModel?.path ?: getPreferredVideoInfoForStreaming(viewModel.videoQuality).url
+                    val videoUrl = downloadModel?.path ?: getPreferredVideoInfoForStreaming(
+                        viewModel.videoQuality
+                    ).url
                     val transcripts =
                         downloadModel?.transcriptPaths ?: block.studentViewData?.transcripts
 

--- a/course/src/main/java/org/openedx/course/presentation/unit/container/CourseUnitContainerAdapter.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/container/CourseUnitContainerAdapter.kt
@@ -3,7 +3,6 @@ package org.openedx.course.presentation.unit.container
 import androidx.fragment.app.Fragment
 import androidx.viewpager2.adapter.FragmentStateAdapter
 import org.openedx.core.FragmentViewType
-import org.openedx.core.domain.model.AuthorizationDenialReason
 import org.openedx.core.domain.model.Block
 import org.openedx.course.presentation.unit.NotSupportedUnitFragment
 import org.openedx.course.presentation.unit.html.HtmlUnitFragment
@@ -25,7 +24,7 @@ class CourseUnitContainerAdapter(
 
     private fun unitBlockFragment(block: Block): Fragment {
         return when {
-            (block.authorizationDenialReason == AuthorizationDenialReason.FEATURE_BASED_ENROLLMENTS) -> {
+            (block.isPaidContent()) -> {
                 if (viewModel.isIAPEnabled) {
                     UnlockContentFragment.newInstance(viewModel.courseId, block.id)
                 } else {

--- a/course/src/main/java/org/openedx/course/presentation/unit/container/CourseUnitContainerFragment.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/container/CourseUnitContainerFragment.kt
@@ -26,6 +26,10 @@ import androidx.lifecycle.lifecycleScope
 import androidx.viewpager2.widget.ViewPager2
 import com.google.android.gms.cast.framework.CastButtonFactory
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
@@ -33,6 +37,7 @@ import org.koin.core.parameter.parametersOf
 import org.openedx.core.BlockType
 import org.openedx.core.extension.serializable
 import org.openedx.core.presentation.course.CourseViewMode
+import org.openedx.core.presentation.dialog.IAPDialogFragment
 import org.openedx.core.presentation.global.InsetHolder
 import org.openedx.core.ui.theme.OpenEdXTheme
 import org.openedx.core.ui.theme.appColors
@@ -295,6 +300,27 @@ class CourseUnitContainerFragment : Fragment(R.layout.fragment_course_unit_conta
         (requireActivity().supportFragmentManager
             .findFragmentByTag(chapterEndDialogTag) as? ChapterEndFragmentDialog)?.let { fragment ->
             fragment.listener = dialogListener
+        }
+
+        viewModel.refreshComponent.onEach { refresh ->
+            if (refresh) {
+                val currentComponentIndex = binding.viewPager.currentItem
+                initViewPager() // update the adapter with new data
+                binding.viewPager.currentItem = currentComponentIndex
+                dismissIAPDialog()
+            }
+        }
+            .flowOn(Dispatchers.Main)
+            .launchIn(lifecycleScope)
+    }
+
+    private fun dismissIAPDialog() {
+        lifecycleScope.launch {
+            delay(1000) // Delay to ensure the screen refresh is complete
+            val iapDialogFragment = requireActivity()
+                .supportFragmentManager
+                .findFragmentByTag(IAPDialogFragment.TAG) as? IAPDialogFragment
+            iapDialogFragment?.dismiss()
         }
     }
 

--- a/course/src/main/java/org/openedx/course/presentation/unit/container/CourseUnitContainerViewModel.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/container/CourseUnitContainerViewModel.kt
@@ -4,9 +4,14 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.openedx.core.BaseViewModel
@@ -19,9 +24,12 @@ import org.openedx.core.extension.indexOfFirstFromIndex
 import org.openedx.core.module.db.DownloadModel
 import org.openedx.core.module.db.DownloadedState
 import org.openedx.core.presentation.course.CourseViewMode
+import org.openedx.core.presentation.global.AppData
+import org.openedx.core.system.notifier.CourseDataUpdated
 import org.openedx.core.system.notifier.CourseNotifier
 import org.openedx.core.system.notifier.CourseSectionChanged
 import org.openedx.core.system.notifier.CourseStructureUpdated
+import org.openedx.core.system.notifier.IAPNotifier
 import org.openedx.core.utils.Logger
 import org.openedx.course.domain.interactor.CourseInteractor
 import org.openedx.course.presentation.CourseAnalytics
@@ -36,6 +44,8 @@ class CourseUnitContainerViewModel(
     private val notifier: CourseNotifier,
     private val analytics: CourseAnalytics,
     private val corePreferences: CorePreferences,
+    private val appData: AppData,
+    iapNotifier: IAPNotifier,
 ) : BaseViewModel() {
 
     private val logger = Logger(TAG)
@@ -45,6 +55,11 @@ class CourseUnitContainerViewModel(
     val isCourseExpandableSectionsEnabled get() = config.getCourseUIConfig().isCourseDropdownNavigationEnabled
 
     val isCourseUnitProgressEnabled get() = config.getCourseUIConfig().isCourseUnitProgressEnabled
+
+    private val iapConfig
+        get() = corePreferences.appConfig.iapConfig
+    val isUpgradeEnabled
+        get() = iapConfig.isUpgradeEnabled(appData.versionName)
 
     private var currentIndex = 0
     private var currentVerticalIndex = 0
@@ -77,6 +92,9 @@ class CourseUnitContainerViewModel(
     private val _subSectionUnitBlocks = MutableStateFlow<List<Block>>(listOf())
     val subSectionUnitBlocks = _subSectionUnitBlocks.asStateFlow()
 
+    private val _refreshComponent = MutableSharedFlow<Boolean>()
+    val refreshComponent = _refreshComponent.asSharedFlow()
+
     var nextButtonText = ""
     var hasNextBlock = false
 
@@ -90,19 +108,28 @@ class CourseUnitContainerViewModel(
     val videoQuality
         get() = corePreferences.videoSettings.videoStreamingQuality
 
-    fun loadBlocks(mode: CourseViewMode, componentId: String = "") {
+    fun loadBlocks(mode: CourseViewMode, componentId: String = "", isNeedRefresh: Boolean = false) {
         currentMode = mode
         viewModelScope.launch {
             try {
                 val courseStructure = when (mode) {
-                    CourseViewMode.FULL -> interactor.getCourseStructure(courseId)
-                    CourseViewMode.VIDEOS -> interactor.getCourseStructureForVideos(courseId)
+                    CourseViewMode.FULL -> interactor.getCourseStructure(courseId, isNeedRefresh)
+                    CourseViewMode.VIDEOS -> interactor.getCourseStructureForVideos(
+                        courseId,
+                        isNeedRefresh
+                    )
                 }
                 val blocks = courseStructure.blockData
                 courseName = courseStructure.name
                 this@CourseUnitContainerViewModel.blocks.clearAndAddAll(blocks)
 
+                updateDescendantsBlocks(blocks)
                 setupCurrentIndex(componentId)
+                if (isNeedRefresh) {
+                    viewModelScope.launch {
+                        _refreshComponent.emit(true)
+                    }
+                }
             } catch (e: Exception) {
                 logger.e(throwable = e)
             }
@@ -124,6 +151,29 @@ class CourseUnitContainerViewModel(
                 }
             }
         }
+        iapNotifier.notifier.onEach { event ->
+            when (event) {
+                is CourseDataUpdated.CourseUnitDataUpdate -> {
+                    currentMode?.let { loadBlocks(it, currentComponentId, true) }
+                }
+            }
+        }.distinctUntilChanged().launchIn(viewModelScope)
+    }
+
+    private fun updateDescendantsBlocks(blocks: List<Block>) {
+        blocks.forEach { block ->
+            if (block.id == unitId) {
+                if (block.descendants.isNotEmpty() || block.isGated()) {
+                    _descendantsBlocks.value =
+                        block.descendants.mapNotNull { descendant ->
+                            blocks.firstOrNull { descendant == it.id }
+                        }
+                    if (_descendantsBlocks.value.isEmpty()) {
+                        _descendantsBlocks.value = listOf(block)
+                    }
+                }
+            }
+        }
     }
 
     private fun setupCurrentIndex(componentId: String = "") {
@@ -137,16 +187,8 @@ class CourseUnitContainerViewModel(
                     it.descendants.contains(blocks[currentVerticalIndex].id)
                 }
                 if (block.descendants.isNotEmpty() || block.isGated()) {
-                    _descendantsBlocks.value =
-                        block.descendants.mapNotNull { descendant ->
-                            blocks.firstOrNull { descendant == it.id }
-                        }
                     _subSectionUnitBlocks.value =
                         getSubSectionUnitBlocks(blocks, getSubSectionId(unitId))
-
-                    if (_descendantsBlocks.value.isEmpty()) {
-                        _descendantsBlocks.value = listOf(block)
-                    }
                 } else {
                     setNextVerticalIndex()
                 }

--- a/course/src/main/java/org/openedx/course/presentation/unit/container/CourseUnitContainerViewModel.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/container/CourseUnitContainerViewModel.kt
@@ -55,10 +55,7 @@ class CourseUnitContainerViewModel(
     val isCourseExpandableSectionsEnabled get() = config.getCourseUIConfig().isCourseDropdownNavigationEnabled
 
     val isCourseUnitProgressEnabled get() = config.getCourseUIConfig().isCourseUnitProgressEnabled
-
-    private val iapConfig
-        get() = corePreferences.appConfig.iapConfig
-    val isIAPEnabled = iapConfig.isEnabled
+    val isIAPEnabled = corePreferences.appConfig.iapConfig.isEnabled
 
     private var currentIndex = 0
     private var currentVerticalIndex = 0

--- a/course/src/main/java/org/openedx/course/presentation/unit/container/CourseUnitContainerViewModel.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/container/CourseUnitContainerViewModel.kt
@@ -58,8 +58,7 @@ class CourseUnitContainerViewModel(
 
     private val iapConfig
         get() = corePreferences.appConfig.iapConfig
-    val isUpgradeEnabled
-        get() = iapConfig.isUpgradeEnabled(appData.versionName)
+    val isIAPEnabled = iapConfig.isEnabled
 
     private var currentIndex = 0
     private var currentVerticalIndex = 0

--- a/course/src/main/java/org/openedx/course/presentation/unit/container/CourseUnitContainerViewModel.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/container/CourseUnitContainerViewModel.kt
@@ -24,7 +24,6 @@ import org.openedx.core.extension.indexOfFirstFromIndex
 import org.openedx.core.module.db.DownloadModel
 import org.openedx.core.module.db.DownloadedState
 import org.openedx.core.presentation.course.CourseViewMode
-import org.openedx.core.presentation.global.AppData
 import org.openedx.core.system.notifier.CourseDataUpdated
 import org.openedx.core.system.notifier.CourseNotifier
 import org.openedx.core.system.notifier.CourseSectionChanged
@@ -44,7 +43,6 @@ class CourseUnitContainerViewModel(
     private val notifier: CourseNotifier,
     private val analytics: CourseAnalytics,
     private val corePreferences: CorePreferences,
-    private val appData: AppData,
     iapNotifier: IAPNotifier,
 ) : BaseViewModel() {
 

--- a/course/src/main/java/org/openedx/course/presentation/unit/unlockcontent/UnlockContentFragment.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/unlockcontent/UnlockContentFragment.kt
@@ -142,7 +142,7 @@ class UnlockContentFragment : Fragment() {
 private fun GradedAssignmentLockedCard(
     modifier: Modifier = Modifier,
     uiState: UnlockContentUIState,
-    onUpgradeClick: () -> Unit = { }
+    onUpgradeClick: () -> Unit,
 ) {
     Column(
         modifier = modifier

--- a/course/src/main/java/org/openedx/course/presentation/unit/unlockcontent/UnlockContentFragment.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/unlockcontent/UnlockContentFragment.kt
@@ -70,9 +70,8 @@ class UnlockContentFragment : Fragment() {
                 }
 
                 when (uiEvent) {
-
-                    is UnlockContentUIAction.FullScreenLoader -> {
-                        IAPDialogFragment.newInstance((uiEvent as UnlockContentUIAction.FullScreenLoader).purchaseFlowData)
+                    UnlockContentUIAction.FullScreenLoader -> {
+                        IAPDialogFragment.newInstance(viewModel.purchaseData)
                             .show(
                                 requireActivity().supportFragmentManager,
                                 IAPDialogFragment.TAG
@@ -94,6 +93,15 @@ class UnlockContentFragment : Fragment() {
                                         iapException.requestType.request,
                                         iapException.getFormattedErrorMessage()
                                     )
+                                }
+
+                                IAPAction.ACTION_REFRESH,
+                                IAPAction.ACTION_RETRY -> {
+                                    IAPDialogFragment.newInstance(viewModel.purchaseData)
+                                        .show(
+                                            requireActivity().supportFragmentManager,
+                                            IAPDialogFragment.TAG
+                                        )
                                 }
 
                                 else -> {

--- a/course/src/main/java/org/openedx/course/presentation/unit/unlockcontent/UnlockContentFragment.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/unlockcontent/UnlockContentFragment.kt
@@ -131,33 +131,9 @@ class UnlockContentFragment : Fragment() {
 }
 
 @Composable
-fun GradedAssignmentLockedCard(
+private fun GradedAssignmentLockedCard(
     modifier: Modifier = Modifier,
     uiState: UnlockContentUIState,
-    onUpgradeClick: () -> Unit
-) {
-
-    when (uiState) {
-        is UnlockContentUIState.Loading -> {
-            ShowUpgradeBenefits(modifier = modifier, uiAction = UnlockContentUIAction.Loading)
-        }
-
-        is UnlockContentUIState.ProductData -> {
-            ShowUpgradeBenefits(
-                modifier = modifier,
-                uiAction = UnlockContentUIAction.UpgradeButton(formattedPrice = uiState.formattedPrice),
-                onUpgradeClick = onUpgradeClick
-            )
-        }
-
-        else -> {}
-    }
-}
-
-@Composable
-private fun ShowUpgradeBenefits(
-    modifier: Modifier = Modifier,
-    uiAction: UnlockContentUIAction,
     onUpgradeClick: () -> Unit = { }
 ) {
     Column(
@@ -205,16 +181,16 @@ private fun ShowUpgradeBenefits(
 
         Spacer(modifier = Modifier.height(18.dp))
 
-        when (uiAction) {
-            UnlockContentUIAction.Loading -> {
+        when (uiState) {
+            UnlockContentUIState.Loading -> {
                 CircularProgressIndicator(color = MaterialTheme.appColors.primary)
             }
 
-            is UnlockContentUIAction.UpgradeButton -> {
+            is UnlockContentUIState.ProductData -> {
                 OpenEdXBrandButton(
                     text = stringResource(
                         id = R.string.iap_upgrade_price,
-                        uiAction.formattedPrice,
+                        uiState.formattedPrice,
                     ),
                     onClick = onUpgradeClick,
                 )

--- a/course/src/main/java/org/openedx/course/presentation/unit/unlockcontent/UnlockContentFragment.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/unlockcontent/UnlockContentFragment.kt
@@ -1,0 +1,259 @@
+package org.openedx.course.presentation.unit.unlockcontent
+
+import android.content.res.Configuration
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material.icons.outlined.CheckCircle
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.core.os.bundleOf
+import androidx.fragment.app.Fragment
+import org.koin.androidx.viewmodel.ext.android.viewModel
+import org.koin.core.parameter.parametersOf
+import org.openedx.core.R
+import org.openedx.core.presentation.dialog.IAPDialogFragment
+import org.openedx.core.presentation.iap.IAPAction
+import org.openedx.core.ui.IAPErrorDialog
+import org.openedx.core.ui.OpenEdXBrandButton
+import org.openedx.core.ui.theme.OpenEdXTheme
+import org.openedx.core.ui.theme.appColors
+import org.openedx.core.ui.theme.appTypography
+
+class UnlockContentFragment : Fragment() {
+
+    private val viewModel by viewModel<UnlockContentViewModel> {
+        parametersOf(
+            requireArguments().getString(ARG_BLOCK_ID, ""),
+            requireArguments().getString(ARG_COURSE_ID, ""),
+        )
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ) = ComposeView(requireContext()).apply {
+        setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+        setContent {
+            OpenEdXTheme {
+                val uiState by viewModel.uiState.collectAsState()
+                val uiEvent by viewModel.uiEvent.collectAsState(UnlockContentUIAction.None)
+
+                GradedAssignmentLockedCard(uiState = uiState) {
+                    viewModel.startPurchaseFlow(requireActivity())
+                }
+
+                when (uiEvent) {
+
+                    is UnlockContentUIAction.FullScreenLoader -> {
+                        IAPDialogFragment.newInstance((uiEvent as UnlockContentUIAction.FullScreenLoader).purchaseFlowData)
+                            .show(
+                                requireActivity().supportFragmentManager,
+                                IAPDialogFragment.TAG
+                            )
+                    }
+
+                    is UnlockContentUIAction.Error -> {
+                        val iapException = (uiEvent as UnlockContentUIAction.Error).iapException
+                        IAPErrorDialog(iapException = iapException, onIAPAction = { iapAction ->
+                            when (iapAction) {
+
+                                IAPAction.ACTION_RELOAD_PRICE -> {
+                                    viewModel.reloadPrice(iapException)
+                                }
+
+                                IAPAction.ACTION_GET_HELP -> {
+                                    viewModel.showFeedbackScreen(
+                                        context,
+                                        iapException.requestType.request,
+                                        iapException.getFormattedErrorMessage()
+                                    )
+                                }
+
+                                else -> {
+                                    viewModel.refreshIAPState()
+                                }
+                            }
+                        })
+                    }
+
+                    UnlockContentUIAction.Clear -> {
+                        viewModel.refreshIAPState()
+                    }
+
+                    else -> {
+
+                    }
+                }
+            }
+        }
+    }
+
+    companion object {
+        private const val ARG_COURSE_ID = "courseId"
+        private const val ARG_BLOCK_ID = "blockId"
+
+        fun newInstance(courseId: String, blockId: String): UnlockContentFragment {
+            val fragment = UnlockContentFragment()
+            fragment.arguments = bundleOf(
+                ARG_COURSE_ID to courseId,
+                ARG_BLOCK_ID to blockId,
+            )
+            return fragment
+        }
+    }
+}
+
+@Composable
+fun GradedAssignmentLockedCard(
+    modifier: Modifier = Modifier,
+    uiState: UnlockContentUIState,
+    onUpgradeClick: () -> Unit
+) {
+
+    when (uiState) {
+        is UnlockContentUIState.Loading -> {
+            ShowUpgradeBenefits(modifier = modifier, uiAction = UnlockContentUIAction.Loading)
+        }
+
+        is UnlockContentUIState.ProductData -> {
+            ShowUpgradeBenefits(
+                modifier = modifier,
+                uiAction = UnlockContentUIAction.UpgradeButton(formattedPrice = uiState.formattedPrice),
+                onUpgradeClick = onUpgradeClick
+            )
+        }
+
+        else -> {}
+    }
+}
+
+@Composable
+private fun ShowUpgradeBenefits(
+    modifier: Modifier = Modifier,
+    uiAction: UnlockContentUIAction,
+    onUpgradeClick: () -> Unit = { }
+) {
+    Column(
+        modifier = modifier
+            .background(MaterialTheme.appColors.background)
+            .padding(24.dp)
+            .verticalScroll(rememberScrollState())
+            .fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                modifier = Modifier.size(24.dp),
+                imageVector = Icons.Default.Lock,
+                contentDescription = stringResource(id = R.string.iap_locked_content_title),
+                tint = MaterialTheme.appColors.textPrimary,
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = stringResource(id = R.string.iap_locked_content_title),
+                style = MaterialTheme.appTypography.titleMedium,
+                color = MaterialTheme.appColors.textPrimary
+            )
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Text(
+            modifier = Modifier.fillMaxWidth(),
+            text = stringResource(id = R.string.iap_locked_content_description),
+            style = MaterialTheme.appTypography.bodyMedium,
+            color = MaterialTheme.appColors.textPrimary,
+        )
+
+        Spacer(modifier = Modifier.height(18.dp))
+
+        UpgradeBenefit(stringResource(id = R.string.iap_earn_certificate))
+        UpgradeBenefit(stringResource(id = R.string.iap_unlock_access))
+        UpgradeBenefit(stringResource(id = R.string.iap_full_access_course))
+
+        Spacer(modifier = Modifier.height(18.dp))
+
+        when (uiAction) {
+            UnlockContentUIAction.Loading -> {
+                CircularProgressIndicator(color = MaterialTheme.appColors.primary)
+            }
+
+            is UnlockContentUIAction.UpgradeButton -> {
+                OpenEdXBrandButton(
+                    text = stringResource(
+                        id = R.string.iap_upgrade_price,
+                        uiAction.formattedPrice,
+                    ),
+                    onClick = onUpgradeClick,
+                )
+            }
+
+            else -> {}
+        }
+    }
+}
+
+@Composable
+private fun UpgradeBenefit(text: String) {
+    Row(
+        verticalAlignment = Alignment.Top,
+        modifier = Modifier
+            .padding(vertical = 8.dp)
+            .fillMaxWidth()
+    ) {
+        Icon(
+            imageVector = Icons.Outlined.CheckCircle,
+            contentDescription = text,
+            tint = MaterialTheme.appColors.successGreen,
+            modifier = Modifier
+                .size(20.dp)
+        )
+        Spacer(modifier = Modifier.width(12.dp))
+        Text(
+            text = text,
+            style = MaterialTheme.appTypography.bodyMedium,
+            color = MaterialTheme.appColors.textPrimary
+        )
+    }
+}
+
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_NO)
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun GradedAssignmentLockedCardPreview() {
+    OpenEdXTheme {
+        GradedAssignmentLockedCard(uiState = UnlockContentUIState.ProductData(formattedPrice = "$9.99")) {}
+    }
+}

--- a/course/src/main/java/org/openedx/course/presentation/unit/unlockcontent/UnlockContentUIState.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/unlockcontent/UnlockContentUIState.kt
@@ -1,0 +1,20 @@
+package org.openedx.course.presentation.unit.unlockcontent
+
+import org.openedx.core.domain.model.iap.PurchaseFlowData
+import org.openedx.core.exception.iap.IAPException
+import org.openedx.core.presentation.global.ErrorType
+
+sealed class UnlockContentUIState {
+    data object Loading : UnlockContentUIState()
+    data class ProductData(val formattedPrice: String) : UnlockContentUIState()
+    data class Error(val errorType: ErrorType) : UnlockContentUIState()
+}
+
+sealed class UnlockContentUIAction {
+    data object Loading : UnlockContentUIAction()
+    data class UpgradeButton(val formattedPrice: String) : UnlockContentUIAction()
+    data class FullScreenLoader(val purchaseFlowData: PurchaseFlowData) : UnlockContentUIAction()
+    data class Error(val iapException: IAPException) : UnlockContentUIAction()
+    data object Clear : UnlockContentUIAction()
+    data object None : UnlockContentUIAction()
+}

--- a/course/src/main/java/org/openedx/course/presentation/unit/unlockcontent/UnlockContentUIState.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/unlockcontent/UnlockContentUIState.kt
@@ -7,6 +7,7 @@ import org.openedx.core.presentation.global.ErrorType
 sealed class UnlockContentUIState {
     data object Loading : UnlockContentUIState()
     data class ProductData(val formattedPrice: String) : UnlockContentUIState()
+    data object Empty : UnlockContentUIState()  // No upgrade button in case of upgrade disabled
     data class Error(val errorType: ErrorType) : UnlockContentUIState()
 }
 

--- a/course/src/main/java/org/openedx/course/presentation/unit/unlockcontent/UnlockContentUIState.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/unlockcontent/UnlockContentUIState.kt
@@ -1,13 +1,11 @@
 package org.openedx.course.presentation.unit.unlockcontent
 
 import org.openedx.core.exception.iap.IAPException
-import org.openedx.core.presentation.global.ErrorType
 
 sealed class UnlockContentUIState {
     data object Loading : UnlockContentUIState()
     data class ProductData(val formattedPrice: String) : UnlockContentUIState()
     data object Empty : UnlockContentUIState()  // No upgrade button in case of upgrade disabled
-    data class Error(val errorType: ErrorType) : UnlockContentUIState()
 }
 
 sealed class UnlockContentUIAction {

--- a/course/src/main/java/org/openedx/course/presentation/unit/unlockcontent/UnlockContentUIState.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/unlockcontent/UnlockContentUIState.kt
@@ -1,6 +1,5 @@
 package org.openedx.course.presentation.unit.unlockcontent
 
-import org.openedx.core.domain.model.iap.PurchaseFlowData
 import org.openedx.core.exception.iap.IAPException
 import org.openedx.core.presentation.global.ErrorType
 
@@ -13,8 +12,7 @@ sealed class UnlockContentUIState {
 
 sealed class UnlockContentUIAction {
     data object Loading : UnlockContentUIAction()
-    data class UpgradeButton(val formattedPrice: String) : UnlockContentUIAction()
-    data class FullScreenLoader(val purchaseFlowData: PurchaseFlowData) : UnlockContentUIAction()
+    data object FullScreenLoader : UnlockContentUIAction()
     data class Error(val iapException: IAPException) : UnlockContentUIAction()
     data object Clear : UnlockContentUIAction()
     data object None : UnlockContentUIAction()

--- a/course/src/main/java/org/openedx/course/presentation/unit/unlockcontent/UnlockContentViewModel.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/unlockcontent/UnlockContentViewModel.kt
@@ -47,7 +47,10 @@ class UnlockContentViewModel(
                 if (purchase.getCourseId() == purchaseData.courseId) {
                     purchaseData.purchaseToken = purchase.purchaseToken
                     // execute order, consume order and course data update will performed behind the fullscreen loader
-                    _uiEvent.emit(UnlockContentUIAction.FullScreenLoader(purchaseData))
+                    _uiEvent.emit(UnlockContentUIAction.FullScreenLoader)
+                    purchaseData.formattedPrice?.let {
+                        _uiState.value = UnlockContentUIState.ProductData(it)
+                    }
                 }
             }
         }
@@ -74,7 +77,7 @@ class UnlockContentViewModel(
     val uiMessage: SharedFlow<UIMessage>
         get() = _uiMessage.asSharedFlow()
 
-    private val purchaseData: PurchaseFlowData = PurchaseFlowData(
+    val purchaseData = PurchaseFlowData(
         iapFlow = IAPFlow.USER_INITIATED,
         screenName = IAPFlowSource.COURSE_COMPONENT.screen,
         courseId = courseId,
@@ -221,7 +224,7 @@ class UnlockContentViewModel(
     fun refreshIAPState() {
         viewModelScope.launch {
             _uiEvent.emit(UnlockContentUIAction.None)
-            purchaseData.reset()
+            purchaseData.resetSessionData()
             loadPrice()
         }
     }

--- a/course/src/main/java/org/openedx/course/presentation/unit/unlockcontent/UnlockContentViewModel.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/unlockcontent/UnlockContentViewModel.kt
@@ -1,0 +1,230 @@
+package org.openedx.course.presentation.unit.unlockcontent
+
+import android.content.Context
+import androidx.fragment.app.FragmentActivity
+import androidx.lifecycle.viewModelScope
+import com.android.billingclient.api.BillingClient
+import com.android.billingclient.api.Purchase
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import org.openedx.core.BaseViewModel
+import org.openedx.core.R
+import org.openedx.core.UIMessage
+import org.openedx.core.domain.interactor.IAPInteractor
+import org.openedx.core.domain.model.iap.IAPFlow
+import org.openedx.core.domain.model.iap.IAPFlowSource
+import org.openedx.core.domain.model.iap.PurchaseFlowData
+import org.openedx.core.exception.iap.IAPException
+import org.openedx.core.module.billing.BillingProcessor
+import org.openedx.core.module.billing.getCourseId
+import org.openedx.core.module.billing.getPriceAmount
+import org.openedx.core.presentation.IAPAnalytics
+import org.openedx.core.presentation.iap.IAPAction
+import org.openedx.core.presentation.iap.IAPEventLogger
+import org.openedx.core.presentation.iap.IAPRequestType
+import org.openedx.core.system.ResourceManager
+import org.openedx.core.utils.TimeUtils
+import org.openedx.course.domain.interactor.CourseInteractor
+
+class UnlockContentViewModel(
+    val blockId: String,
+    val courseId: String,
+    private val courseInteractor: CourseInteractor,
+    private val iapInteractor: IAPInteractor,
+    private val resourceManager: ResourceManager,
+    analytics: IAPAnalytics,
+) : BaseViewModel() {
+
+    private val purchaseListeners = object : BillingProcessor.PurchaseListeners {
+        override fun onPurchaseComplete(purchase: Purchase) {
+            viewModelScope.launch {
+                if (purchase.getCourseId() == purchaseData.courseId) {
+                    purchaseData.purchaseToken = purchase.purchaseToken
+                    // execute order, consume order and course data update will performed behind the fullscreen loader
+                    _uiEvent.emit(UnlockContentUIAction.FullScreenLoader(purchaseData))
+                }
+            }
+        }
+
+        override fun onPurchaseCancel(responseCode: Int, message: String) {
+            updateErrorState(
+                IAPException(
+                    IAPRequestType.PAYMENT_SDK_CODE,
+                    httpErrorCode = responseCode,
+                    errorMessage = message
+                )
+            )
+        }
+    }
+
+    private val _uiState = MutableStateFlow<UnlockContentUIState>(UnlockContentUIState.Loading)
+    val uiState: StateFlow<UnlockContentUIState>
+        get() = _uiState.asStateFlow()
+
+    private val _uiEvent = MutableSharedFlow<UnlockContentUIAction>()
+    val uiEvent = _uiEvent.asSharedFlow()
+
+    private val _uiMessage = MutableSharedFlow<UIMessage>()
+    val uiMessage: SharedFlow<UIMessage>
+        get() = _uiMessage.asSharedFlow()
+
+    private val purchaseData: PurchaseFlowData = PurchaseFlowData(
+        iapFlow = IAPFlow.USER_INITIATED,
+        screenName = IAPFlowSource.COURSE_COMPONENT.screen,
+        courseId = courseId,
+        courseName = null,
+        courseExpiresDate = null,
+        isSelfPaced = null,
+        componentId = blockId,
+        productInfo = null,
+    )
+
+    private val eventLogger = IAPEventLogger(
+        analytics = analytics,
+        isSilentIAPFlow = false,
+        purchaseFlowData = purchaseData
+    )
+
+    init {
+        viewModelScope.launch(Dispatchers.IO) {
+            fetchCourseData()
+            loadPrice()
+            eventLogger.loadIAPScreenEvent()
+        }
+    }
+
+    private suspend fun fetchCourseData() {
+        val courseEnrollmentDetails = courseInteractor.getEnrollmentDetails(courseId)
+        purchaseData.apply {
+            courseName = courseEnrollmentDetails.courseInfoOverview.name
+            isSelfPaced = courseEnrollmentDetails.courseInfoOverview.isSelfPaced
+            productInfo = courseEnrollmentDetails.courseInfoOverview.productInfo
+        }
+    }
+
+    private suspend fun loadPrice() {
+        purchaseData.takeIf { it.courseId != null && it.productInfo != null }
+            ?.apply {
+                _uiState.value = UnlockContentUIState.Loading
+                runCatching {
+                    iapInteractor.loadPrice(purchaseData.productInfo?.storeSku!!)
+                }.onSuccess {
+                    this.formattedPrice = it.formattedPrice
+                    this.price = it.getPriceAmount()
+                    this.currencyCode = it.priceCurrencyCode
+                    _uiState.value =
+                        UnlockContentUIState.ProductData(formattedPrice = it.formattedPrice)
+                }.onFailure {
+                    if (it is IAPException) {
+                        updateErrorState(it)
+                    }
+                }
+            } ?: run {
+            updateErrorState(
+                IAPException(
+                    requestType = IAPRequestType.PRICE_CODE,
+                    httpErrorCode = IAPRequestType.PRICE_CODE.hashCode(),
+                    errorMessage = "Product SKU is not provided in the request."
+                )
+            )
+        }
+    }
+
+    fun startPurchaseFlow(activity: FragmentActivity) {
+        eventLogger.upgradeNowClickedEvent()
+        _uiState.value = UnlockContentUIState.Loading
+        purchaseData.flowStartTime = TimeUtils.getCurrentTime()
+        val productInfo = purchaseData.productInfo
+
+        if (productInfo == null) {
+            // Handle missing data error
+            updateErrorState(
+                IAPException(
+                    requestType = IAPRequestType.NO_SKU_CODE,
+                    httpErrorCode = IAPRequestType.NO_SKU_CODE.hashCode(),
+                    errorMessage = ""
+                )
+            )
+            return
+        }
+        checkCourseMode(activity)
+    }
+
+    private fun checkCourseMode(activity: FragmentActivity) {
+        viewModelScope.launch {
+            val isAuditMode = try {
+                courseInteractor.getEnrollmentDetails(courseId).enrollmentDetails.isAuditMode
+            } catch (_: Exception) {
+                true
+            }
+
+            if (isAuditMode) {
+                purchaseItem(activity)
+            } else {
+                updateErrorState(
+                    IAPException(
+                        requestType = IAPRequestType.PURCHASE_PRECHECK_CODE,
+                        httpErrorCode = 409, // Purchase already completed; enforcing ACTION_REFRESH to update the state.
+                        errorMessage = resourceManager.getString(R.string.iap_course_already_paid_for_message)
+                    )
+                )
+            }
+        }
+    }
+
+    private fun purchaseItem(activity: FragmentActivity) {
+        viewModelScope.launch(Dispatchers.IO) {
+            takeIf {
+                purchaseData.productInfo != null
+            }?.apply {
+                iapInteractor.purchaseItem(
+                    activity,
+                    courseId = courseId,
+                    productInfo = purchaseData.productInfo!!,
+                    purchaseListeners = purchaseListeners
+                )
+            }
+        }
+    }
+
+    private fun updateErrorState(iapException: IAPException) {
+        eventLogger.logExceptionEvent(iapException)
+        viewModelScope.launch {
+            if (BillingClient.BillingResponseCode.USER_CANCELED != iapException.httpErrorCode) {
+                _uiEvent.emit(UnlockContentUIAction.Error(iapException))
+            } else {
+                _uiEvent.emit(UnlockContentUIAction.Clear)
+            }
+        }
+    }
+
+    fun reloadPrice(iapException: IAPException) {
+        viewModelScope.launch(Dispatchers.IO) {
+            eventLogger.logIAPErrorActionEvent(
+                alertType = iapException.requestType.request,
+                action = IAPAction.ACTION_CLOSE.action
+            )
+            refreshIAPState()
+        }
+    }
+
+    fun refreshIAPState() {
+        viewModelScope.launch {
+            _uiEvent.emit(UnlockContentUIAction.None)
+            purchaseData.reset()
+            loadPrice()
+        }
+    }
+
+    fun showFeedbackScreen(context: Context, requestType: String, message: String) {
+        iapInteractor.showFeedbackScreen(context, message)
+        eventLogger.logIAPErrorActionEvent(requestType, IAPAction.ACTION_GET_HELP.action)
+        refreshIAPState()
+    }
+}

--- a/course/src/main/java/org/openedx/course/presentation/unit/unlockcontent/UnlockContentViewModel.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/unlockcontent/UnlockContentViewModel.kt
@@ -88,11 +88,7 @@ class UnlockContentViewModel(
         productInfo = null,
     )
 
-    private val eventLogger = IAPEventLogger(
-        analytics = analytics,
-        isSilentIAPFlow = false,
-        purchaseFlowData = purchaseData
-    )
+    private val eventLogger = IAPEventLogger(analytics = analytics, purchaseFlowData = purchaseData)
 
     init {
         viewModelScope.launch(Dispatchers.IO) {

--- a/course/src/main/java/org/openedx/course/presentation/unit/unlockcontent/UnlockContentViewModel.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/unlockcontent/UnlockContentViewModel.kt
@@ -94,7 +94,11 @@ class UnlockContentViewModel(
     init {
         viewModelScope.launch(Dispatchers.IO) {
             fetchCourseData()
-            loadPrice()
+            if (iapInteractor.isUpgradeEnabled) {
+                loadPrice()
+            } else {
+                _uiState.value = UnlockContentUIState.Empty
+            }
             eventLogger.loadIAPScreenEvent()
         }
     }

--- a/course/src/test/java/org/openedx/course/presentation/outline/CourseOutlineViewModelTest.kt
+++ b/course/src/test/java/org/openedx/course/presentation/outline/CourseOutlineViewModelTest.kt
@@ -36,6 +36,7 @@ import org.openedx.core.config.Config
 import org.openedx.core.data.model.DateType
 import org.openedx.core.data.storage.CorePreferences
 import org.openedx.core.domain.model.AssignmentProgress
+import org.openedx.core.domain.model.AuthorizationDenialReason
 import org.openedx.core.domain.model.Block
 import org.openedx.core.domain.model.BlockCounts
 import org.openedx.core.domain.model.CourseAccessDetails
@@ -116,6 +117,7 @@ class CourseOutlineViewModelTest {
             descendantsType = BlockType.HTML,
             completion = 0.0,
             assignmentProgress = assignmentProgress,
+            authorizationDenialReason = AuthorizationDenialReason.UNKNOWN,
             due = Date()
         ),
         Block(
@@ -134,6 +136,7 @@ class CourseOutlineViewModelTest {
             descendantsType = BlockType.HTML,
             completion = 0.0,
             assignmentProgress = assignmentProgress,
+            authorizationDenialReason = AuthorizationDenialReason.UNKNOWN,
             due = Date()
         ),
         Block(
@@ -152,6 +155,7 @@ class CourseOutlineViewModelTest {
             descendantsType = BlockType.HTML,
             completion = 0.0,
             assignmentProgress = assignmentProgress,
+            authorizationDenialReason = AuthorizationDenialReason.UNKNOWN,
             due = Date()
         )
     )

--- a/course/src/test/java/org/openedx/course/presentation/section/CourseSectionViewModelTest.kt
+++ b/course/src/test/java/org/openedx/course/presentation/section/CourseSectionViewModelTest.kt
@@ -28,6 +28,7 @@ import org.openedx.core.R
 import org.openedx.core.UIMessage
 import org.openedx.core.data.storage.CorePreferences
 import org.openedx.core.domain.model.AssignmentProgress
+import org.openedx.core.domain.model.AuthorizationDenialReason
 import org.openedx.core.domain.model.Block
 import org.openedx.core.domain.model.BlockCounts
 import org.openedx.core.domain.model.CourseAccessDetails
@@ -96,6 +97,7 @@ class CourseSectionViewModelTest {
             descendantsType = BlockType.HTML,
             completion = 0.0,
             assignmentProgress = assignmentProgress,
+            authorizationDenialReason = AuthorizationDenialReason.UNKNOWN,
             due = Date()
         ),
         Block(
@@ -114,6 +116,7 @@ class CourseSectionViewModelTest {
             descendantsType = BlockType.HTML,
             completion = 0.0,
             assignmentProgress = assignmentProgress,
+            authorizationDenialReason = AuthorizationDenialReason.UNKNOWN,
             due = Date()
         ),
         Block(
@@ -132,6 +135,7 @@ class CourseSectionViewModelTest {
             descendantsType = BlockType.HTML,
             completion = 0.0,
             assignmentProgress = assignmentProgress,
+            authorizationDenialReason = AuthorizationDenialReason.UNKNOWN,
             due = Date()
         )
     )

--- a/course/src/test/java/org/openedx/course/presentation/unit/container/CourseUnitContainerViewModelTest.kt
+++ b/course/src/test/java/org/openedx/course/presentation/unit/container/CourseUnitContainerViewModelTest.kt
@@ -30,6 +30,7 @@ import org.openedx.core.domain.model.CourseAccessDetails
 import org.openedx.core.domain.model.CourseStructure
 import org.openedx.core.domain.model.CoursewareAccess
 import org.openedx.core.domain.model.EnrollmentDetails
+import org.openedx.core.domain.model.IAPConfig
 import org.openedx.core.presentation.course.CourseViewMode
 import org.openedx.core.presentation.global.AppData
 import org.openedx.core.system.notifier.CourseNotifier
@@ -180,6 +181,8 @@ class CourseUnitContainerViewModelTest {
         productInfo = null
     )
 
+    private val iapConfig = IAPConfig(false, "prefix", listOf())
+
     @Before
     fun setUp() {
         Dispatchers.setMain(dispatcher)
@@ -197,6 +200,7 @@ class CourseUnitContainerViewModelTest {
     fun `getBlocks no internet connection exception`() = runTest {
         every { notifier.notifier } returns MutableSharedFlow()
         every { iapNotifier.notifier } returns MutableSharedFlow()
+        every { corePreferences.appConfig.iapConfig } returns iapConfig
 
         val viewModel =
             CourseUnitContainerViewModel(
@@ -224,6 +228,7 @@ class CourseUnitContainerViewModelTest {
     fun `getBlocks unknown exception`() = runTest {
         every { notifier.notifier } returns MutableSharedFlow()
         every { iapNotifier.notifier } returns MutableSharedFlow()
+        every { corePreferences.appConfig.iapConfig } returns iapConfig
 
         val viewModel =
             CourseUnitContainerViewModel(
@@ -251,6 +256,7 @@ class CourseUnitContainerViewModelTest {
     fun `getBlocks unknown success`() = runTest {
         every { notifier.notifier } returns MutableSharedFlow()
         every { iapNotifier.notifier } returns MutableSharedFlow()
+        every { corePreferences.appConfig.iapConfig } returns iapConfig
 
         val viewModel =
             CourseUnitContainerViewModel(
@@ -280,6 +286,7 @@ class CourseUnitContainerViewModelTest {
     fun setupCurrentIndex() = runTest {
         every { notifier.notifier } returns MutableSharedFlow()
         every { iapNotifier.notifier } returns MutableSharedFlow()
+        every { corePreferences.appConfig.iapConfig } returns iapConfig
 
         val viewModel =
             CourseUnitContainerViewModel(
@@ -307,6 +314,7 @@ class CourseUnitContainerViewModelTest {
     fun `getCurrentBlock test`() = runTest {
         every { notifier.notifier } returns MutableSharedFlow()
         every { iapNotifier.notifier } returns MutableSharedFlow()
+        every { corePreferences.appConfig.iapConfig } returns iapConfig
 
         val viewModel =
             CourseUnitContainerViewModel(
@@ -336,6 +344,7 @@ class CourseUnitContainerViewModelTest {
     fun `moveToPrevBlock null`() = runTest {
         every { notifier.notifier } returns MutableSharedFlow()
         every { iapNotifier.notifier } returns MutableSharedFlow()
+        every { corePreferences.appConfig.iapConfig } returns iapConfig
 
         val viewModel =
             CourseUnitContainerViewModel(
@@ -365,6 +374,7 @@ class CourseUnitContainerViewModelTest {
     fun `moveToPrevBlock not null`() = runTest {
         every { notifier.notifier } returns MutableSharedFlow()
         every { iapNotifier.notifier } returns MutableSharedFlow()
+        every { corePreferences.appConfig.iapConfig } returns iapConfig
 
         val viewModel =
             CourseUnitContainerViewModel(
@@ -394,6 +404,7 @@ class CourseUnitContainerViewModelTest {
     fun `moveToNextBlock null`() = runTest {
         every { notifier.notifier } returns MutableSharedFlow()
         every { iapNotifier.notifier } returns MutableSharedFlow()
+        every { corePreferences.appConfig.iapConfig } returns iapConfig
 
         val viewModel =
             CourseUnitContainerViewModel(
@@ -423,6 +434,7 @@ class CourseUnitContainerViewModelTest {
     fun `moveToNextBlock not null`() = runTest {
         every { notifier.notifier } returns MutableSharedFlow()
         every { iapNotifier.notifier } returns MutableSharedFlow()
+        every { corePreferences.appConfig.iapConfig } returns iapConfig
 
         val viewModel =
             CourseUnitContainerViewModel(
@@ -452,6 +464,7 @@ class CourseUnitContainerViewModelTest {
     fun `currentIndex isLastIndex`() = runTest {
         every { notifier.notifier } returns MutableSharedFlow()
         every { iapNotifier.notifier } returns MutableSharedFlow()
+        every { corePreferences.appConfig.iapConfig } returns iapConfig
 
         val viewModel =
             CourseUnitContainerViewModel(

--- a/course/src/test/java/org/openedx/course/presentation/unit/container/CourseUnitContainerViewModelTest.kt
+++ b/course/src/test/java/org/openedx/course/presentation/unit/container/CourseUnitContainerViewModelTest.kt
@@ -32,7 +32,6 @@ import org.openedx.core.domain.model.CoursewareAccess
 import org.openedx.core.domain.model.EnrollmentDetails
 import org.openedx.core.domain.model.IAPConfig
 import org.openedx.core.presentation.course.CourseViewMode
-import org.openedx.core.presentation.global.AppData
 import org.openedx.core.system.notifier.CourseNotifier
 import org.openedx.core.system.notifier.IAPNotifier
 import org.openedx.core.utils.Logger
@@ -54,7 +53,6 @@ class CourseUnitContainerViewModelTest {
     private val notifier = mockk<CourseNotifier>()
     private val analytics = mockk<CourseAnalytics>()
     private val corePreferences = mockk<CorePreferences>()
-    private val appData = mockk<AppData>()
     private val iapNotifier = mockk<IAPNotifier>()
 
     private val assignmentProgress = AssignmentProgress(
@@ -211,7 +209,6 @@ class CourseUnitContainerViewModelTest {
                 notifier,
                 analytics,
                 corePreferences,
-                appData,
                 iapNotifier,
             )
 
@@ -239,7 +236,6 @@ class CourseUnitContainerViewModelTest {
                 notifier,
                 analytics,
                 corePreferences,
-                appData,
                 iapNotifier,
             )
 
@@ -267,7 +263,6 @@ class CourseUnitContainerViewModelTest {
                 notifier,
                 analytics,
                 corePreferences,
-                appData,
                 iapNotifier,
             )
 
@@ -297,7 +292,6 @@ class CourseUnitContainerViewModelTest {
                 notifier,
                 analytics,
                 corePreferences,
-                appData,
                 iapNotifier,
             )
         coEvery { interactor.getCourseStructure(any()) } returns courseStructure
@@ -325,7 +319,6 @@ class CourseUnitContainerViewModelTest {
                 notifier,
                 analytics,
                 corePreferences,
-                appData,
                 iapNotifier,
             )
         coEvery { interactor.getCourseStructure(any()) } returns courseStructure
@@ -355,7 +348,6 @@ class CourseUnitContainerViewModelTest {
                 notifier,
                 analytics,
                 corePreferences,
-                appData,
                 iapNotifier,
             )
         coEvery { interactor.getCourseStructure(any()) } returns courseStructure
@@ -385,7 +377,6 @@ class CourseUnitContainerViewModelTest {
                 notifier,
                 analytics,
                 corePreferences,
-                appData,
                 iapNotifier,
             )
         coEvery { interactor.getCourseStructure(any()) } returns courseStructure
@@ -415,7 +406,6 @@ class CourseUnitContainerViewModelTest {
                 notifier,
                 analytics,
                 corePreferences,
-                appData,
                 iapNotifier,
             )
         coEvery { interactor.getCourseStructure(any()) } returns courseStructure
@@ -445,7 +435,6 @@ class CourseUnitContainerViewModelTest {
                 notifier,
                 analytics,
                 corePreferences,
-                appData,
                 iapNotifier,
             )
         coEvery { interactor.getCourseStructure("") } returns courseStructure
@@ -475,7 +464,6 @@ class CourseUnitContainerViewModelTest {
                 notifier,
                 analytics,
                 corePreferences,
-                appData,
                 iapNotifier,
             )
         coEvery { interactor.getCourseStructure(any()) } returns courseStructure

--- a/course/src/test/java/org/openedx/course/presentation/unit/container/CourseUnitContainerViewModelTest.kt
+++ b/course/src/test/java/org/openedx/course/presentation/unit/container/CourseUnitContainerViewModelTest.kt
@@ -23,6 +23,7 @@ import org.openedx.core.BlockType
 import org.openedx.core.config.Config
 import org.openedx.core.data.storage.CorePreferences
 import org.openedx.core.domain.model.AssignmentProgress
+import org.openedx.core.domain.model.AuthorizationDenialReason
 import org.openedx.core.domain.model.Block
 import org.openedx.core.domain.model.BlockCounts
 import org.openedx.core.domain.model.CourseAccessDetails
@@ -30,7 +31,9 @@ import org.openedx.core.domain.model.CourseStructure
 import org.openedx.core.domain.model.CoursewareAccess
 import org.openedx.core.domain.model.EnrollmentDetails
 import org.openedx.core.presentation.course.CourseViewMode
+import org.openedx.core.presentation.global.AppData
 import org.openedx.core.system.notifier.CourseNotifier
+import org.openedx.core.system.notifier.IAPNotifier
 import org.openedx.core.utils.Logger
 import org.openedx.course.domain.interactor.CourseInteractor
 import org.openedx.course.presentation.CourseAnalytics
@@ -50,6 +53,8 @@ class CourseUnitContainerViewModelTest {
     private val notifier = mockk<CourseNotifier>()
     private val analytics = mockk<CourseAnalytics>()
     private val corePreferences = mockk<CorePreferences>()
+    private val appData = mockk<AppData>()
+    private val iapNotifier = mockk<IAPNotifier>()
 
     private val assignmentProgress = AssignmentProgress(
         assignmentType = "Homework",
@@ -74,6 +79,7 @@ class CourseUnitContainerViewModelTest {
             descendantsType = BlockType.HTML,
             completion = 0.0,
             assignmentProgress = assignmentProgress,
+            authorizationDenialReason = AuthorizationDenialReason.UNKNOWN,
             due = Date()
         ),
         Block(
@@ -92,6 +98,7 @@ class CourseUnitContainerViewModelTest {
             descendantsType = BlockType.HTML,
             completion = 0.0,
             assignmentProgress = assignmentProgress,
+            authorizationDenialReason = AuthorizationDenialReason.UNKNOWN,
             due = Date()
         ),
         Block(
@@ -110,6 +117,7 @@ class CourseUnitContainerViewModelTest {
             descendantsType = BlockType.HTML,
             completion = 0.0,
             assignmentProgress = assignmentProgress,
+            authorizationDenialReason = AuthorizationDenialReason.UNKNOWN,
             due = Date()
         ),
         Block(
@@ -128,6 +136,7 @@ class CourseUnitContainerViewModelTest {
             descendantsType = BlockType.HTML,
             completion = 0.0,
             assignmentProgress = assignmentProgress,
+            authorizationDenialReason = AuthorizationDenialReason.UNKNOWN,
             due = Date()
         )
 
@@ -187,6 +196,8 @@ class CourseUnitContainerViewModelTest {
     @Test
     fun `getBlocks no internet connection exception`() = runTest {
         every { notifier.notifier } returns MutableSharedFlow()
+        every { iapNotifier.notifier } returns MutableSharedFlow()
+
         val viewModel =
             CourseUnitContainerViewModel(
                 "",
@@ -195,7 +206,9 @@ class CourseUnitContainerViewModelTest {
                 interactor,
                 notifier,
                 analytics,
-                corePreferences
+                corePreferences,
+                appData,
+                iapNotifier,
             )
 
         coEvery { interactor.getCourseStructure(any()) } throws UnknownHostException()
@@ -210,6 +223,8 @@ class CourseUnitContainerViewModelTest {
     @Test
     fun `getBlocks unknown exception`() = runTest {
         every { notifier.notifier } returns MutableSharedFlow()
+        every { iapNotifier.notifier } returns MutableSharedFlow()
+
         val viewModel =
             CourseUnitContainerViewModel(
                 "",
@@ -218,7 +233,9 @@ class CourseUnitContainerViewModelTest {
                 interactor,
                 notifier,
                 analytics,
-                corePreferences
+                corePreferences,
+                appData,
+                iapNotifier,
             )
 
         coEvery { interactor.getCourseStructure(any()) } throws UnknownHostException()
@@ -233,6 +250,8 @@ class CourseUnitContainerViewModelTest {
     @Test
     fun `getBlocks unknown success`() = runTest {
         every { notifier.notifier } returns MutableSharedFlow()
+        every { iapNotifier.notifier } returns MutableSharedFlow()
+
         val viewModel =
             CourseUnitContainerViewModel(
                 "",
@@ -241,7 +260,9 @@ class CourseUnitContainerViewModelTest {
                 interactor,
                 notifier,
                 analytics,
-                corePreferences
+                corePreferences,
+                appData,
+                iapNotifier,
             )
 
         coEvery { interactor.getCourseStructure(any()) } returns courseStructure
@@ -258,6 +279,8 @@ class CourseUnitContainerViewModelTest {
     @Test
     fun setupCurrentIndex() = runTest {
         every { notifier.notifier } returns MutableSharedFlow()
+        every { iapNotifier.notifier } returns MutableSharedFlow()
+
         val viewModel =
             CourseUnitContainerViewModel(
                 "",
@@ -266,7 +289,9 @@ class CourseUnitContainerViewModelTest {
                 interactor,
                 notifier,
                 analytics,
-                corePreferences
+                corePreferences,
+                appData,
+                iapNotifier,
             )
         coEvery { interactor.getCourseStructure(any()) } returns courseStructure
         coEvery { interactor.getCourseStructureForVideos(any()) } returns courseStructure
@@ -281,6 +306,8 @@ class CourseUnitContainerViewModelTest {
     @Test
     fun `getCurrentBlock test`() = runTest {
         every { notifier.notifier } returns MutableSharedFlow()
+        every { iapNotifier.notifier } returns MutableSharedFlow()
+
         val viewModel =
             CourseUnitContainerViewModel(
                 "",
@@ -289,7 +316,9 @@ class CourseUnitContainerViewModelTest {
                 interactor,
                 notifier,
                 analytics,
-                corePreferences
+                corePreferences,
+                appData,
+                iapNotifier,
             )
         coEvery { interactor.getCourseStructure(any()) } returns courseStructure
         coEvery { interactor.getCourseStructureForVideos(any()) } returns courseStructure
@@ -306,6 +335,8 @@ class CourseUnitContainerViewModelTest {
     @Test
     fun `moveToPrevBlock null`() = runTest {
         every { notifier.notifier } returns MutableSharedFlow()
+        every { iapNotifier.notifier } returns MutableSharedFlow()
+
         val viewModel =
             CourseUnitContainerViewModel(
                 "",
@@ -314,7 +345,9 @@ class CourseUnitContainerViewModelTest {
                 interactor,
                 notifier,
                 analytics,
-                corePreferences
+                corePreferences,
+                appData,
+                iapNotifier,
             )
         coEvery { interactor.getCourseStructure(any()) } returns courseStructure
         coEvery { interactor.getCourseStructureForVideos(any()) } returns courseStructure
@@ -331,6 +364,8 @@ class CourseUnitContainerViewModelTest {
     @Test
     fun `moveToPrevBlock not null`() = runTest {
         every { notifier.notifier } returns MutableSharedFlow()
+        every { iapNotifier.notifier } returns MutableSharedFlow()
+
         val viewModel =
             CourseUnitContainerViewModel(
                 "",
@@ -339,7 +374,9 @@ class CourseUnitContainerViewModelTest {
                 interactor,
                 notifier,
                 analytics,
-                corePreferences
+                corePreferences,
+                appData,
+                iapNotifier,
             )
         coEvery { interactor.getCourseStructure(any()) } returns courseStructure
         coEvery { interactor.getCourseStructureForVideos(any()) } returns courseStructure
@@ -356,6 +393,8 @@ class CourseUnitContainerViewModelTest {
     @Test
     fun `moveToNextBlock null`() = runTest {
         every { notifier.notifier } returns MutableSharedFlow()
+        every { iapNotifier.notifier } returns MutableSharedFlow()
+
         val viewModel =
             CourseUnitContainerViewModel(
                 "",
@@ -364,7 +403,9 @@ class CourseUnitContainerViewModelTest {
                 interactor,
                 notifier,
                 analytics,
-                corePreferences
+                corePreferences,
+                appData,
+                iapNotifier,
             )
         coEvery { interactor.getCourseStructure(any()) } returns courseStructure
         coEvery { interactor.getCourseStructureForVideos(any()) } returns courseStructure
@@ -381,6 +422,8 @@ class CourseUnitContainerViewModelTest {
     @Test
     fun `moveToNextBlock not null`() = runTest {
         every { notifier.notifier } returns MutableSharedFlow()
+        every { iapNotifier.notifier } returns MutableSharedFlow()
+
         val viewModel =
             CourseUnitContainerViewModel(
                 "",
@@ -389,7 +432,9 @@ class CourseUnitContainerViewModelTest {
                 interactor,
                 notifier,
                 analytics,
-                corePreferences
+                corePreferences,
+                appData,
+                iapNotifier,
             )
         coEvery { interactor.getCourseStructure("") } returns courseStructure
         coEvery { interactor.getCourseStructureForVideos("") } returns courseStructure
@@ -406,6 +451,8 @@ class CourseUnitContainerViewModelTest {
     @Test
     fun `currentIndex isLastIndex`() = runTest {
         every { notifier.notifier } returns MutableSharedFlow()
+        every { iapNotifier.notifier } returns MutableSharedFlow()
+
         val viewModel =
             CourseUnitContainerViewModel(
                 "",
@@ -414,7 +461,9 @@ class CourseUnitContainerViewModelTest {
                 interactor,
                 notifier,
                 analytics,
-                corePreferences
+                corePreferences,
+                appData,
+                iapNotifier,
             )
         coEvery { interactor.getCourseStructure(any()) } returns courseStructure
         coEvery { interactor.getCourseStructureForVideos(any()) } returns courseStructure
@@ -426,5 +475,4 @@ class CourseUnitContainerViewModelTest {
         coVerify(exactly = 0) { interactor.getCourseStructure(any()) }
         coVerify(exactly = 1) { interactor.getCourseStructureForVideos(any()) }
     }
-
 }

--- a/course/src/test/java/org/openedx/course/presentation/videos/CourseVideoViewModelTest.kt
+++ b/course/src/test/java/org/openedx/course/presentation/videos/CourseVideoViewModelTest.kt
@@ -33,6 +33,7 @@ import org.openedx.core.UIMessage
 import org.openedx.core.config.Config
 import org.openedx.core.data.storage.CorePreferences
 import org.openedx.core.domain.model.AssignmentProgress
+import org.openedx.core.domain.model.AuthorizationDenialReason
 import org.openedx.core.domain.model.Block
 import org.openedx.core.domain.model.BlockCounts
 import org.openedx.core.domain.model.CourseAccessDetails
@@ -105,6 +106,7 @@ class CourseVideoViewModelTest {
             descendantsType = BlockType.HTML,
             completion = 0.0,
             assignmentProgress = assignmentProgress,
+            authorizationDenialReason = AuthorizationDenialReason.UNKNOWN,
             due = Date()
         ),
         Block(
@@ -123,6 +125,7 @@ class CourseVideoViewModelTest {
             descendantsType = BlockType.HTML,
             completion = 0.0,
             assignmentProgress = assignmentProgress,
+            authorizationDenialReason = AuthorizationDenialReason.UNKNOWN,
             due = Date()
         ),
         Block(
@@ -141,6 +144,7 @@ class CourseVideoViewModelTest {
             descendantsType = BlockType.HTML,
             completion = 0.0,
             assignmentProgress = assignmentProgress,
+            authorizationDenialReason = AuthorizationDenialReason.UNKNOWN,
             due = Date()
         )
     )


### PR DESCRIPTION
### Description

[LEARNER-10028](https://2u-internal.atlassian.net/browse/LEARNER-10028), [LEARNER-10635](https://2u-internal.atlassian.net/browse/LEARNER-10635)

- Design the value prop for the locked content.
- IAP flow improvement after bumping the block API to v4.
- Add Loading course price on the upgrade button.
- Integrate necessary APIs on interaction with the upgrade button.
- Integrate the course upgrade (IAP flow and error handling).
- Relevant analytics events are triggered throughout the flow.
- Fix unit test cases.
- Migrate to the CT backend.
- Replace legacy e-commerce endpoints with the new single API provided by the backend team.
- Ensure correct API calls are made when users interact with upgrade buttons in content.
- Handle the full course upgrade flow via IAP from locked components.
- Revise and align error handling and analytics with the updated integration.
- Ensure payment processor is updated to "android_iap".

Example: 
<video src="https://github.com/user-attachments/assets/1a3a60f2-b8ef-4f13-bb30-b8aab2e06b34" height="512"/>
