### PR TITLE
fix: Captions Disappear After Rotating Device to Landscape Mode

### DIFF
--- a/course/src/main/java/org/openedx/course/presentation/unit/video/EncodedVideoUnitViewModel.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/video/EncodedVideoUnitViewModel.kt
@@ -2,7 +2,7 @@ package org.openedx.course.presentation.unit.video
 
 import android.annotation.SuppressLint
 import android.content.Context
-import android.net.Uri
+import androidx.core.net.toUri
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.asFlow
 import androidx.lifecycle.viewModelScope
@@ -108,7 +108,7 @@ class EncodedVideoUnitViewModel(
                 val selectionFlags =
                     if (language == state.value.selectedLanguage) C.SELECTION_FLAG_DEFAULT else 0
 
-                MediaItem.SubtitleConfiguration.Builder(Uri.parse(uri))
+                MediaItem.SubtitleConfiguration.Builder(uri.toUri())
                     .setMimeType(MimeTypes.APPLICATION_SUBRIP)
                     .setSelectionFlags(selectionFlags)
                     .setLanguage(language)
@@ -278,7 +278,8 @@ class EncodedVideoUnitViewModel(
                     setViewportSize(videoQuality.width, videoQuality.height, false)
                 }
             }
-            .setRendererDisabled(C.TRACK_TYPE_TEXT, isSubtitlesDisabled)
+            .setPreferredTextLanguage(_state.value.selectedLanguage)
+            .setTrackTypeDisabled(C.TRACK_TYPE_TEXT, isSubtitlesDisabled)
             .build()
 
         val factory = AdaptiveTrackSelection.Factory()

--- a/course/src/main/java/org/openedx/course/presentation/unit/video/VideoViewModel.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/video/VideoViewModel.kt
@@ -1,17 +1,12 @@
 package org.openedx.course.presentation.unit.video
 
-import android.net.Uri
 import androidx.lifecycle.viewModelScope
 import androidx.media3.common.C
-import androidx.media3.common.MediaItem
-import androidx.media3.common.MimeTypes
 import kotlinx.coroutines.launch
 import org.openedx.core.data.storage.CorePreferences
-import org.openedx.core.domain.model.VideoPlaybackSpeed
 import org.openedx.core.system.notifier.CourseCompletionSet
 import org.openedx.core.system.notifier.CourseNotifier
 import org.openedx.core.system.notifier.CourseVideoPositionChanged
-import org.openedx.core.utils.LocaleUtils
 import org.openedx.core.utils.Logger
 import org.openedx.course.data.repository.CourseRepository
 import org.openedx.course.presentation.CourseAnalytics
@@ -35,24 +30,6 @@ class VideoViewModel(
         get() = preferencesManager.videoSettings
 
     private var isBlockAlreadyCompleted = false
-
-    var transcripts = emptyMap<String, String>()
-    var selectedLanguage: String = ""
-    val subtitleConfigurations: List<MediaItem.SubtitleConfiguration>
-        get() = transcripts
-            .toSortedMap(
-                compareBy { LocaleUtils.getLanguageByLanguageCode(it) }
-            )
-            .map { (language, uri) ->
-                val selectionFlags =
-                    if (language == selectedLanguage) C.SELECTION_FLAG_DEFAULT else 0
-
-                MediaItem.SubtitleConfiguration.Builder(Uri.parse(uri))
-                    .setMimeType(MimeTypes.APPLICATION_SUBRIP)
-                    .setSelectionFlags(selectionFlags)
-                    .setLanguage(language)
-                    .build()
-            }
 
     fun sendTime() {
         if (currentVideoTime != C.TIME_UNSET) {
@@ -89,13 +66,6 @@ class VideoViewModel(
                 }
             }
         }
-    }
-
-    fun getVideoQuality() = videoSettings.videoStreamingQuality
-
-    fun setVideoPlaybackSpeed(speed: Float) {
-        preferencesManager.videoSettings =
-            videoSettings.copy(videoPlaybackSpeed = VideoPlaybackSpeed.getVideoPlaybackSpeed(speed))
     }
 
     companion object {


### PR DESCRIPTION
### Description

Jira ticket: [LEARNER-10499](https://2u-internal.atlassian.net/browse/LEARNER-10499)

- Fix Captions Disappear After Rotating Device to Landscape Mode
- Reapply the saved captions to the player upon orientation change.

Example:

https://github.com/user-attachments/assets/588e2004-e452-4833-9162-5882ff851772

