### PR TITLE
fix: Reduce tappable area on username to wrap content

### DIFF
--- a/discussion/src/main/java/org/openedx/discussion/presentation/responses/DiscussionResponsesFragment.kt
+++ b/discussion/src/main/java/org/openedx/discussion/presentation/responses/DiscussionResponsesFragment.kt
@@ -51,6 +51,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.ComposeView
@@ -88,6 +89,7 @@ import org.openedx.core.ui.theme.appColors
 import org.openedx.core.ui.theme.appShapes
 import org.openedx.core.ui.theme.appTypography
 import org.openedx.core.ui.windowSizeValue
+import org.openedx.discussion.R
 import org.openedx.discussion.domain.model.DiscussionComment
 import org.openedx.discussion.presentation.DiscussionRouter
 import org.openedx.discussion.presentation.comments.DiscussionCommentsFragment
@@ -235,11 +237,7 @@ private fun DiscussionResponsesScreen(
     var commentValue by rememberSaveable {
         mutableStateOf("")
     }
-    val sendButtonColor = if (commentValue.isEmpty()) {
-        MaterialTheme.appColors.textFieldBorder
-    } else {
-        MaterialTheme.appColors.primaryButtonBackground
-    }
+    val sendButtonAlpha = if (commentValue.isEmpty()) 0.3f else 1f
 
     val iconButtonColor = if (commentValue.isEmpty()) {
         MaterialTheme.appColors.textFieldBackgroundVariant
@@ -373,7 +371,7 @@ private fun DiscussionResponsesScreen(
                                                         .padding(horizontal = paddingContent)
                                                         .padding(top = 24.dp, bottom = 8.dp),
                                                     text = pluralStringResource(
-                                                        id = org.openedx.discussion.R.plurals.discussion_comments,
+                                                        id = R.plurals.discussion_comments,
                                                         uiState.mainComment.childCount,
                                                         uiState.mainComment.childCount
                                                     ),
@@ -460,7 +458,7 @@ private fun DiscussionResponsesScreen(
                                                 shape = MaterialTheme.appShapes.buttonShape,
                                                 placeholder = {
                                                     Text(
-                                                        text = stringResource(id = org.openedx.discussion.R.string.discussion_add_comment),
+                                                        text = stringResource(id = R.string.discussion_add_comment),
                                                         color = MaterialTheme.appColors.textFieldHint,
                                                         style = MaterialTheme.appTypography.labelLarge,
                                                     )
@@ -476,7 +474,8 @@ private fun DiscussionResponsesScreen(
                                                 modifier = Modifier
                                                     .size(48.dp)
                                                     .clip(CircleShape)
-                                                    .background(sendButtonColor)
+                                                    .alpha(sendButtonAlpha)
+                                                    .background(MaterialTheme.appColors.primaryButtonBackground)
                                                     .clickable {
                                                         keyboardController?.hide()
                                                         focusManager.clearFocus()
@@ -489,7 +488,7 @@ private fun DiscussionResponsesScreen(
                                             ) {
                                                 Icon(
                                                     modifier = Modifier.padding(7.dp),
-                                                    painter = painterResource(id = org.openedx.discussion.R.drawable.discussion_ic_send),
+                                                    painter = painterResource(id = R.drawable.discussion_ic_send),
                                                     contentDescription = null,
                                                     tint = iconButtonColor
                                                 )
@@ -549,7 +548,7 @@ private fun DiscussionResponsesScreenPreview() {
             onBackClick = {},
             isClosed = false,
             onUserPhotoClick = {},
-            isPostingEnabled = false,
+            isPostingEnabled = true,
         )
     }
 }
@@ -581,7 +580,7 @@ private fun DiscussionResponsesScreenTabletPreview() {
             onBackClick = {},
             isClosed = false,
             onUserPhotoClick = {},
-            isPostingEnabled = false,
+            isPostingEnabled = true,
         )
     }
 }

--- a/discussion/src/main/java/org/openedx/discussion/presentation/ui/DiscussionUI.kt
+++ b/discussion/src/main/java/org/openedx/discussion/presentation/ui/DiscussionUI.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.Card
 import androidx.compose.material.Divider
@@ -102,7 +103,7 @@ fun ThreadMainItem(
     val context = LocalContext.current
 
     Column(
-        modifier = modifier
+        modifier = modifier.background(MaterialTheme.appColors.background)
     ) {
         Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
             AsyncImage(
@@ -127,7 +128,7 @@ fun ThreadMainItem(
             Spacer(Modifier.width(16.dp))
             Column(
                 modifier = Modifier
-                    .weight(1f)
+                    .wrapContentWidth()
                     .clickable {
                         if (thread.author.isNotEmpty()) {
                             onUserPhotoClick(thread.author)
@@ -146,6 +147,7 @@ fun ThreadMainItem(
                     color = MaterialTheme.appColors.textPrimaryVariant
                 )
             }
+            Spacer(Modifier.weight(1f))
             IconText(
                 text = stringResource(id = R.string.discussion_follow),
                 painter = painterResource(if (thread.following) R.drawable.discussion_star_filled else R.drawable.discussion_star),
@@ -295,7 +297,7 @@ fun CommentItem(
                 Spacer(Modifier.width(12.dp))
                 Column(
                     modifier = Modifier
-                        .weight(1f)
+                        .wrapContentWidth()
                         .clickable {
                             onUserPhotoClick(comment.author)
                         },
@@ -312,6 +314,7 @@ fun CommentItem(
                         color = MaterialTheme.appColors.textPrimaryVariant
                     )
                 }
+                Spacer(Modifier.weight(1f))
                 IconText(
                     text = reportText,
                     painter = painterResource(id = R.drawable.discussion_ic_report),
@@ -446,7 +449,7 @@ fun CommentMainItem(
                 Spacer(Modifier.width(12.dp))
                 Column(
                     modifier = Modifier
-                        .weight(1f)
+                        .wrapContentWidth()
                         .clickable {
                             onUserPhotoClick(comment.author)
                         },
@@ -463,6 +466,7 @@ fun CommentMainItem(
                         color = MaterialTheme.appColors.textPrimaryVariant
                     )
                 }
+                Spacer(Modifier.weight(1f))
             }
             Spacer(modifier = Modifier.height(14.dp))
             HyperlinkImageText(
@@ -732,12 +736,14 @@ private fun CommentItemPreview() {
 @Preview
 @Composable
 private fun ThreadMainItemPreview() {
-    ThreadMainItem(
-        modifier = Modifier.fillMaxWidth(),
-        thread = mockThread,
-        onClick = { _, _ -> },
-        onUserPhotoClick = {}
-    )
+    OpenEdXTheme {
+        ThreadMainItem(
+            modifier = Modifier.fillMaxWidth(),
+            thread = mockThread,
+            onClick = { _, _ -> },
+            onUserPhotoClick = {}
+        )
+    }
 }
 
 private val mockComment = DiscussionComment(

--- a/discussion/src/main/java/org/openedx/discussion/presentation/ui/DiscussionUI.kt
+++ b/discussion/src/main/java/org/openedx/discussion/presentation/ui/DiscussionUI.kt
@@ -19,7 +19,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.Card
 import androidx.compose.material.Divider
@@ -128,15 +127,16 @@ fun ThreadMainItem(
             Spacer(Modifier.width(16.dp))
             Column(
                 modifier = Modifier
-                    .wrapContentWidth()
-                    .clickable {
-                        if (thread.author.isNotEmpty()) {
-                            onUserPhotoClick(thread.author)
-                        }
-                    },
+                    .weight(1f),
                 verticalArrangement = Arrangement.spacedBy(4.dp)
             ) {
                 Text(
+                    modifier = Modifier
+                        .clickable {
+                            if (thread.author.isNotEmpty()) {
+                                onUserPhotoClick(thread.author)
+                            }
+                        },
                     text = thread.author.ifEmpty { stringResource(id = R.string.discussion_anonymous) },
                     color = MaterialTheme.appColors.textPrimary,
                     style = MaterialTheme.appTypography.titleMedium
@@ -147,7 +147,6 @@ fun ThreadMainItem(
                     color = MaterialTheme.appColors.textPrimaryVariant
                 )
             }
-            Spacer(Modifier.weight(1f))
             IconText(
                 text = stringResource(id = R.string.discussion_follow),
                 painter = painterResource(if (thread.following) R.drawable.discussion_star_filled else R.drawable.discussion_star),
@@ -297,13 +296,14 @@ fun CommentItem(
                 Spacer(Modifier.width(12.dp))
                 Column(
                     modifier = Modifier
-                        .wrapContentWidth()
-                        .clickable {
-                            onUserPhotoClick(comment.author)
-                        },
+                        .weight(1f),
                     verticalArrangement = Arrangement.spacedBy(4.dp)
                 ) {
                     Text(
+                        modifier = Modifier
+                            .clickable {
+                                onUserPhotoClick(comment.author)
+                            },
                         text = comment.author,
                         color = MaterialTheme.appColors.textPrimary,
                         style = MaterialTheme.appTypography.titleSmall
@@ -314,7 +314,6 @@ fun CommentItem(
                         color = MaterialTheme.appColors.textPrimaryVariant
                     )
                 }
-                Spacer(Modifier.weight(1f))
                 IconText(
                     text = reportText,
                     painter = painterResource(id = R.drawable.discussion_ic_report),
@@ -449,13 +448,14 @@ fun CommentMainItem(
                 Spacer(Modifier.width(12.dp))
                 Column(
                     modifier = Modifier
-                        .wrapContentWidth()
-                        .clickable {
-                            onUserPhotoClick(comment.author)
-                        },
+                        .weight(1f),
                     verticalArrangement = Arrangement.spacedBy(4.dp)
                 ) {
                     Text(
+                        modifier = Modifier
+                            .clickable {
+                                onUserPhotoClick(comment.author)
+                            },
                         text = comment.author,
                         color = MaterialTheme.appColors.textPrimary,
                         style = MaterialTheme.appTypography.titleMedium
@@ -466,7 +466,6 @@ fun CommentMainItem(
                         color = MaterialTheme.appColors.textPrimaryVariant
                     )
                 }
-                Spacer(Modifier.weight(1f))
             }
             Spacer(modifier = Modifier.height(14.dp))
             HyperlinkImageText(


### PR DESCRIPTION
### Description

- Make the tappable area restricted to username view instead of covering the whole row

fix: [LEARNER-10662](https://2u-internal.atlassian.net/browse/LEARNER-10662)

<img width="480" alt="ProfileTapArea" src="https://github.com/user-attachments/assets/9bfc0e0b-aca2-43d9-a073-3cf90854eabf" />
