### PR TITLE
feat: Set 'Earn a Certificate' as Default on Track Selection Screen

### DIFF
--- a/core/src/main/java/org/openedx/core/presentation/dialog/IAPDialogFragment.kt
+++ b/core/src/main/java/org/openedx/core/presentation/dialog/IAPDialogFragment.kt
@@ -76,7 +76,7 @@ class IAPDialogFragment : DialogFragment() {
                 val uiMessage by iapViewModel.uiMessage.collectAsState(null)
                 val scaffoldState = rememberScaffoldState()
 
-                var selectedOption by remember { mutableStateOf(CourseTrack.FREE) }
+                var selectedOption by remember { mutableStateOf(CourseTrack.CERTIFICATE) }
 
                 val isFullScreenLoader =
                     (iapState as? IAPUIState.Loading)?.loaderType == IAPLoaderType.FULL_SCREEN


### PR DESCRIPTION
### Description

[LEARNER-10689](https://2u-internal.atlassian.net/browse/LEARNER-10689)

Previously, the "Free track" was the default selection. After the Product and Business decision, the "Earn  a  Certificate track" (to purchase and upgrade the course) is now set as the default option.

### Demo

https://github.com/user-attachments/assets/a24c7aa0-ed8d-4bc8-a506-f76445f644ba


