### PR TITLE
fix: Post CT Migration Improvements

### DIFF
--- a/core/src/main/java/org/openedx/core/AppDataConstants.kt
+++ b/core/src/main/java/org/openedx/core/AppDataConstants.kt
@@ -16,6 +16,10 @@ object AppDataConstants {
     // Equal 1GB
     const val DOWNLOADS_CONFIRMATION_SIZE = 1024 * 1024 * 1024L
 
+    // Initial retry count that controls whether the enrollment mode transition is attempted
+    // immediately or after the base delay, depending on the current count.
+    const val ENROLLMENT_MODE_RETRY_INITIAL_COUNT = 1
+
     // Max retry attempts allowed for checking enrollment mode transition after purchase.
     const val ENROLLMENT_MODE_RETRY_THRESHOLD = 3
 

--- a/core/src/main/java/org/openedx/core/domain/interactor/IAPInteractor.kt
+++ b/core/src/main/java/org/openedx/core/domain/interactor/IAPInteractor.kt
@@ -105,7 +105,11 @@ class IAPInteractor(
 
     suspend fun consumePurchaseByToken(purchaseToken: String) {
         val result = billingProcessor.consumePurchase(purchaseToken)
-        if (result.responseCode != BillingResponseCode.OK) {
+        if (result.responseCode !in listOf(
+                BillingResponseCode.OK,
+                BillingResponseCode.ITEM_NOT_OWNED
+            )
+        ) {
             throw IAPException(
                 requestType = IAPRequestType.CONSUME_CODE,
                 httpErrorCode = result.responseCode,

--- a/core/src/main/java/org/openedx/core/domain/interactor/IAPInteractor.kt
+++ b/core/src/main/java/org/openedx/core/domain/interactor/IAPInteractor.kt
@@ -138,7 +138,7 @@ class IAPInteractor(
             val courseId = purchase.getCourseId()
 
             userAccountId == userId && enrolledCourses.any { enrolledCourse ->
-                courseId == enrolledCourse.course.id
+                courseId == enrolledCourse.course.id && enrolledCourse.isAuditMode
             }
         }
         if (userPurchases.isNotEmpty()) {

--- a/core/src/main/java/org/openedx/core/domain/model/EnrolledCourse.kt
+++ b/core/src/main/java/org/openedx/core/domain/model/EnrolledCourse.kt
@@ -21,7 +21,7 @@ data class EnrolledCourse(
     val productInfo: ProductInfo?,
 ) : Parcelable {
 
-    private val isAuditMode: Boolean
+    val isAuditMode: Boolean
         get() = EnrollmentMode.AUDIT.toString().equals(mode, ignoreCase = true)
 
     val isVerifiedMode: Boolean

--- a/core/src/main/java/org/openedx/core/domain/model/iap/PurchaseFlowData.kt
+++ b/core/src/main/java/org/openedx/core/domain/model/iap/PurchaseFlowData.kt
@@ -2,6 +2,7 @@ package org.openedx.core.domain.model.iap
 
 import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
+import org.openedx.core.AppDataConstants
 import java.util.Date
 
 @Parcelize
@@ -24,7 +25,7 @@ data class PurchaseFlowData(
     var purchaseToken: String? = null
 
     var flowStartTime: Long = 0
-    var courseModeTransitionRetryCount: Long = 0
+    var courseModeTransitionRetryCount: Int = AppDataConstants.ENROLLMENT_MODE_RETRY_INITIAL_COUNT
     var isConsumed: Boolean = false
 
     fun resetAll() {
@@ -47,8 +48,8 @@ data class PurchaseFlowData(
         formattedPrice = null
         purchaseToken = null
         flowStartTime = 0
-        courseModeTransitionRetryCount = 0
         isConsumed = false
+        resetTransitionRetryCount()
     }
 
     fun isSilentIAPFlow(): Boolean? {
@@ -65,6 +66,10 @@ data class PurchaseFlowData(
                 null
             }
         }
+    }
+
+    fun resetTransitionRetryCount() {
+        courseModeTransitionRetryCount = AppDataConstants.ENROLLMENT_MODE_RETRY_INITIAL_COUNT
     }
 }
 

--- a/core/src/main/java/org/openedx/core/presentation/iap/IAPViewModel.kt
+++ b/core/src/main/java/org/openedx/core/presentation/iap/IAPViewModel.kt
@@ -285,10 +285,11 @@ class IAPViewModel(
     private fun updateCourseData() {
         viewModelScope.launch(Dispatchers.IO) {
             purchaseFlowData.courseId?.let { courseId ->
-                iapNotifier.send(UpdateCourseData(courseId = courseId, isFromValueProp = true))
                 if (!checkingCourseMode) {
+                    delay(purchaseData.courseModeTransitionRetryCount * AppDataConstants.ENROLLMENT_MODE_RETRY_BASE_DELAY_MS)
                     purchaseFlowData.courseModeTransitionRetryCount++
                 }
+                iapNotifier.send(UpdateCourseData(courseId = courseId, isFromValueProp = true))
             }
         }
     }
@@ -338,12 +339,9 @@ class IAPViewModel(
                     errorMessage = resourceManager.getString(R.string.iap_course_not_fullfilled)
                 )
             )
-            purchaseFlowData.courseModeTransitionRetryCount = 0
+            purchaseFlowData.resetTransitionRetryCount()
         } else {
-            viewModelScope.launch {
-                delay(purchaseData.courseModeTransitionRetryCount * AppDataConstants.ENROLLMENT_MODE_RETRY_BASE_DELAY_MS)
-                updateCourseData()
-            }
+            updateCourseData()
         }
     }
 

--- a/course/src/main/java/org/openedx/course/presentation/container/CourseContainerViewModel.kt
+++ b/course/src/main/java/org/openedx/course/presentation/container/CourseContainerViewModel.kt
@@ -538,6 +538,7 @@ class CourseContainerViewModel(
 
     private fun updateCourseData() {
         viewModelScope.launch(Dispatchers.IO) {
+            delay(purchaseFlowData.courseModeTransitionRetryCount * AppDataConstants.ENROLLMENT_MODE_RETRY_BASE_DELAY_MS)
             purchaseFlowData.courseId?.let {
                 iapNotifier.send(UpdateCourseData(courseId = it, isExpiredCoursePurchase = true))
             }
@@ -583,12 +584,9 @@ class CourseContainerViewModel(
                     errorMessage = resourceManager.getString(CoreR.string.iap_course_not_fullfilled)
                 )
             )
-            purchaseFlowData.courseModeTransitionRetryCount = 0
+            purchaseFlowData.resetTransitionRetryCount()
         } else {
-            viewModelScope.launch {
-                delay(purchaseFlowData.courseModeTransitionRetryCount * AppDataConstants.ENROLLMENT_MODE_RETRY_BASE_DELAY_MS)
-                updateCourseData()
-            }
+            updateCourseData()
         }
     }
 

--- a/dashboard/src/main/java/org/openedx/courses/presentation/DashboardGalleryUIState.kt
+++ b/dashboard/src/main/java/org/openedx/courses/presentation/DashboardGalleryUIState.kt
@@ -3,7 +3,9 @@ package org.openedx.courses.presentation
 import org.openedx.core.domain.model.CourseEnrollments
 
 sealed class DashboardGalleryUIState {
-    data class Courses(val userCourses: CourseEnrollments) : DashboardGalleryUIState()
+    data class Courses(val userCourses: CourseEnrollments, val isCachedData: Boolean) :
+        DashboardGalleryUIState()
+
     data object Empty : DashboardGalleryUIState()
     data object Loading : DashboardGalleryUIState()
 }

--- a/dashboard/src/main/java/org/openedx/courses/presentation/DashboardGalleryView.kt
+++ b/dashboard/src/main/java/org/openedx/courses/presentation/DashboardGalleryView.kt
@@ -278,8 +278,8 @@ private fun DashboardGalleryView(
                                 },
                                 onIAPAction = onIAPAction,
                             )
-                            LaunchedEffect(uiState.userCourses.hasEnrolledCourses()) {
-                                if (uiState.userCourses.hasEnrolledCourses()) {
+                            LaunchedEffect(uiState.isCachedData) {
+                                if (!uiState.isCachedData && uiState.userCourses.hasEnrolledCourses()) {
                                     onIAPAction(IAPAction.ACTION_UNFULFILLED, null, null)
                                 }
                             }
@@ -1096,7 +1096,7 @@ private fun ViewAllItemPreview() {
 private fun DashboardGalleryViewPreview() {
     OpenEdXTheme {
         DashboardGalleryView(
-            uiState = DashboardGalleryUIState.Courses(mockUserCourses),
+            uiState = DashboardGalleryUIState.Courses(mockUserCourses, false),
             iapUiState = null,
             apiHostUrl = "",
             uiMessage = null,

--- a/dashboard/src/main/java/org/openedx/courses/presentation/DashboardGalleryViewModel.kt
+++ b/dashboard/src/main/java/org/openedx/courses/presentation/DashboardGalleryViewModel.kt
@@ -109,12 +109,18 @@ class DashboardGalleryViewModel(
     private val eventLogger = IAPEventLogger(analytics = iapAnalytics, isSilentIAPFlow = true)
 
     private var isLoading = false
+    private var courseUnfulfillmentProcessed = false
 
     init {
         collectAppEvent()
         collectDiscoveryNotifier()
         collectIapNotifier()
         getCourses()
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        courseUnfulfillmentProcessed = false
     }
 
     private fun collectAppEvent() {
@@ -340,6 +346,7 @@ class DashboardGalleryViewModel(
     }
 
     private fun detectUnfulfilledPurchase() {
+        if (courseUnfulfillmentProcessed) return
         viewModelScope.launch(Dispatchers.IO) {
             try {
                 val enrolledCourses =
@@ -375,6 +382,7 @@ class DashboardGalleryViewModel(
             } catch (e: Exception) {
                 logger.e(throwable = e)
             }
+            courseUnfulfillmentProcessed = true
         }
     }
 

--- a/dashboard/src/main/java/org/openedx/courses/presentation/DashboardGalleryViewModel.kt
+++ b/dashboard/src/main/java/org/openedx/courses/presentation/DashboardGalleryViewModel.kt
@@ -147,7 +147,7 @@ class DashboardGalleryViewModel(
                     }
                 } else {
                     _uiState.value =
-                        DashboardGalleryUIState.Courses(cachedCourseEnrollments.mapToDomain())
+                        DashboardGalleryUIState.Courses(cachedCourseEnrollments.mapToDomain(), true)
                 }
                 if (networkConnection.isOnline()) {
                     isLoading = true
@@ -160,7 +160,7 @@ class DashboardGalleryViewModel(
                     if (response.primary == null && response.enrollments.courses.isEmpty()) {
                         _uiState.value = DashboardGalleryUIState.Empty
                     } else {
-                        _uiState.value = DashboardGalleryUIState.Courses(response)
+                        _uiState.value = DashboardGalleryUIState.Courses(response, false)
                     }
                     if (isIAPFlow) {
                         courseId?.let {
@@ -187,7 +187,7 @@ class DashboardGalleryViewModel(
                         _uiState.value = DashboardGalleryUIState.Empty
                     } else {
                         _uiState.value =
-                            DashboardGalleryUIState.Courses(courseEnrollments.mapToDomain())
+                            DashboardGalleryUIState.Courses(courseEnrollments.mapToDomain(), true)
                     }
                 }
             } catch (e: Exception) {

--- a/dashboard/src/main/java/org/openedx/dashboard/presentation/DashboardListViewModel.kt
+++ b/dashboard/src/main/java/org/openedx/dashboard/presentation/DashboardListViewModel.kt
@@ -110,6 +110,7 @@ class DashboardListViewModel(
         get() = _appUpgradeEvent
 
     private val eventLogger = IAPEventLogger(analytics = iapAnalytics, isSilentIAPFlow = true)
+    private var courseUnfulfillmentProcessed = false
 
     override fun onCreate(owner: LifecycleOwner) {
         super.onCreate(owner)
@@ -136,6 +137,11 @@ class DashboardListViewModel(
     init {
         getCourses()
         collectAppEvent()
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        courseUnfulfillmentProcessed = false
     }
 
     fun getCourses() {
@@ -340,6 +346,7 @@ class DashboardListViewModel(
     }
 
     private fun detectUnfulfilledPurchase() {
+        if (courseUnfulfillmentProcessed) return
         viewModelScope.launch(Dispatchers.IO) {
             runCatching {
                 interactor.getAllUserCourses(status = CourseStatusFilter.ALL).courses
@@ -375,6 +382,7 @@ class DashboardListViewModel(
             }.onFailure {
                 logger.d { "Error getting enrolled courses: $it" }
             }
+            courseUnfulfillmentProcessed = true
         }
     }
 


### PR DESCRIPTION
### Description

Jira Ticket: [LEARNER-10684](https://2u-internal.atlassian.net/browse/LEARNER-10684)

- Fix the issue produced after CT Migration.
- Executed Unfulfillment flow only for audit courses and one per session.
- Trigger `course_enrollments` API initial call after 2.5 seconds of `create-order`.

**Steps to reproduce:**

**Issue-1**
Executed Unfulfillment for the already purchased course.
- Initiates a purchase.
- Immediately closes the app before the mobile app verifies fulfillment and consumes the product.
- When the app is reopened later, it triggers a retry and results in an error due to an outdated state.

**Issue-2**
Multiple `iap/create-order/` requests from the mobile.
- Open the expired course and initiate the course purchase.
- Click the back button after the payment pop-up closes.
- App will trigger `iap/create-order/` multiple times with a gap of some sec.
