### PR TITLE
build: enable signed ProdRelease build

### DIFF
--- a/app/.gitignore
+++ b/app/.gitignore
@@ -1,2 +1,6 @@
 /build
 /google-services.json
+
+# Files related to release signing
+*.keystore
+*/keystore.properties

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,6 +2,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 def config = configHelper.fetchConfig()
 def appId = config.getOrDefault("APPLICATION_ID", "org.openedx.app")
+def platformName = config.getOrDefault("PLATFORM_NAME", "OpenEdX")
 def themeDirectory = config.getOrDefault("THEME_DIRECTORY", "openedx")
 def firebaseConfig = config.get('FIREBASE')
 def firebaseEnabled = firebaseConfig?.getOrDefault('ENABLED', false)
@@ -87,6 +88,17 @@ android {
             if (firebaseEnabled) {
                 firebaseCrashlytics {
                     mappingFileUploadEnabled = true
+                }
+            }
+
+            // Only apply release signing configurations if keystore.properties is available
+            if (project.file("signing/keystore.properties").exists()) {
+                apply from: "signing/signing.gradle"
+
+                applicationVariants.all { variant ->
+                    variant.outputs.all { output ->
+                        output.outputFileName = "${platformName}-${variant.buildType.name}-v${versionName}.apk"
+                    }
                 }
             }
         }

--- a/app/signing/README.md
+++ b/app/signing/README.md
@@ -1,0 +1,73 @@
+# Android Release Build Signing
+
+This document defines how to configure signing and build the **edX Android app** in release mode.
+
+---
+
+## 📌 Overview
+
+* Introduces `keystore.properties` for secure signing configuration.
+* Ensures the release build process can be executed via **Gradle CLI** or **Android Studio**.
+* `signing.gradle` automatically picks up values from `keystore.properties` during the build process.
+* Keeps sensitive signing information **local only** (not committed to Git).
+
+---
+
+## 🛠️ Setup Instructions
+
+### 1. Create `keystore.properties`
+
+Create a new file at:
+
+```
+openedx-app-android/app/signing/keystore.properties
+```
+
+Add the following content (replace placeholders with actual values):
+RELEASE_KEY_ALIAS
+```properties
+RELEASE_STORE_FILE=<path_to_your_keystore_file>
+RELEASE_STORE_PASSWORD=<store_password>
+RELEASE_KEY_ALIAS=<release_key_alias>
+RELEASE_KEY_PASSWORD=<key_password>
+```
+
+⚠️ **Important Notes**
+
+* This file is **ignored by Git** (`.gitignore`).
+* Do **not** commit or publish its contents.
+* Keep the keystore file and credentials secure.
+* If your password contains special characters (e.g., $, !, #, /, \), use the appropriate escape specifier or string formater in the keystore.properties file to avoid issues with string formatting.
+
+---
+
+### 2. Build the Release APK
+
+#### Option A: Using Gradle CLI
+
+```bash
+./gradlew clean assembleProdRelease
+```
+
+#### Option B: Using Android Studio
+
+1. Navigate to **Build > Generate Signed Bundle / APK...**
+2. Select **APK**.
+3. Provide the path to your `*.keystore` file.
+4. Complete the wizard to generate a signed APK.
+
+---
+
+### 3. Output Location
+
+The signed APK will be generated at:
+
+```
+app/build/outputs/apk/prod/release/
+```
+
+---
+
+## 📖 Reference
+
+* [Android App Signing - Official Documentation](https://developer.android.com/studio/publish/app-signing#gradle-signing)

--- a/app/signing/signing.gradle
+++ b/app/signing/signing.gradle
@@ -1,0 +1,21 @@
+def buildType = "release"
+def keystorePropertiesFile = file("signing/keystore.properties")
+def keystoreProperties = new Properties()
+keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+
+android {
+    signingConfigs {
+        create(buildType) {
+            storeFile = file(keystoreProperties['RELEASE_STORE_FILE'])
+            storePassword = keystoreProperties['RELEASE_STORE_PASSWORD']
+            keyAlias = keystoreProperties['RELEASE_KEY_ALIAS']
+            keyPassword = keystoreProperties['RELEASE_KEY_PASSWORD']
+        }
+    }
+
+    buildTypes {
+        named(buildType) {
+            signingConfig = signingConfigs.getByName(buildType)
+        }
+    }
+}


### PR DESCRIPTION
### Description

Enable signed ProdRelease build
Jira Ticket: [LEARNER-9582](https://2u-internal.atlassian.net/browse/LEARNER-9582)

- Configured Gradle signing configs.
- Verified build with `./gradlew clean assembleProdRelease`.