### PR TITLE
fix: Handle Firebase Analytics Routing

### DIFF
--- a/app/src/main/java/org/openedx/app/AnalyticsManager.kt
+++ b/app/src/main/java/org/openedx/app/AnalyticsManager.kt
@@ -28,7 +28,7 @@ class AnalyticsManager(
 
     init {
         // Initialise all the analytics libraries here
-        if (config.getFirebaseConfig().enabled) {
+        if (config.getFirebaseConfig().isFirebaseAnalyticsSource()) {
             addAnalyticsTracker(FirebaseAnalytics(context = context))
         }
 

--- a/core/src/main/java/org/openedx/core/config/AnalyticsSource.kt
+++ b/core/src/main/java/org/openedx/core/config/AnalyticsSource.kt
@@ -6,6 +6,9 @@ enum class AnalyticsSource {
     @SerializedName("segment")
     SEGMENT,
 
+    @SerializedName("firebase")
+    FIREBASE,
+
     @SerializedName("none")
     NONE,
 }

--- a/core/src/main/java/org/openedx/core/config/FirebaseConfig.kt
+++ b/core/src/main/java/org/openedx/core/config/FirebaseConfig.kt
@@ -27,4 +27,8 @@ data class FirebaseConfig(
     fun isSegmentAnalyticsSource(): Boolean {
         return enabled && analyticsSource == AnalyticsSource.SEGMENT
     }
+
+    fun isFirebaseAnalyticsSource(): Boolean {
+        return enabled && analyticsSource == AnalyticsSource.FIREBASE
+    }
 }

--- a/core/src/main/java/org/openedx/core/config/VideoPlayerConfig.kt
+++ b/core/src/main/java/org/openedx/core/config/VideoPlayerConfig.kt
@@ -3,9 +3,6 @@ package org.openedx.core.config
 import com.google.gson.annotations.SerializedName
 
 data class VideoPlayerConfig(
-    @SerializedName("VIDEO_TRANSCRIPT_ENABLED")
-    val isVideoTranscriptEnabled: Boolean = false,
-
     @SerializedName("BLACKLIST_URLS")
     val blacklistUrls: List<String> = emptyList(),
 )

--- a/core/src/main/java/org/openedx/core/data/model/DateType.kt
+++ b/core/src/main/java/org/openedx/core/data/model/DateType.kt
@@ -28,5 +28,9 @@ enum class DateType(val drawableResId: Int? = null) {
     @SerializedName("verification-deadline-date")
     VERIFICATION_DEADLINE_DATE(R.drawable.core_ic_calendar),
 
-    NONE,
+    NONE;
+
+    override fun toString(): String {
+        return name.lowercase()
+    }
 }

--- a/course/src/main/java/org/openedx/course/presentation/dates/CourseDatesViewModel.kt
+++ b/course/src/main/java/org/openedx/course/presentation/dates/CourseDatesViewModel.kt
@@ -265,7 +265,7 @@ class CourseDatesViewModel(
     fun logCourseComponentTapped(isSupported: Boolean, block: CourseDateBlock) {
         val params = buildMap<String, Any> {
             put(CourseAnalyticsKey.BLOCK_ID.key, block.blockId)
-            put(CourseAnalyticsKey.BLOCK_TYPE.key, block.dateType)
+            put(CourseAnalyticsKey.BLOCK_TYPE.key, block.dateType.toString())
             put(CourseAnalyticsKey.LINK.key, block.link)
             put(CourseAnalyticsKey.SUPPORTED.key, isSupported)
         }

--- a/whatsnew/src/main/java/org/openedx/whatsnew/WhatsNewManager.kt
+++ b/whatsnew/src/main/java/org/openedx/whatsnew/WhatsNewManager.kt
@@ -28,6 +28,7 @@ class WhatsNewManager(
     }
 
     override fun shouldShowWhatsNew(): Boolean {
+        if (!config.isWhatsNewEnabled()) return false
         return try {
             val dataVersion = Version(getNewestData().version)
             val appVersion = Version(appData.versionName)


### PR DESCRIPTION
### Description

Jira Ticket: [LEARNER-10730](https://2u-internal.atlassian.net/browse/LEARNER-10730)

- Disable Firebase analytics manager if the source isn’t Firebase 
- Put the What's new behind the feature flag `WHATS_NEW_ENABLED` 
- Config cleanup, remove `VIDEO_TRANSCRIPT_ENABLED` 
- Fix issue of `block_type` getting null for `DATES_COURSE_COMPONENT_CLICKED`