### PR TITLE
fix: Add Loader on POST Actions in Discussions

### DIFF
--- a/discussion/src/main/java/org/openedx/discussion/presentation/comments/DiscussionCommentsFragment.kt
+++ b/discussion/src/main/java/org/openedx/discussion/presentation/comments/DiscussionCommentsFragment.kt
@@ -67,6 +67,7 @@ import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
 import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import kotlinx.coroutines.delay
@@ -96,6 +97,7 @@ import org.openedx.discussion.domain.model.DiscussionComment
 import org.openedx.discussion.domain.model.DiscussionType
 import org.openedx.discussion.domain.model.Thread
 import org.openedx.discussion.presentation.DiscussionRouter
+import org.openedx.discussion.presentation.responses.DiscussionResponsesUIState
 import org.openedx.discussion.presentation.ui.CommentItem
 import org.openedx.discussion.presentation.ui.ThreadMainItem
 
@@ -131,6 +133,7 @@ class DiscussionCommentsFragment : Fragment() {
                 val uiState by viewModel.uiState.observeAsState(DiscussionCommentsUIState.Loading)
                 val uiMessage by viewModel.uiMessage.observeAsState()
                 val canLoadMore by viewModel.canLoadMore.observeAsState(false)
+                val isLoading by viewModel.isLoading.observeAsState(false)
                 val refreshing by viewModel.isUpdating.observeAsState(false)
 
                 DiscussionCommentsScreen(
@@ -139,6 +142,7 @@ class DiscussionCommentsFragment : Fragment() {
                     uiMessage = uiMessage,
                     title = viewModel.title,
                     canLoadMore = canLoadMore,
+                    isloading = isLoading,
                     refreshing = refreshing,
                     isPostingEnabled = viewModel.isPostingEnabled,
                     onCommentPulseEnd = { comment ->
@@ -256,6 +260,7 @@ private fun DiscussionCommentsScreen(
     uiMessage: UIMessage?,
     title: String,
     canLoadMore: Boolean,
+    isloading: Boolean,
     refreshing: Boolean,
     isPostingEnabled: Boolean,
     onCommentPulseEnd: (DiscussionComment) -> Unit = {},
@@ -310,7 +315,16 @@ private fun DiscussionCommentsScreen(
                 )
             )
         }
-
+        if (!uiState.equals(DiscussionResponsesUIState.Loading) && isloading){
+            Dialog(onDismissRequest = { /* Do nothing to prevent dismiss */ }) {
+                Box(
+                    Modifier
+                        .fillMaxSize(), contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator(color = MaterialTheme.appColors.primary)
+                }
+            }
+        }
         HandleUIMessage(uiMessage = uiMessage, scaffoldState = scaffoldState)
 
         Column(
@@ -565,6 +579,7 @@ private fun DiscussionCommentsScreenPreview() {
             uiMessage = null,
             title = "Test Screen",
             canLoadMore = false,
+            isloading = false,
             isPostingEnabled = false,
             paginationCallBack = {},
             onItemClick = { _, _, _ ->
@@ -596,6 +611,7 @@ private fun DiscussionCommentsScreenTabletPreview() {
             uiMessage = null,
             title = "Test Screen",
             canLoadMore = false,
+            isloading = false,
             isPostingEnabled = false,
             paginationCallBack = {},
             onItemClick = { _, _, _ ->

--- a/discussion/src/main/java/org/openedx/discussion/presentation/comments/DiscussionCommentsViewModel.kt
+++ b/discussion/src/main/java/org/openedx/discussion/presentation/comments/DiscussionCommentsViewModel.kt
@@ -66,7 +66,10 @@ class DiscussionCommentsViewModel(
 
     private val comments = mutableListOf<DiscussionComment>()
     private var page = 1
-    private var isLoading = false
+    private val _isLoading = MutableLiveData<Boolean>()
+    val isLoading: LiveData<Boolean>
+        get() = _isLoading
+    //private var isLoading = false
 
     override fun onCreate(owner: LifecycleOwner) {
         super.onCreate(owner)
@@ -104,7 +107,7 @@ class DiscussionCommentsViewModel(
     private fun internalLoadComments(markReadIfSuccessful: Boolean) {
         viewModelScope.launch {
             try {
-                isLoading = true
+                //isLoading = true
                 val response = if (thread.type == DiscussionType.DISCUSSION) {
                     interactor.getThreadComments(thread.id, page)
                 } else {
@@ -143,7 +146,7 @@ class DiscussionCommentsViewModel(
             } catch (e: Exception) {
                 handleException(e)
             } finally {
-                isLoading = false
+               // isLoading = false
                 _isUpdating.value = false
             }
         }
@@ -184,7 +187,7 @@ class DiscussionCommentsViewModel(
     }
 
     fun fetchMore() {
-        if (!isLoading && page != -1) {
+        if (_isLoading.value != true && page != -1) {
             internalLoadComments(markReadIfSuccessful = false)
         }
     }
@@ -292,6 +295,7 @@ class DiscussionCommentsViewModel(
     }
 
     fun createComment(rawBody: String) {
+        _isLoading.postValue(true)
         viewModelScope.launch {
             try {
                 val reCaptchaToken = interactor.getRecaptchaToken(
@@ -315,6 +319,8 @@ class DiscussionCommentsViewModel(
                 notifier.send(DiscussionCommentAdded())
             } catch (e: Exception) {
                 handleException(e)
+            }finally {
+                _isLoading.postValue(false)
             }
         }
     }

--- a/discussion/src/main/java/org/openedx/discussion/presentation/responses/DiscussionResponsesFragment.kt
+++ b/discussion/src/main/java/org/openedx/discussion/presentation/responses/DiscussionResponsesFragment.kt
@@ -67,6 +67,7 @@ import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
 import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import org.koin.android.ext.android.inject
@@ -128,6 +129,7 @@ class DiscussionResponsesFragment : Fragment() {
                 val uiState by viewModel.uiState.observeAsState(DiscussionResponsesUIState.Loading)
                 val uiMessage by viewModel.uiMessage.observeAsState()
                 val canLoadMore by viewModel.canLoadMore.observeAsState(false)
+                val isLoading by viewModel.isLoading.observeAsState(false)
                 val refreshing by viewModel.isUpdating.observeAsState(false)
 
                 DiscussionResponsesScreen(
@@ -135,6 +137,7 @@ class DiscussionResponsesFragment : Fragment() {
                     uiState = uiState,
                     uiMessage = uiMessage,
                     canLoadMore = canLoadMore,
+                    isloading = isLoading,
                     refreshing = refreshing,
                     isClosed = viewModel.isThreadClosed,
                     isPostingEnabled = viewModel.isPostingEnabled,
@@ -213,6 +216,7 @@ private fun DiscussionResponsesScreen(
     uiState: DiscussionResponsesUIState,
     uiMessage: UIMessage?,
     canLoadMore: Boolean,
+    isloading: Boolean,
     refreshing: Boolean,
     isClosed: Boolean,
     isPostingEnabled: Boolean,
@@ -244,7 +248,16 @@ private fun DiscussionResponsesScreen(
     } else {
         Color.White
     }
-
+    if (!uiState.equals(DiscussionResponsesUIState.Loading) && isloading){
+            Dialog(onDismissRequest = { /* Do nothing to prevent dismiss */ }) {
+                Box(
+                    Modifier
+                        .fillMaxSize(), contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator(color = MaterialTheme.appColors.primary)
+                }
+            }
+    }
     Scaffold(
         scaffoldState = scaffoldState,
         modifier = Modifier
@@ -536,6 +549,7 @@ private fun DiscussionResponsesScreenPreview() {
             ),
             uiMessage = null,
             canLoadMore = false,
+            isloading = false,
             refreshing = false,
             onSwipeRefresh = {},
             paginationCallBack = { },
@@ -568,6 +582,7 @@ private fun DiscussionResponsesScreenTabletPreview() {
             ),
             uiMessage = null,
             canLoadMore = false,
+            isloading = false,
             refreshing = false,
             onSwipeRefresh = {},
             paginationCallBack = { },

--- a/discussion/src/main/java/org/openedx/discussion/presentation/responses/DiscussionResponsesViewModel.kt
+++ b/discussion/src/main/java/org/openedx/discussion/presentation/responses/DiscussionResponsesViewModel.kt
@@ -56,7 +56,10 @@ class DiscussionResponsesViewModel(
 
     private val comments = mutableListOf<DiscussionComment>()
     private var page = 1
-    private var isLoading = false
+    private val _isLoading = MutableLiveData<Boolean>()
+    val isLoading: LiveData<Boolean>
+        get() = _isLoading
+//     var isLoading = false
 
     private suspend fun sendUpdatedComment() {
         notifier.send(DiscussionCommentDataChanged(comment))
@@ -80,7 +83,7 @@ class DiscussionResponsesViewModel(
     }
 
     fun fetchMore() {
-        if (!isLoading && page != -1) {
+        if (_isLoading.value != true && page != -1) {
             loadCommentsInternal()
         }
     }
@@ -88,7 +91,7 @@ class DiscussionResponsesViewModel(
     private fun loadCommentsInternal() {
         viewModelScope.launch {
             try {
-                isLoading = true
+               // _isLoading.postValue(true)
                 val response = interactor.getCommentsResponses(comment.id, page)
                 if (response.pagination.next.isNotEmpty()) {
                     _canLoadMore.value = true
@@ -104,7 +107,7 @@ class DiscussionResponsesViewModel(
             } catch (e: Exception) {
                 handleException(e)
             } finally {
-                isLoading = false
+              //  _isLoading.postValue(false)
                 _isUpdating.value = false
             }
         }
@@ -178,6 +181,7 @@ class DiscussionResponsesViewModel(
     }
 
     fun createComment(rawBody: String) {
+        _isLoading.postValue(true)
         viewModelScope.launch {
             try {
                 val reCaptchaToken = interactor.getRecaptchaToken(
@@ -207,6 +211,8 @@ class DiscussionResponsesViewModel(
                 notifier.send(DiscussionResponseAdded())
             } catch (e: Exception) {
                 handleException(e)
+            }finally {
+                _isLoading.postValue(false)
             }
         }
     }


### PR DESCRIPTION
Loader is shown during each POST action
Button becomes disabled during request
User receives clear success or failure feedback