### PR TITLE
fix: Refresh Discussions UI and Scroll to Response After Posting

### DIFF
--- a/discussion/src/main/java/org/openedx/discussion/presentation/comments/DiscussionCommentsFragment.kt
+++ b/discussion/src/main/java/org/openedx/discussion/presentation/comments/DiscussionCommentsFragment.kt
@@ -49,7 +49,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -71,8 +70,6 @@ import androidx.compose.ui.unit.dp
 import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.first
 import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.koin.core.parameter.parametersOf
@@ -362,13 +359,9 @@ private fun DiscussionCommentsScreen(
                             var previousFirstId by remember { mutableStateOf<String?>(null) }
                             val currentFirstId = uiState.commentsData.firstOrNull()?.id
                             LaunchedEffect(currentFirstId) {
-                                // Only scroll if a new item has appeared at the top
                                 if (currentFirstId != null && currentFirstId != previousFirstId) {
-                                    // Wait until the list is actually composed
-                                    snapshotFlow { scrollState.layoutInfo.totalItemsCount }
-                                        .filter { it > 0 } // Ensure list has content
-                                        .first() // Suspend until this is true
-                                    scrollState.animateScrollToItem(0) // Use animateScrollToItem for reliability
+                                    delay(100)
+                                    scrollState.animateScrollToItem(0)
                                     previousFirstId = currentFirstId
                                 }
                             }

--- a/discussion/src/main/java/org/openedx/discussion/presentation/comments/DiscussionCommentsFragment.kt
+++ b/discussion/src/main/java/org/openedx/discussion/presentation/comments/DiscussionCommentsFragment.kt
@@ -1,5 +1,6 @@
 package org.openedx.discussion.presentation.comments
 
+import android.annotation.SuppressLint
 import android.content.res.Configuration
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -47,6 +48,7 @@ import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -70,6 +72,8 @@ import androidx.compose.ui.unit.dp
 import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import okhttp3.internal.notify
 import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.koin.core.parameter.parametersOf
@@ -248,6 +252,7 @@ class DiscussionCommentsFragment : Fragment() {
 
 }
 
+@SuppressLint("CoroutineCreationDuringComposition")
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
 private fun DiscussionCommentsScreen(
@@ -356,6 +361,7 @@ private fun DiscussionCommentsScreen(
                 Box(Modifier.pullRefresh(pullRefreshState)) {
                     when (uiState) {
                         is DiscussionCommentsUIState.Success -> {
+
                             Column(
                                 Modifier.fillMaxSize(),
                                 horizontalAlignment = Alignment.CenterHorizontally
@@ -391,7 +397,7 @@ private fun DiscussionCommentsScreen(
                                         )
                                     }
                                     if (uiState.commentsData.isNotEmpty()) {
-                                        item {
+                                        item(uiState.count) {
                                             Text(
                                                 modifier = Modifier
                                                     .fillMaxWidth()
@@ -673,3 +679,4 @@ private val mockComment = DiscussionComment(
     users = mapOf(),
     isAuthor = false,
 )
+

--- a/discussion/src/main/java/org/openedx/discussion/presentation/comments/DiscussionCommentsFragment.kt
+++ b/discussion/src/main/java/org/openedx/discussion/presentation/comments/DiscussionCommentsFragment.kt
@@ -1,6 +1,5 @@
 package org.openedx.discussion.presentation.comments
 
-import android.annotation.SuppressLint
 import android.content.res.Configuration
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -48,9 +47,9 @@ import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -72,8 +71,8 @@ import androidx.compose.ui.unit.dp
 import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
-import okhttp3.internal.notify
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
 import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.koin.core.parameter.parametersOf
@@ -252,7 +251,6 @@ class DiscussionCommentsFragment : Fragment() {
 
 }
 
-@SuppressLint("CoroutineCreationDuringComposition")
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
 private fun DiscussionCommentsScreen(
@@ -361,6 +359,19 @@ private fun DiscussionCommentsScreen(
                 Box(Modifier.pullRefresh(pullRefreshState)) {
                     when (uiState) {
                         is DiscussionCommentsUIState.Success -> {
+                            var previousFirstId by remember { mutableStateOf<String?>(null) }
+                            val currentFirstId = uiState.commentsData.firstOrNull()?.id
+                            LaunchedEffect(currentFirstId) {
+                                // Only scroll if a new item has appeared at the top
+                                if (currentFirstId != null && currentFirstId != previousFirstId) {
+                                    // Wait until the list is actually composed
+                                    snapshotFlow { scrollState.layoutInfo.totalItemsCount }
+                                        .filter { it > 0 } // Ensure list has content
+                                        .first() // Suspend until this is true
+                                    scrollState.animateScrollToItem(0) // Use animateScrollToItem for reliability
+                                    previousFirstId = currentFirstId
+                                }
+                            }
 
                             Column(
                                 Modifier.fillMaxSize(),
@@ -397,7 +408,7 @@ private fun DiscussionCommentsScreen(
                                         )
                                     }
                                     if (uiState.commentsData.isNotEmpty()) {
-                                        item(uiState.count) {
+                                        item {
                                             Text(
                                                 modifier = Modifier
                                                     .fillMaxWidth()
@@ -679,4 +690,3 @@ private val mockComment = DiscussionComment(
     users = mapOf(),
     isAuthor = false,
 )
-

--- a/discussion/src/main/java/org/openedx/discussion/presentation/comments/DiscussionCommentsUIState.kt
+++ b/discussion/src/main/java/org/openedx/discussion/presentation/comments/DiscussionCommentsUIState.kt
@@ -7,7 +7,7 @@ sealed class DiscussionCommentsUIState {
     data class Success(
         val thread: org.openedx.discussion.domain.model.Thread,
         val commentsData: List<DiscussionComment>,
-        val count: Int
+        val count: Int,
     ) : DiscussionCommentsUIState()
 
     object Loading : DiscussionCommentsUIState()

--- a/discussion/src/main/java/org/openedx/discussion/presentation/comments/DiscussionCommentsViewModel.kt
+++ b/discussion/src/main/java/org/openedx/discussion/presentation/comments/DiscussionCommentsViewModel.kt
@@ -66,7 +66,6 @@ class DiscussionCommentsViewModel(
         get() = _isUpdating
 
     private val comments = mutableStateListOf<DiscussionComment>()
-
     private var page = 1
     private var isLoading = false
 
@@ -302,6 +301,7 @@ class DiscussionCommentsViewModel(
                 )
                 val response = interactor.createComment(thread.id, rawBody, null, reCaptchaToken)
                 response.isAuthor = response.author == corePreferences.user?.username
+
                 thread = thread.copy(commentCount = thread.commentCount + 1)
                 sendThreadUpdated()
 
@@ -320,6 +320,7 @@ class DiscussionCommentsViewModel(
             }
         }
     }
+
     private fun handleException(e: Exception) {
         logger.e(throwable = e, metadata = mapOf("courseId" to courseId))
         if (e.isInternetError()) {

--- a/discussion/src/main/java/org/openedx/discussion/presentation/comments/DiscussionCommentsViewModel.kt
+++ b/discussion/src/main/java/org/openedx/discussion/presentation/comments/DiscussionCommentsViewModel.kt
@@ -1,5 +1,6 @@
 package org.openedx.discussion.presentation.comments
 
+import androidx.compose.runtime.mutableStateListOf
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
@@ -64,7 +65,8 @@ class DiscussionCommentsViewModel(
     val isUpdating: LiveData<Boolean>
         get() = _isUpdating
 
-    private val comments = mutableListOf<DiscussionComment>()
+    private val comments = mutableStateListOf<DiscussionComment>()
+
     private var page = 1
     private var isLoading = false
 
@@ -300,7 +302,6 @@ class DiscussionCommentsViewModel(
                 )
                 val response = interactor.createComment(thread.id, rawBody, null, reCaptchaToken)
                 response.isAuthor = response.author == corePreferences.user?.username
-                response.shouldHighlight = commentId.isEmpty()
                 thread = thread.copy(commentCount = thread.commentCount + 1)
                 sendThreadUpdated()
 

--- a/discussion/src/main/java/org/openedx/discussion/presentation/comments/DiscussionCommentsViewModel.kt
+++ b/discussion/src/main/java/org/openedx/discussion/presentation/comments/DiscussionCommentsViewModel.kt
@@ -300,11 +300,12 @@ class DiscussionCommentsViewModel(
                 )
                 val response = interactor.createComment(thread.id, rawBody, null, reCaptchaToken)
                 response.isAuthor = response.author == corePreferences.user?.username
-
+                response.shouldHighlight = commentId.isEmpty()
                 thread = thread.copy(commentCount = thread.commentCount + 1)
                 sendThreadUpdated()
 
                 comments.add(0, response)
+                commentCount++
                 _uiState.value =
                     DiscussionCommentsUIState.Success(thread, comments.toList(), commentCount)
                 logResponseAddedEvent(
@@ -318,7 +319,6 @@ class DiscussionCommentsViewModel(
             }
         }
     }
-
     private fun handleException(e: Exception) {
         logger.e(throwable = e, metadata = mapOf("courseId" to courseId))
         if (e.isInternetError()) {

--- a/discussion/src/main/java/org/openedx/discussion/presentation/responses/DiscussionResponsesViewModel.kt
+++ b/discussion/src/main/java/org/openedx/discussion/presentation/responses/DiscussionResponsesViewModel.kt
@@ -191,6 +191,7 @@ class DiscussionResponsesViewModel(
                     captchaToken = reCaptchaToken,
                 )
                 response.isAuthor = response.author == corePreferences.user?.username
+
                 comment = comment.copy(childCount = comment.childCount + 1)
                 sendUpdatedComment()
 

--- a/discussion/src/main/java/org/openedx/discussion/presentation/responses/DiscussionResponsesViewModel.kt
+++ b/discussion/src/main/java/org/openedx/discussion/presentation/responses/DiscussionResponsesViewModel.kt
@@ -191,7 +191,6 @@ class DiscussionResponsesViewModel(
                     captchaToken = reCaptchaToken,
                 )
                 response.isAuthor = response.author == corePreferences.user?.username
-
                 comment = comment.copy(childCount = comment.childCount + 1)
                 sendUpdatedComment()
 


### PR DESCRIPTION
Response is visible immediately after posting (via scroll or animation)

Response count updates immediately

No duplicate entries or jumpy UI transitions