### PR TITLE
feat: Add reCAPTCHA support on Registration

### DIFF
--- a/app/src/main/java/org/openedx/app/di/ScreenModule.kt
+++ b/app/src/main/java/org/openedx/app/di/ScreenModule.kt
@@ -135,8 +135,6 @@ val screenModule = module {
             get(),
             courseId,
             infoType,
-            get (),
-            get()
         )
     }
     viewModel { RestorePasswordViewModel(get(), get(), get(), get()) }

--- a/app/src/main/java/org/openedx/app/di/ScreenModule.kt
+++ b/app/src/main/java/org/openedx/app/di/ScreenModule.kt
@@ -91,7 +91,7 @@ val screenModule = module {
     }
     viewModel { MainViewModel(get(), get(), get(), get(), get()) }
 
-    factory { AuthRepository(get(), get(), get()) }
+    factory { AuthRepository(get(), get(), get(),get()) }
     factory { AuthInteractor(get()) }
     factory { Validator() }
 
@@ -134,7 +134,9 @@ val screenModule = module {
             get(),
             get(),
             courseId,
-            infoType
+            infoType,
+            get (),
+            get()
         )
     }
     viewModel { RestorePasswordViewModel(get(), get(), get(), get()) }

--- a/auth/src/main/java/org/openedx/auth/data/api/AuthApi.kt
+++ b/auth/src/main/java/org/openedx/auth/data/api/AuthApi.kt
@@ -45,6 +45,7 @@ interface AuthApi {
     @GET(ApiConstants.URL_REGISTRATION_FIELDS)
     suspend fun getRegistrationFields(): RegistrationFields
 
+    @Headers("Mobile-Platform-Identifier: android")
     @FormUrlEncoded
     @POST(ApiConstants.URL_REGISTER)
     suspend fun registerUser(@FieldMap fields: Map<String, String>)

--- a/auth/src/main/java/org/openedx/auth/data/repository/AuthRepository.kt
+++ b/auth/src/main/java/org/openedx/auth/data/repository/AuthRepository.kt
@@ -1,5 +1,6 @@
 package org.openedx.auth.data.repository
 
+import com.google.android.recaptcha.RecaptchaAction
 import org.openedx.auth.data.api.AuthApi
 import org.openedx.auth.data.model.AuthType
 import org.openedx.auth.data.model.ValidationFields
@@ -9,12 +10,14 @@ import org.openedx.core.config.Config
 import org.openedx.core.data.storage.CorePreferences
 import org.openedx.core.domain.model.RegistrationField
 import org.openedx.core.system.EdxError
+import org.openedx.core.system.RecaptchaManager
 
 class AuthRepository(
     private val config: Config,
     private val api: AuthApi,
     private val preferencesManager: CorePreferences,
-) {
+    private val recaptchaManager: RecaptchaManager,
+    ) {
 
     suspend fun login(
         username: String,
@@ -69,4 +72,10 @@ class AuthRepository(
         val user = api.getProfile()
         preferencesManager.user = user
     }
+
+    suspend fun getRecaptchaToken(recaptchaAction: RecaptchaAction): String {
+        val isCaptchaEnabled = config.getRecaptchaConfig().isEnabled
+        return if (isCaptchaEnabled) recaptchaManager.getActionToken(recaptchaAction) else ""
+    }
+
 }

--- a/auth/src/main/java/org/openedx/auth/data/repository/AuthRepository.kt
+++ b/auth/src/main/java/org/openedx/auth/data/repository/AuthRepository.kt
@@ -72,10 +72,8 @@ class AuthRepository(
         val user = api.getProfile()
         preferencesManager.user = user
     }
-
     suspend fun getRecaptchaToken(recaptchaAction: RecaptchaAction): String {
         val isCaptchaEnabled = config.getRecaptchaConfig().isEnabled
         return if (isCaptchaEnabled) recaptchaManager.getActionToken(recaptchaAction) else ""
     }
-
 }

--- a/auth/src/main/java/org/openedx/auth/domain/interactor/AuthInteractor.kt
+++ b/auth/src/main/java/org/openedx/auth/domain/interactor/AuthInteractor.kt
@@ -38,6 +38,4 @@ class AuthInteractor(private val repository: AuthRepository) {
     suspend fun getRecaptchaToken(recaptchaAction: RecaptchaAction) =
         repository.getRecaptchaToken(recaptchaAction)
 
-
-
 }

--- a/auth/src/main/java/org/openedx/auth/domain/interactor/AuthInteractor.kt
+++ b/auth/src/main/java/org/openedx/auth/domain/interactor/AuthInteractor.kt
@@ -1,5 +1,6 @@
 package org.openedx.auth.domain.interactor
 
+import com.google.android.recaptcha.RecaptchaAction
 import org.openedx.auth.data.model.AuthType
 import org.openedx.auth.data.model.ValidationFields
 import org.openedx.auth.data.repository.AuthRepository
@@ -33,5 +34,10 @@ class AuthInteractor(private val repository: AuthRepository) {
     suspend fun passwordReset(email: String): Boolean {
         return repository.passwordReset(email)
     }
+
+    suspend fun getRecaptchaToken(recaptchaAction: RecaptchaAction) =
+        repository.getRecaptchaToken(recaptchaAction)
+
+
 
 }

--- a/auth/src/main/java/org/openedx/auth/presentation/signup/SignUpViewModel.kt
+++ b/auth/src/main/java/org/openedx/auth/presentation/signup/SignUpViewModel.kt
@@ -162,7 +162,8 @@ class SignUpViewModel(
             }
         )
         val mapFields = uiState.value.allFields.associate { it.name to it.placeholder } +
-                mapOf(ApiConstants.RegistrationFields.HONOR_CODE to true.toString())+mapOf(ApiConstants.RegistrationFields.CAPTCHA_TOKEN to true.toString())
+                mapOf(ApiConstants.RegistrationFields.HONOR_CODE to true.toString())+
+                mapOf(ApiConstants.RegistrationFields.CAPTCHA_TOKEN to true.toString())
         val resultMap = mapFields.toMutableMap()
         if(captchaName.isNotNullOrEmpty()) {
             reCaptchaToken?.let { resultMap.put(captchaName.toString(), it) }

--- a/auth/src/main/java/org/openedx/auth/presentation/signup/SignUpViewModel.kt
+++ b/auth/src/main/java/org/openedx/auth/presentation/signup/SignUpViewModel.kt
@@ -162,7 +162,8 @@ class SignUpViewModel(
             }
         )
         val mapFields = uiState.value.allFields.associate { it.name to it.placeholder } +
-                mapOf(ApiConstants.RegistrationFields.HONOR_CODE to true.toString())
+                mapOf(ApiConstants.RegistrationFields.HONOR_CODE to true.toString())+
+                mapOf(ApiConstants.RegistrationFields.CAPTCHA_TOKEN to true.toString())
         val resultMap = mapFields.toMutableMap()
         if(captchaName.isNotNullOrEmpty()) {
             reCaptchaToken?.let { resultMap.put(captchaName.toString(), it) }

--- a/auth/src/main/java/org/openedx/auth/presentation/signup/SignUpViewModel.kt
+++ b/auth/src/main/java/org/openedx/auth/presentation/signup/SignUpViewModel.kt
@@ -55,12 +55,11 @@ class SignUpViewModel(
     private val router: AuthRouter,
     val courseId: String?,
     val infoType: String?,
-    var captchaName : String?,
-    var reCaptchaToken: String?
 ) : BaseViewModel() {
 
     private val logger = Logger("SignUpViewModel")
-
+    var captchaName : String? =""
+    var reCaptchaToken: String =""
     private val _uiState = MutableStateFlow(
         SignUpUIState(
             isFacebookAuthEnabled = config.getFacebookConfig().isEnabled(),
@@ -166,7 +165,7 @@ class SignUpViewModel(
                 mapOf(ApiConstants.RegistrationFields.CAPTCHA_TOKEN to true.toString())
         val resultMap = mapFields.toMutableMap()
         if(captchaName.isNotNullOrEmpty()) {
-            reCaptchaToken?.let { resultMap.put(captchaName.toString(), it) }
+            reCaptchaToken.let { resultMap.put(captchaName.toString(), it) }
         }
         uiState.value.allFields.filter { !it.required }.forEach { (k, _) ->
             if (mapFields[k].isNullOrEmpty()) {

--- a/auth/src/main/java/org/openedx/auth/presentation/signup/SignUpViewModel.kt
+++ b/auth/src/main/java/org/openedx/auth/presentation/signup/SignUpViewModel.kt
@@ -162,8 +162,7 @@ class SignUpViewModel(
             }
         )
         val mapFields = uiState.value.allFields.associate { it.name to it.placeholder } +
-                mapOf(ApiConstants.RegistrationFields.HONOR_CODE to true.toString())+
-                mapOf(ApiConstants.RegistrationFields.CAPTCHA_TOKEN to true.toString())
+                mapOf(ApiConstants.RegistrationFields.HONOR_CODE to true.toString())
         val resultMap = mapFields.toMutableMap()
         if(captchaName.isNotNullOrEmpty()) {
             reCaptchaToken?.let { resultMap.put(captchaName.toString(), it) }

--- a/auth/src/main/java/org/openedx/auth/presentation/signup/SignUpViewModel.kt
+++ b/auth/src/main/java/org/openedx/auth/presentation/signup/SignUpViewModel.kt
@@ -32,6 +32,8 @@ import org.openedx.core.domain.model.RegistrationField
 import org.openedx.core.domain.model.RegistrationFieldType
 import org.openedx.core.domain.model.createHonorCodeField
 import org.openedx.core.extension.isInternetError
+import org.openedx.core.extension.isNotNullOrEmpty
+import org.openedx.core.system.RecaptchaManager
 import org.openedx.core.system.ResourceManager
 import org.openedx.core.system.notifier.app.AppNotifier
 import org.openedx.core.system.notifier.app.AppUpgradeEvent
@@ -53,6 +55,8 @@ class SignUpViewModel(
     private val router: AuthRouter,
     val courseId: String?,
     val infoType: String?,
+    var captchaName : String?,
+    var reCaptchaToken: String?
 ) : BaseViewModel() {
 
     private val logger = Logger("SignUpViewModel")
@@ -86,6 +90,9 @@ class SignUpViewModel(
         _uiState.update { it.copy(isLoading = true) }
         viewModelScope.launch {
             try {
+                reCaptchaToken = interactor.getRecaptchaToken(
+                    recaptchaAction = RecaptchaManager.RecaptchaActionRegistration
+                )
                 updateFields(interactor.getRegistrationFields())
             } catch (e: Exception) {
                 logger.e(throwable = e)
@@ -122,6 +129,10 @@ class SignUpViewModel(
             val marketingEmails =
                 allFields.find { it.name == ApiConstants.RegistrationFields.MARKETING_EMAILS }
             mutableAllFields.remove(honourCode)
+            val captchaTokenField=allFields.find { it.name == ApiConstants.RegistrationFields.CAPTCHA_TOKEN }
+            if(captchaTokenField!=null) {
+                captchaName = captchaTokenField.name
+            }
             requiredFields.addAll(mutableAllFields.filter { it.required })
             optionalFields.addAll(mutableAllFields.filter { !it.required })
             requiredFields.remove(marketingEmails)
@@ -151,8 +162,11 @@ class SignUpViewModel(
             }
         )
         val mapFields = uiState.value.allFields.associate { it.name to it.placeholder } +
-                mapOf(ApiConstants.RegistrationFields.HONOR_CODE to true.toString())
+                mapOf(ApiConstants.RegistrationFields.HONOR_CODE to true.toString())+mapOf(ApiConstants.RegistrationFields.CAPTCHA_TOKEN to true.toString())
         val resultMap = mapFields.toMutableMap()
+        if(captchaName.isNotNullOrEmpty()) {
+            reCaptchaToken?.let { resultMap.put(captchaName.toString(), it) }
+        }
         uiState.value.allFields.filter { !it.required }.forEach { (k, _) ->
             if (mapFields[k].isNullOrEmpty()) {
                 resultMap.remove(k)

--- a/auth/src/test/java/org/openedx/auth/presentation/signup/SignUpViewModelTest.kt
+++ b/auth/src/test/java/org/openedx/auth/presentation/signup/SignUpViewModelTest.kt
@@ -132,6 +132,7 @@ class SignUpViewModelTest {
         mockkObject(CrashlyticsHelper)
         every { anyConstructed<Logger>().e(any(), any()) } returns Unit
         every { CrashlyticsHelper.setUserId(any()) } returns Unit
+        coEvery { interactor.getRecaptchaToken(any()) } returns ""
     }
 
     @After
@@ -153,8 +154,6 @@ class SignUpViewModelTest {
             router = router,
             courseId = "",
             infoType = "",
-            captchaName = "",
-            reCaptchaToken = ""
         )
         coEvery { interactor.validateRegistrationFields(parametersMap) } returns ValidationFields(
             parametersMap
@@ -199,8 +198,6 @@ class SignUpViewModelTest {
             router = router,
             courseId = "",
             infoType = "",
-            captchaName = "",
-            reCaptchaToken = ""
         )
         val deferred = async { viewModel.uiMessage.first() }
 
@@ -251,8 +248,6 @@ class SignUpViewModelTest {
             router = router,
             courseId = "",
             infoType = "",
-            captchaName = "",
-            reCaptchaToken = ""
         )
         val deferred = async { viewModel.uiMessage.first() }
 
@@ -292,8 +287,6 @@ class SignUpViewModelTest {
             router = router,
             courseId = "",
             infoType = "",
-            captchaName = "",
-            reCaptchaToken = ""
         )
         coEvery { interactor.validateRegistrationFields(parametersMap) } returns ValidationFields(
             emptyMap()
@@ -344,8 +337,6 @@ class SignUpViewModelTest {
             router = router,
             courseId = "",
             infoType = "",
-            captchaName = "",
-            reCaptchaToken = ""
         )
         val deferred = async { viewModel.uiMessage.first() }
 
@@ -373,8 +364,6 @@ class SignUpViewModelTest {
             router = router,
             courseId = "",
             infoType = "",
-            captchaName = "",
-            reCaptchaToken = ""
         )
         val deferred = async { viewModel.uiMessage.first() }
 
@@ -402,8 +391,6 @@ class SignUpViewModelTest {
             router = router,
             courseId = "",
             infoType = "",
-            captchaName = "",
-            reCaptchaToken = ""
         )
         coEvery { interactor.getRegistrationFields() } returns listOfFields
         viewModel.getRegistrationFields()

--- a/auth/src/test/java/org/openedx/auth/presentation/signup/SignUpViewModelTest.kt
+++ b/auth/src/test/java/org/openedx/auth/presentation/signup/SignUpViewModelTest.kt
@@ -74,7 +74,7 @@ class SignUpViewModelTest {
         ApiConstants.EMAIL to "user@gmail.com",
         ApiConstants.PASSWORD to "password123",
         "honor_code" to "true",
-        "captcha_token" to "true"
+        ApiConstants.RegistrationFields.CAPTCHA_TOKEN to "true"
     )
 
     private val listOfFields = listOf(

--- a/auth/src/test/java/org/openedx/auth/presentation/signup/SignUpViewModelTest.kt
+++ b/auth/src/test/java/org/openedx/auth/presentation/signup/SignUpViewModelTest.kt
@@ -74,6 +74,7 @@ class SignUpViewModelTest {
         ApiConstants.EMAIL to "user@gmail.com",
         ApiConstants.PASSWORD to "password123",
         "honor_code" to "true",
+        "captcha_token" to "true"
     )
 
     private val listOfFields = listOf(

--- a/auth/src/test/java/org/openedx/auth/presentation/signup/SignUpViewModelTest.kt
+++ b/auth/src/test/java/org/openedx/auth/presentation/signup/SignUpViewModelTest.kt
@@ -89,7 +89,6 @@ class SignUpViewModelTest {
             defaultValue = false,
             restrictions = RegistrationField.Restrictions(),
             options = emptyList(),
-
         ),
 
         RegistrationField(

--- a/auth/src/test/java/org/openedx/auth/presentation/signup/SignUpViewModelTest.kt
+++ b/auth/src/test/java/org/openedx/auth/presentation/signup/SignUpViewModelTest.kt
@@ -87,7 +87,8 @@ class SignUpViewModelTest {
             required = true,
             defaultValue = false,
             restrictions = RegistrationField.Restrictions(),
-            options = emptyList()
+            options = emptyList(),
+
         ),
 
         RegistrationField(
@@ -151,6 +152,8 @@ class SignUpViewModelTest {
             router = router,
             courseId = "",
             infoType = "",
+            captchaName = "",
+            reCaptchaToken = ""
         )
         coEvery { interactor.validateRegistrationFields(parametersMap) } returns ValidationFields(
             parametersMap
@@ -195,6 +198,8 @@ class SignUpViewModelTest {
             router = router,
             courseId = "",
             infoType = "",
+            captchaName = "",
+            reCaptchaToken = ""
         )
         val deferred = async { viewModel.uiMessage.first() }
 
@@ -245,6 +250,8 @@ class SignUpViewModelTest {
             router = router,
             courseId = "",
             infoType = "",
+            captchaName = "",
+            reCaptchaToken = ""
         )
         val deferred = async { viewModel.uiMessage.first() }
 
@@ -284,6 +291,8 @@ class SignUpViewModelTest {
             router = router,
             courseId = "",
             infoType = "",
+            captchaName = "",
+            reCaptchaToken = ""
         )
         coEvery { interactor.validateRegistrationFields(parametersMap) } returns ValidationFields(
             emptyMap()
@@ -334,6 +343,8 @@ class SignUpViewModelTest {
             router = router,
             courseId = "",
             infoType = "",
+            captchaName = "",
+            reCaptchaToken = ""
         )
         val deferred = async { viewModel.uiMessage.first() }
 
@@ -361,6 +372,8 @@ class SignUpViewModelTest {
             router = router,
             courseId = "",
             infoType = "",
+            captchaName = "",
+            reCaptchaToken = ""
         )
         val deferred = async { viewModel.uiMessage.first() }
 
@@ -388,6 +401,8 @@ class SignUpViewModelTest {
             router = router,
             courseId = "",
             infoType = "",
+            captchaName = "",
+            reCaptchaToken = ""
         )
         coEvery { interactor.getRegistrationFields() } returns listOfFields
         viewModel.getRegistrationFields()

--- a/core/src/main/java/org/openedx/core/ApiConstants.kt
+++ b/core/src/main/java/org/openedx/core/ApiConstants.kt
@@ -32,9 +32,11 @@ object ApiConstants {
     const val BLOCKS_API_VERSION = "v4"
     const val HEADER_STALE_IF_ERROR = "stale-if-error=0"
 
-    object RegistrationFields {
+    object  RegistrationFields {
         const val HONOR_CODE = "honor_code"
         const val MARKETING_EMAILS = "marketing_emails_opt_in"
+        const val CAPTCHA_TOKEN = "captcha_token"
+
     }
 
     object IAPFields {

--- a/core/src/main/java/org/openedx/core/ApiConstants.kt
+++ b/core/src/main/java/org/openedx/core/ApiConstants.kt
@@ -36,7 +36,6 @@ object ApiConstants {
         const val HONOR_CODE = "honor_code"
         const val MARKETING_EMAILS = "marketing_emails_opt_in"
         const val CAPTCHA_TOKEN = "captcha_token"
-
     }
 
     object IAPFields {

--- a/core/src/main/java/org/openedx/core/system/RecaptchaManager.kt
+++ b/core/src/main/java/org/openedx/core/system/RecaptchaManager.kt
@@ -46,6 +46,5 @@ class RecaptchaManager(
         val RecaptchaActionThread = RecaptchaAction.custom("thread")
         val RecaptchaActionComment = RecaptchaAction.custom("comment")
         val RecaptchaActionRegistration = RecaptchaAction.custom("signup")
-
     }
 }

--- a/core/src/main/java/org/openedx/core/system/RecaptchaManager.kt
+++ b/core/src/main/java/org/openedx/core/system/RecaptchaManager.kt
@@ -45,5 +45,7 @@ class RecaptchaManager(
         private const val TAG = "RecaptchaManager"
         val RecaptchaActionThread = RecaptchaAction.custom("thread")
         val RecaptchaActionComment = RecaptchaAction.custom("comment")
+        val RecaptchaActionRegistration = RecaptchaAction.custom("signup")
+
     }
 }


### PR DESCRIPTION

Implemented  reCAPTCHA Token for SignUp and  captcha_token is added to registration API. 

[LEARNER-10731](https://2u-internal.atlassian.net/browse/LEARNER-10731)





