### PR TITLE
fix: Android_ Comment count changes are not dynamically reflected on the “All Posts” screen until the page is manually refreshed.

### DIFF
--- a/discussion/src/main/java/org/openedx/discussion/presentation/comments/DiscussionCommentsViewModel.kt
+++ b/discussion/src/main/java/org/openedx/discussion/presentation/comments/DiscussionCommentsViewModel.kt
@@ -24,6 +24,7 @@ import org.openedx.discussion.domain.model.Thread
 import org.openedx.discussion.presentation.BaseDiscussionViewModel
 import org.openedx.discussion.presentation.DiscussionAnalytics
 import org.openedx.discussion.presentation.DiscussionAnalyticsType
+import org.openedx.discussion.presentation.threads.CommentEvents
 import org.openedx.discussion.system.notifier.DiscussionCommentAdded
 import org.openedx.discussion.system.notifier.DiscussionCommentDataChanged
 import org.openedx.discussion.system.notifier.DiscussionNotifier
@@ -316,6 +317,7 @@ class DiscussionCommentsViewModel(
                 commentCount++
                 _uiState.value =
                     DiscussionCommentsUIState.Success(thread, comments.toList(), commentCount)
+                CommentEvents.commentAdded.emit(Unit)
                 logResponseAddedEvent(
                     responseId = response.id,
                     author = response.author

--- a/discussion/src/main/java/org/openedx/discussion/presentation/responses/DiscussionResponsesViewModel.kt
+++ b/discussion/src/main/java/org/openedx/discussion/presentation/responses/DiscussionResponsesViewModel.kt
@@ -205,6 +205,7 @@ class DiscussionResponsesViewModel(
                 comments.add(0, response)
                 _uiState.value =
                     DiscussionResponsesUIState.Success(comment, comments.toList())
+                CommentEvents.commentAdded.emit(Unit)
                 logCommentAddedEvent(
                     responseId = response.id,
                     commentId = comment.id,

--- a/discussion/src/main/java/org/openedx/discussion/presentation/responses/DiscussionResponsesViewModel.kt
+++ b/discussion/src/main/java/org/openedx/discussion/presentation/responses/DiscussionResponsesViewModel.kt
@@ -20,6 +20,7 @@ import org.openedx.discussion.domain.model.DiscussionComment
 import org.openedx.discussion.presentation.BaseDiscussionViewModel
 import org.openedx.discussion.presentation.DiscussionAnalytics
 import org.openedx.discussion.presentation.DiscussionAnalyticsType
+import org.openedx.discussion.presentation.threads.CommentEvents
 import org.openedx.discussion.system.notifier.DiscussionCommentDataChanged
 import org.openedx.discussion.system.notifier.DiscussionNotifier
 import org.openedx.discussion.system.notifier.DiscussionResponseAdded

--- a/discussion/src/main/java/org/openedx/discussion/presentation/search/DiscussionSearchThreadFragment.kt
+++ b/discussion/src/main/java/org/openedx/discussion/presentation/search/DiscussionSearchThreadFragment.kt
@@ -344,7 +344,7 @@ private fun DiscussionSearchThreadScreen(
 
                                 is DiscussionSearchThreadUIState.Threads -> {
                                     items(uiState.data) { thread ->
-                                        ThreadItem(thread = thread, onClick = onItemClick)
+                                        ThreadItem(thread = thread, onClick = onItemClick, onBackClick = {})
                                         Divider()
                                     }
                                     item {

--- a/discussion/src/main/java/org/openedx/discussion/presentation/threads/CommentEvents.kt
+++ b/discussion/src/main/java/org/openedx/discussion/presentation/threads/CommentEvents.kt
@@ -1,0 +1,10 @@
+package org.openedx.discussion.presentation.threads
+
+import kotlinx.coroutines.flow.MutableSharedFlow
+
+object CommentEvents {
+    val commentAdded = MutableSharedFlow<Unit>(
+        replay = 1,                 // makes AllPosts catch the event when returning
+        extraBufferCapacity = 1     // event won't be lost
+    )
+}

--- a/discussion/src/main/java/org/openedx/discussion/presentation/threads/DiscussionThreadsFragment.kt
+++ b/discussion/src/main/java/org/openedx/discussion/presentation/threads/DiscussionThreadsFragment.kt
@@ -152,6 +152,13 @@ class DiscussionThreadsFragment : Fragment() {
                 val canLoadMore by viewModel.canLoadMore.observeAsState(false)
                 val refreshing by viewModel.isUpdating.observeAsState(false)
 
+                LaunchedEffect(Unit) {
+                    CommentEvents.commentAdded.collect {
+                        viewModel.refreshThreads()
+                        CommentEvents.commentAdded.resetReplayCache()
+                    }
+                }
+
                 DiscussionThreadsScreen(
                     windowSize = windowSize,
                     title = requireArguments().getString(ARG_TITLE, ""),
@@ -594,7 +601,7 @@ private fun DiscussionThreadsScreen(
                                                     items(uiState.data) { threadItem ->
                                                         ThreadItem(thread = threadItem, onClick = {
                                                             onItemClick(it)
-                                                        })
+                                                        }, onBackClick = {} )
                                                         Divider()
                                                     }
                                                     item {

--- a/discussion/src/main/java/org/openedx/discussion/presentation/ui/DiscussionUI.kt
+++ b/discussion/src/main/java/org/openedx/discussion/presentation/ui/DiscussionUI.kt
@@ -533,6 +533,7 @@ fun CommentMainItem(
 fun ThreadItem(
     thread: Thread,
     onClick: (Thread) -> Unit,
+    onBackClick: () -> Unit,
 ) {
     val icon = when (thread.type) {
         DiscussionType.DISCUSSION -> painterResource(id = R.drawable.discussion_ic_discussion)
@@ -726,6 +727,7 @@ private fun ThreadItemPreview() {
         ThreadItem(
             thread = mockThread,
             onClick = {},
+            onBackClick = {}
         )
     }
 }


### PR DESCRIPTION

Fixes : [LEARNER-10764](https://2u-internal.atlassian.net/browse/LEARNER-10764)